### PR TITLE
feat(media_pool): support positioned AppendToTimeline via clip_infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DaVinci Resolve MCP Server
 
-[![Version](https://img.shields.io/badge/version-2.3.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.3.1-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](#api-coverage)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-27%20(354%20full)-blue.svg)](#server-modes)
 [![Tested](https://img.shields.io/badge/Live%20Tested-98.5%25-green.svg)](#test-results)
@@ -10,7 +10,12 @@
 
 A Model Context Protocol (MCP) server providing **complete coverage** of the DaVinci Resolve Scripting API. Connect AI assistants (Claude, Cursor, Windsurf) to DaVinci Resolve and control every aspect of your post-production workflow through natural language.
 
-### What's New in v2.3.0
+### What's New in v2.3.1
+
+- **Positioned append failure reporting** — `media_pool(action="append_to_timeline", params={"clip_infos": [...]})` now returns `{"error": ...}` when Resolve fails to produce valid timeline items, including falsey `AppendToTimeline()` results and returned item handles without a timeline item id
+- **Live disposable Resolve validation** — verified the fix against DaVinci Resolve Studio 20.3.2 with synthetic temp media in a disposable project: valid `clip_infos` append returned `success`, `count=1`, and `timeline_item_id`; invalid `clip_infos` calls returned errors
+
+### v2.3.0
 
 - **Resolve 20.2.2 API sync** — added the 12 scripting methods introduced across Resolve 20.0-20.2.2, with compatibility guards so older Resolve builds return clear "requires Resolve 20.x" errors instead of crashing
 - **Resolve 20 live validation** — revalidated the new API surface against DaVinci Resolve Studio 20.3.2, bringing live-tested coverage to 331/336 methods (98.5%)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -363,6 +363,10 @@ media_pool(action="get_current_folder")
 media_pool(action="create_timeline", params={"name": "Assembly"})
 media_pool(action="get_selected")
 media_pool(action="append_to_timeline", params={"clip_ids": ["<uuid>", ...]})
+# Positioned append (MediaPool.AppendToTimeline([{clipInfo}, ...])) — e.g. rebuild a subtitle row after delete_clips
+media_pool(action="append_to_timeline", params={"clip_infos": [
+  {"clip_id": "<uuid>", "start_frame": 0, "end_frame": 100, "record_frame": 1200, "track_index": 4}
+]})
 ```
 
 ### 4. Inspect and annotate timeline items

--- a/install.py
+++ b/install.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.3.0"
+VERSION = "2.3.1"
 
 # ─── Colors (disabled on Windows cmd without ANSI support) ────────────────────
 

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -82,7 +82,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.3.0"
+VERSION = "2.3.1"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -391,6 +391,51 @@ def _navigate_folder(mp, path):
             return None
     return current
 
+
+def _build_append_clip_info_dict(root, ci: Dict[str, Any], index: int):
+    """Build one MediaPool.AppendToTimeline clipInfo map (Python API uses camelCase keys).
+
+    See docs/resolve_scripting_api.txt: mediaPoolItem, startFrame, endFrame,
+    optional mediaType, trackIndex, recordFrame.
+    """
+    if not isinstance(ci, dict):
+        return None, _err(f"clip_infos[{index}] must be an object")
+    cid = ci.get("clip_id") or ci.get("media_pool_item_id")
+    if not cid:
+        return None, _err(f"clip_infos[{index}] requires clip_id or media_pool_item_id")
+    mp_item = _find_clip(root, cid)
+    if not mp_item:
+        return None, _err(f"clip_infos[{index}]: media pool clip not found: {cid}")
+    sf = ci.get("startFrame", ci.get("start_frame"))
+    ef = ci.get("endFrame", ci.get("end_frame"))
+    if sf is None or ef is None:
+        return None, _err(
+            f"clip_infos[{index}] requires start_frame/startFrame and end_frame/endFrame "
+            "(source range on the MediaPoolItem)"
+        )
+    rf = ci.get("recordFrame", ci.get("record_frame"))
+    if rf is None:
+        return None, _err(
+            f"clip_infos[{index}] requires record_frame/recordFrame (timeline record frame)"
+        )
+    ti = ci.get("trackIndex", ci.get("track_index"))
+    if ti is None:
+        return None, _err(
+            f"clip_infos[{index}] requires track_index/trackIndex (1-based track index)"
+        )
+    out: Dict[str, Any] = {
+        "mediaPoolItem": mp_item,
+        "startFrame": sf,
+        "endFrame": ef,
+        "recordFrame": rf,
+        "trackIndex": ti,
+    }
+    mt = ci.get("mediaType", ci.get("media_type"))
+    if mt is not None:
+        out["mediaType"] = mt
+    return out, None
+
+
 def _ser(obj):
     """Serialize Resolve API objects to JSON-safe values."""
     if obj is None:
@@ -949,6 +994,12 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
       import_timeline(path, options?) -> {success, name}
       delete_timelines(timeline_ids) -> {success}
       append_to_timeline(clip_ids) -> {success, count}
+        — legacy: params.clip_ids only (appends at end / default placement)
+      append_to_timeline(clip_infos) -> {success, count, items}
+        — positioned: params.clip_infos is a list of {clip_id or media_pool_item_id,
+          start_frame & end_frame (or startFrame/endFrame), record_frame/recordFrame,
+          track_index/trackIndex (1-based), optional media_type/mediaType (1=video, 2=audio)}.
+          Matches MediaPool.AppendToTimeline([{clipInfo}, ...]). Returns timeline_item_id per item.
       import_media(paths) -> {imported}
       delete_clips(clip_ids) -> {success}
       move_clips(clip_ids, target_path) -> {success}
@@ -1027,7 +1078,36 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
                 timelines.append(tl)
         return {"success": bool(mp.DeleteTimelines(timelines))} if timelines else _err("No timelines found")
     elif action == "append_to_timeline":
-        clips = [_find_clip(root, cid) for cid in p["clip_ids"]]
+        if p.get("clip_infos") is not None:
+            raw = p["clip_infos"]
+            if not isinstance(raw, list):
+                return _err("clip_infos must be a list")
+            if not raw:
+                return _err("clip_infos must be a non-empty list")
+            built = []
+            for i, ci in enumerate(raw):
+                row, row_err = _build_append_clip_info_dict(root, ci, i)
+                if row_err:
+                    return row_err
+                built.append(row)
+            result = mp.AppendToTimeline(built)
+            items_out = []
+            if result:
+                for item in result:
+                    try:
+                        items_out.append(
+                            {
+                                "timeline_item_id": item.GetUniqueId(),
+                                "name": item.GetName(),
+                            }
+                        )
+                    except Exception:
+                        items_out.append({"timeline_item_id": None, "name": None})
+            return _ok(count=len(result) if result else 0, items=items_out)
+        clip_ids = p.get("clip_ids")
+        if not clip_ids:
+            return _err("Provide clip_ids (simple append) or clip_infos (positioned append)")
+        clips = [_find_clip(root, cid) for cid in clip_ids]
         clips = [c for c in clips if c]
         result = mp.AppendToTimeline(clips)
         return _ok(count=len(result) if result else 0)

--- a/src/server.py
+++ b/src/server.py
@@ -1091,19 +1091,20 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
                     return row_err
                 built.append(row)
             result = mp.AppendToTimeline(built)
+            if not result:
+                return _err("Failed to append clip_infos to timeline")
             items_out = []
-            if result:
-                for item in result:
-                    try:
-                        items_out.append(
-                            {
-                                "timeline_item_id": item.GetUniqueId(),
-                                "name": item.GetName(),
-                            }
-                        )
-                    except Exception:
-                        items_out.append({"timeline_item_id": None, "name": None})
-            return _ok(count=len(result) if result else 0, items=items_out)
+            for item in result:
+                try:
+                    items_out.append(
+                        {
+                            "timeline_item_id": item.GetUniqueId(),
+                            "name": item.GetName(),
+                        }
+                    )
+                except Exception:
+                    items_out.append({"timeline_item_id": None, "name": None})
+            return _ok(count=len(result), items=items_out)
         clip_ids = p.get("clip_ids")
         if not clip_ids:
             return _err("Provide clip_ids (simple append) or clip_infos (positioned append)")

--- a/src/server.py
+++ b/src/server.py
@@ -10,7 +10,7 @@ Usage:
     python src/server.py --full       # Start the 354-tool granular server instead
 """
 
-VERSION = "2.3.0"
+VERSION = "2.3.1"
 
 import base64
 import os
@@ -434,6 +434,20 @@ def _build_append_clip_info_dict(root, ci: Dict[str, Any], index: int):
     if mt is not None:
         out["mediaType"] = mt
     return out, None
+
+
+def _serialize_appended_timeline_item(item, index: int):
+    if not item:
+        return None, _err(f"Failed to append clip_infos to timeline: missing timeline item at index {index}")
+    try:
+        item_id = item.GetUniqueId()
+        name = item.GetName()
+    except Exception as exc:
+        logger.warning(f"Invalid timeline item returned for clip_infos[{index}]: {exc}")
+        return None, _err(f"Failed to append clip_infos to timeline: invalid timeline item at index {index}")
+    if not item_id:
+        return None, _err(f"Failed to append clip_infos to timeline: missing timeline item id at index {index}")
+    return {"timeline_item_id": item_id, "name": name}, None
 
 
 def _ser(obj):
@@ -1094,16 +1108,11 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
             if not result:
                 return _err("Failed to append clip_infos to timeline")
             items_out = []
-            for item in result:
-                try:
-                    items_out.append(
-                        {
-                            "timeline_item_id": item.GetUniqueId(),
-                            "name": item.GetName(),
-                        }
-                    )
-                except Exception:
-                    items_out.append({"timeline_item_id": None, "name": None})
+            for i, item in enumerate(result):
+                item_out, item_err = _serialize_appended_timeline_item(item, i)
+                if item_err:
+                    return item_err
+                items_out.append(item_out)
             return _ok(count=len(result), items=items_out)
         clip_ids = p.get("clip_ids")
         if not clip_ids:

--- a/tests/test_append_clip_infos_result_handling.py
+++ b/tests/test_append_clip_infos_result_handling.py
@@ -1,0 +1,65 @@
+import unittest
+
+from src.server import _serialize_appended_timeline_item
+
+
+class TimelineItemStub:
+    def __init__(self, unique_id="timeline-item-123", name="synthetic_append_clip_infos.mp4"):
+        self.unique_id = unique_id
+        self.name = name
+
+    def GetUniqueId(self):
+        return self.unique_id
+
+    def GetName(self):
+        return self.name
+
+
+class BrokenTimelineItemStub:
+    def GetUniqueId(self):
+        raise RuntimeError("Resolve returned no item handle")
+
+
+class AppendClipInfosResultHandlingTest(unittest.TestCase):
+    def test_serialize_appended_timeline_item_requires_item_handle(self):
+        item_out, item_err = _serialize_appended_timeline_item(None, 0)
+
+        self.assertIsNone(item_out)
+        self.assertEqual(
+            item_err,
+            {"error": "Failed to append clip_infos to timeline: missing timeline item at index 0"},
+        )
+
+    def test_serialize_appended_timeline_item_requires_unique_id(self):
+        item_out, item_err = _serialize_appended_timeline_item(TimelineItemStub(unique_id=""), 2)
+
+        self.assertIsNone(item_out)
+        self.assertEqual(
+            item_err,
+            {"error": "Failed to append clip_infos to timeline: missing timeline item id at index 2"},
+        )
+
+    def test_serialize_appended_timeline_item_rejects_invalid_item_handle(self):
+        item_out, item_err = _serialize_appended_timeline_item(BrokenTimelineItemStub(), 1)
+
+        self.assertIsNone(item_out)
+        self.assertEqual(
+            item_err,
+            {"error": "Failed to append clip_infos to timeline: invalid timeline item at index 1"},
+        )
+
+    def test_serialize_appended_timeline_item_returns_summary(self):
+        item_out, item_err = _serialize_appended_timeline_item(TimelineItemStub(), 0)
+
+        self.assertIsNone(item_err)
+        self.assertEqual(
+            item_out,
+            {
+                "timeline_item_id": "timeline-item-123",
+                "name": "synthetic_append_clip_infos.mp4",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose MediaPool.AppendToTimeline([{clipInfo}, ...]) by accepting
params.clip_infos alongside the existing clip_ids simple-append path.
Each clip info entry resolves clip_id/media_pool_item_id through the
media pool tree and maps snake_case JSON keys to Resolve's camelCase
clipInfo fields (start/end frame, record frame, track index, optional
media type). Positioned returns include timeline_item_id per appended
item for follow-up Fusion ops.

Update SKILL.md with an example for rebuilding subtitle rows after
delete_clips.

Made-with: Cursor
Co-authored-by: Cursor <cursoragent@cursor.com>
