### PR TITLE
fix: normalize SetCDL arrays to space-separated strings

### DIFF
--- a/src/resolve_mcp_server.py
+++ b/src/resolve_mcp_server.py
@@ -5349,6 +5349,24 @@ def _get_timeline_item(track_type="video", track_index=1, item_index=0):
     return items[item_index], None
 
 
+def _normalize_cdl(cdl):
+    """Resolve's SetCDL expects string values ("1.0 1.0 1.0"), not arrays.
+    Accepts either and converts to the string form the API requires."""
+    if not isinstance(cdl, dict):
+        return cdl
+    out = {}
+    for k, v in cdl.items():
+        if isinstance(v, (list, tuple)):
+            out[k] = " ".join(str(x) for x in v)
+        elif isinstance(v, bool):
+            out[k] = str(v)
+        elif isinstance(v, (int, float)):
+            out[k] = str(v)
+        else:
+            out[k] = v
+    return out
+
+
 # ------------------
 # MediaPool Tools (remaining)
 # ------------------
@@ -8041,7 +8059,7 @@ def ti_set_cdl(cdl: Dict[str, Any], item_index: int = 0, track_type: str = "vide
     item, err = _get_timeline_item(track_type, track_index, item_index)
     if err:
         return err
-    return {"success": bool(item.SetCDL(cdl))}
+    return {"success": bool(item.SetCDL(_normalize_cdl(cdl)))}
 
 @mcp.tool()
 def ti_add_take(media_pool_item_id: str, start_frame: int = 0, end_frame: int = 0, item_index: int = 0, track_type: str = "video", track_index: int = 1) -> Dict[str, Any]:

--- a/src/server.py
+++ b/src/server.py
@@ -268,6 +268,23 @@ def _ser(obj):
 def _unknown(action, valid):
     return _err(f"Unknown action '{action}'. Valid actions: {', '.join(valid)}")
 
+def _normalize_cdl(cdl):
+    """Resolve's SetCDL expects string values ("1.0 1.0 1.0"), not arrays.
+    Accepts either and converts to the string form the API requires."""
+    if not isinstance(cdl, dict):
+        return cdl
+    out = {}
+    for k, v in cdl.items():
+        if isinstance(v, (list, tuple)):
+            out[k] = " ".join(str(x) for x in v)
+        elif isinstance(v, bool):
+            out[k] = str(v)
+        elif isinstance(v, (int, float)):
+            out[k] = str(v)
+        else:
+            out[k] = v
+    return out
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # TOOL 1: resolve
@@ -1777,7 +1794,7 @@ def timeline_item_color(action: str, params: Optional[Dict[str, Any]] = None) ->
     _, proj, _ = _check()
 
     if action == "set_cdl":
-        return {"success": bool(item.SetCDL(p["cdl"]))}
+        return {"success": bool(item.SetCDL(_normalize_cdl(p["cdl"])))}
     elif action == "copy_grades":
         # Find target items by IDs
         _, tl, _ = _get_tl()


### PR DESCRIPTION
## Summary

`TimelineItem.SetCDL()` in the Resolve scripting API expects string values (`"1.0 1.0 1.0"`) for `Slope`/`Offset`/`Power`, per the [official docs](https://github.com/samuelgursky/davinci-resolve-mcp/blob/main/docs/resolve_scripting_api.txt#L456):

```python
SetCDL({"NodeIndex": "1", "Slope": "0.5 0.4 0.2", ...})
```

Both servers were forwarding the caller's CDL dict unchanged, so any client passing arrays (very natural for MCP clients — JSON arrays are the obvious shape) got silently corrupted grades: `SetCDL` returned `True`, but the resulting node had garbage values in some channels.

Concretely, calling `set_cdl` with `Slope: [1, 1, 1], Offset: [0, 0, 0], Power: [1, 1, 1], Saturation: 1` (a pass-through CDL) produced a heavy red cast on the viewer because the Blue channel on the Gain wheel ended up at `0.01` instead of `1.00`.

## Fix

Adds `_normalize_cdl()` helper in both servers. It converts list/tuple/number values in the CDL dict to the space-separated-string form the API actually expects. Clients can now pass either form — arrays or pre-formatted strings.

- `src/server.py` — compound `timeline_item_color.set_cdl` action
- `src/resolve_mcp_server.py` — granular `timeline_item_set_cdl` tool

No version bump included — leaving that to the maintainer's release cycle.

## Test plan

- [ ] Call `set_cdl` with array form `{"Slope": [1,1,1], "Offset": [0,0,0], "Power": [1,1,1], "Saturation": 1}` — verify Gain/Offset/Gamma/Sat on the node show the expected values in Resolve (not `0.01` residuals)
- [ ] Call `set_cdl` with the documented string form `{"Slope": "1 1 1", ...}` — verify backwards compat still works
- [ ] Apply a non-neutral grade (e.g., `Power: [1.2, 1.2, 1.2]`) and confirm the image updates correctly with no spurious color cast

🤖 Generated with [Claude Code](https://claude.com/claude-code)