### PR TITLE
feat(timeline): title property scan and set_title_text for generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.17.2
+
+**Edit-page title / Text+ text (undocumented keys)** — `timeline.title_property_scan`,
+`timeline.set_title_text`, and `timeline.bulk_set_title_text` use
+`TimelineItem.GetProperty` / `SetProperty` to discover and update generator Text+
+payloads when `GetFusionCompCount()` is zero (no Fusion comp for `fusion_comp`).
+Heuristic key ranking and a minimal styled-text XML fallback are included; callers
+should confirm keys with `title_property_scan` on their Resolve build.
+
 ## What's New in v2.17.1
 
 Operational and client-safety hardening for the v2.17 media-analysis release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
-## What's New in v2.17.2
+## What's New in v2.18.0
 
 **Edit-page title / Text+ text (undocumented keys)** — `timeline.title_property_scan`,
 `timeline.set_title_text`, and `timeline.bulk_set_title_text` use

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DaVinci Resolve MCP Server
 
-[![Version](https://img.shields.io/badge/version-2.17.2-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.18.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-31%20(328%20full)-blue.svg)](#server-modes)
 [![Tested](https://img.shields.io/badge/Live%20Tested-98.5%25-green.svg)](docs/reference/api-coverage.md#test-results)
@@ -53,7 +53,7 @@ The compound server is recommended unless you specifically need the granular one
 | App and project control | Launch/reconnect, page switching, project CRUD, project folders, databases, cloud project wrappers, settings, presets, archives |
 | Media pool and ingest | Safe import, image sequences, bin organization, metadata normalization, marks, annotations, relink/proxy/full-resolution guards |
 | Media analysis | Read-only file/clip/bin/project analysis, session-only defaults, existing-report reuse, chat-context visual analysis by default in `analyze_media` with opt-out, optional transcription |
-| Timeline editing and conform | Track/item probing, copy/move/duplicate helpers, range operations, gaps/overlaps, source ranges, checked interchange exports/imports |
+| Timeline editing and conform | Track/item probing, title text key scans/writes, copy/move/duplicate helpers, range operations, gaps/overlaps, source ranges, checked interchange exports/imports |
 | Review annotations | Timeline/item/clip markers, custom data, flags, clip color, copy/move/sync cleanup, review reports, marker thumbnail review |
 | Color and grading | Node graph probing, CDL validation, grade copy, DRX/LUT helpers, versions, Gallery stills, color groups |
 | Fusion | Timeline-item comps, safe tool creation, input writes, port inspection, validated connections, scoped bulk writes |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DaVinci Resolve MCP Server
 
-[![Version](https://img.shields.io/badge/version-2.17.1-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.17.2-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-31%20(328%20full)-blue.svg)](#server-modes)
 [![Tested](https://img.shields.io/badge/Live%20Tested-98.5%25-green.svg)](docs/reference/api-coverage.md#test-results)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -464,6 +464,11 @@ Key actions:
   capability/property probe for timeline items, including available item
   methods, `GetProperty()` values, known property keys, keyframe counts, and
   linked item summaries
+- `title_property_scan(clip_id|timeline_item_id|timeline_item)` — inspect
+  undocumented Edit-page title/generator `TimelineItem.GetProperty()` keys
+- `set_title_text(clip_id|..., text, property_key?, as_styled_xml?, try_plain_first?, try_heuristic_keys?, readback?)`
+  / `bulk_set_title_text(ops, ...)` — update title text via explicit or scanned
+  keys when the current Resolve build accepts the `SetProperty()` write
 - `export(path, type, subtype?)` — type: `"AAF"`, `"EDL"`, `"FCPXML"`, `"DRT"`, etc.
 - `insert_generator(name)`, `insert_title(name)`, `insert_fusion_title(name)`
 - `get_mark_in_out`, `set_mark_in_out(mark_in, mark_out, type?)`

--- a/docs/kernels/README.md
+++ b/docs/kernels/README.md
@@ -5,12 +5,12 @@ Resolve Scripting API. They are tracked separately from API method coverage:
 API coverage answers "can MCP reach every Blackmagic method?", while kernel
 coverage answers "which higher-level, guarded agent workflows are available?".
 
-Current kernel coverage: **128 actions** across **9 compound MCP tools**.
+Current kernel coverage: **131 actions** across **9 compound MCP tools**.
 
 | Kernel | MCP Tool | Actions |
 |--------|----------|---------|
 | Media analysis | `media_analysis` | `capabilities`, `install_guidance`, `resolve_output_root`, `plan`, `analyze_file`, `analyze_clip`, `analyze_bin`, `analyze_project`, `review_timeline_markers`, `summarize`, `get_report`, `cleanup_artifacts` |
-| Timeline edit | `timeline` | `duplicate_clips`, `copy_clips`, `move_clips`, `copy_range`, `duplicate_range`, `overwrite_range`, `lift_range`, `story_spine_report`, `create_variant_from_ranges`, `bulk_set_item_properties`, `apply_look_to_items`, `thumbnail_contact_sheet`, `marker_thumbnail_review`, `edit_kernel_capabilities`, `probe_edit_kernel_item` |
+| Timeline edit | `timeline` | `duplicate_clips`, `copy_clips`, `move_clips`, `copy_range`, `duplicate_range`, `overwrite_range`, `lift_range`, `story_spine_report`, `create_variant_from_ranges`, `bulk_set_item_properties`, `apply_look_to_items`, `thumbnail_contact_sheet`, `marker_thumbnail_review`, `edit_kernel_capabilities`, `probe_edit_kernel_item`, `title_property_scan`, `set_title_text`, `bulk_set_title_text` |
 | Media Pool / ingest | `media_pool` | `ingest_capabilities`, `probe_ingest_item`, `probe_media_pool`, `safe_import_media`, `safe_import_sequence`, `safe_import_folder`, `organize_clips`, `copy_metadata`, `normalize_metadata`, `probe_clip_properties`, `safe_relink`, `safe_unlink`, `link_proxy_checked`, `link_full_resolution_checked`, `set_clip_marks`, `clear_clip_marks`, `copy_clip_annotations`, `media_pool_boundary_report` |
 | Render / Deliver | `render` | `render_capabilities`, `probe_render_matrix`, `probe_render_settings`, `validate_render_settings`, `safe_set_render_settings`, `prepare_render_job`, `render_job_lifecycle_probe`, `quick_export_capabilities`, `safe_quick_export`, `export_render_boundary_report` |
 | Review annotations | `timeline_markers` | `annotation_capabilities`, `probe_annotations`, `normalize_marker_payload`, `copy_annotations`, `move_annotations`, `sync_marker_custom_data`, `clear_annotations_by_scope`, `export_review_report`, `annotation_boundary_report` |

--- a/docs/kernels/timeline-edit-kernel.md
+++ b/docs/kernels/timeline-edit-kernel.md
@@ -128,6 +128,11 @@ map for supported, partially supported, and unsupported behavior.
 reports method availability, `GetProperty()` output, known property values,
 keyframe counts, and linked item summaries.
 
+`timeline(action="title_property_scan")` inspects undocumented title and
+generator `TimelineItem.GetProperty()` keys for the selected item scope.
+`set_title_text` and `bulk_set_title_text` use explicit or scanned keys when a
+Resolve build accepts `SetProperty()` writes for title text payloads.
+
 ## Partial Support
 
 The probe classifies a feature as partially supported when Resolve exposes a
@@ -140,6 +145,9 @@ Current partial areas:
   Resolve Studio 20.3.2.9.
 - Dynamic zoom, scaling, and stabilization: copied through exposed
   `TimelineItem.GetProperty`/`SetProperty` keys when the build accepts writes.
+- Edit-page title and generator text: `title_property_scan` can expose
+  undocumented Text+ keys, but key names and write acceptance vary by item type,
+  page, and Resolve build.
 - Cache and voice isolation: copied only when item-level read/write APIs are
   callable for the item.
 - Keyframes: copied for exposed properties, but Resolve does not expose enough

--- a/install.py
+++ b/install.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.17.2"
+VERSION = "2.18.0"
 
 # ─── Colors (disabled on Windows cmd without ANSI support) ────────────────────
 

--- a/install.py
+++ b/install.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.17.1"
+VERSION = "2.17.2"
 
 # ─── Colors (disabled on Windows cmd without ANSI support) ────────────────────
 

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -80,7 +80,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.17.2"
+VERSION = "2.18.0"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -80,7 +80,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.17.1"
+VERSION = "2.17.2"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 328-tool granular server instead
 """
 
-VERSION = "2.17.2"
+VERSION = "2.18.0"
 
 import base64
 import os

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 328-tool granular server instead
 """
 
-VERSION = "2.17.1"
+VERSION = "2.17.2"
 
 import base64
 import os
@@ -57,6 +57,11 @@ from src.utils.media_analysis import (
 )
 from src.utils.platform import get_resolve_paths, get_resolve_plugin_paths
 from src.utils import fuse_templates, dctl_templates, script_templates
+from src.utils.timeline_title_text import (
+    candidate_title_property_keys as _candidate_title_property_keys,
+    plain_to_minimal_styled_xml as _plain_to_minimal_styled_xml,
+    timeline_item_get_property_map as _timeline_item_get_property_map,
+)
 
 paths = get_resolve_paths()
 RESOLVE_API_PATH = paths["api_path"]
@@ -232,7 +237,7 @@ Visual feedback:
 
 High-value workflows:
 - Media analysis: use the analyze_media prompt or media_analysis.capabilities/install_guidance, then plan or analyze file/clip/bin/project targets with session-only defaults.
-- Timeline editing: use timeline.probe_edit_kernel_item, duplicate_clips/copy_clips/move_clips, copy_range/overwrite_range/lift_range, and detect_gaps_overlaps.
+- Timeline editing: use timeline.probe_edit_kernel_item, timeline.title_property_scan / timeline.set_title_text for Edit-page Text+ keys, duplicate_clips/copy_clips/move_clips, copy_range/overwrite_range/lift_range, and detect_gaps_overlaps.
 - Media ingest: use media_pool.ingest_capabilities, safe_import_media/safe_import_sequence, organize_clips, normalize_metadata, and relink planning actions.
 - Color: use timeline_item_color.grade_boundary_report, probe_node_graph, safe_set_cdl, safe_apply_drx, grade_version_snapshot/restore, and gallery/color-group capability actions.
 - Fusion: use fusion_comp.fusion_boundary_report, probe_fusion_comp, safe_add_tool, safe_set_inputs, and safe_connect_tools.
@@ -2927,6 +2932,133 @@ def _timeline_probe_edit_kernel_item(tl, p: Dict[str, Any]):
     if warnings:
         out["warnings"] = warnings
     return out
+
+
+def _timeline_resolve_item_optional(tl, p: Dict[str, Any]):
+    """Resolve a single timeline item from clip_id, timeline_item_id, or timeline_item scope."""
+    item_id = p.get("clip_id") or p.get("timeline_item_id")
+    if item_id:
+        item = _find_timeline_item_by_id(tl, item_id)
+        if not item:
+            return None, _err(f"No timeline item with clip_id/timeline_item_id={item_id!r}")
+        return item, None
+    if p.get("timeline_item"):
+        _, item, item_err = _get_item(p["timeline_item"])
+        if item_err:
+            return None, item_err
+        return item, None
+    return None, _err("requires clip_id, timeline_item_id, or timeline_item={track_type, track_index, item_index}")
+
+
+def _timeline_title_property_scan(tl, p: Dict[str, Any]):
+    item, err = _timeline_resolve_item_optional(tl, p)
+    if err:
+        return err
+    flat, exc_text = _timeline_item_get_property_map(item, _ser)
+    if exc_text and not flat:
+        return _err(f"GetProperty failed: {exc_text}")
+    fusion_count = None
+    try:
+        fusion_count = int(item.GetFusionCompCount() or 0)
+    except Exception:
+        pass
+    return {
+        "summary": _timeline_item_summary(item),
+        "fusion_comp_count": fusion_count,
+        "properties": flat,
+        "text_key_candidates": _candidate_title_property_keys(flat),
+        "note": (
+            "Generator / Text+ fields are undocumented in the public Scripting API; "
+            "run this scan, inspect `text_key_candidates`, then call set_title_text with `property_key`."
+        ),
+    }
+
+
+def _timeline_set_title_text(tl, p: Dict[str, Any]) -> Dict[str, Any]:
+    item, err = _timeline_resolve_item_optional(tl, p)
+    if err:
+        return err
+    text = p.get("text")
+    if text is None or not isinstance(text, str):
+        return _err("set_title_text requires params.text (string)")
+
+    property_key = p.get("property_key") or p.get("key")
+    as_styled_xml = bool(p.get("as_styled_xml", p.get("styled", False)))
+    try_plain_first = bool(p.get("try_plain_first", True))
+    readback = bool(p.get("readback", False))
+    try_heuristic_keys = bool(p.get("try_heuristic_keys", not bool(property_key)))
+
+    if as_styled_xml:
+        payload_modes = [(text, "as_given")]
+    elif try_plain_first:
+        payload_modes = [(text, "plain"), (_plain_to_minimal_styled_xml(text), "minimal_xml")]
+    else:
+        payload_modes = [(_plain_to_minimal_styled_xml(text), "minimal_xml"), (text, "plain")]
+
+    keys: List[str] = []
+    if property_key:
+        keys.append(str(property_key))
+    if try_heuristic_keys:
+        flat, exc_text = _timeline_item_get_property_map(item, _ser)
+        if exc_text and not flat:
+            return _err(f"GetProperty failed: {exc_text}")
+        for row in _candidate_title_property_keys(flat):
+            k = row["key"]
+            if k not in keys:
+                keys.append(k)
+    if not keys:
+        keys = ["Styled Text", "StyledText", "Text", "Rich Text"]
+
+    attempts: List[Dict[str, Any]] = []
+    for key in keys:
+        for payload, mode in payload_modes:
+            rec: Dict[str, Any] = {"property_key": key, "mode": mode}
+            try:
+                ok = bool(item.SetProperty(key, payload))
+            except Exception as exc:
+                rec["success"] = False
+                rec["error"] = str(exc)
+                attempts.append(rec)
+                continue
+            rec["success"] = ok
+            if readback and ok:
+                try:
+                    rec["readback"] = item.GetProperty(key)
+                except Exception as exc:
+                    rec["readback_error"] = str(exc)
+            attempts.append(rec)
+            if ok:
+                return {
+                    "success": True,
+                    "timeline_item_id": _safe_timeline_item_id(item),
+                    "property_key": key,
+                    "mode": mode,
+                    "attempts": attempts,
+                }
+
+    return {
+        "success": False,
+        "error": "SetProperty did not succeed; run title_property_scan, copy a real key from `properties`, "
+        "and pass `property_key` (see `attempts` for diagnostics).",
+        "attempts": attempts,
+    }
+
+
+def _timeline_bulk_set_title_text(tl, p: Dict[str, Any]) -> Dict[str, Any]:
+    ops = p.get("ops")
+    if not isinstance(ops, list) or not ops:
+        return _err("bulk_set_title_text requires params.ops: non-empty list")
+    results: List[Dict[str, Any]] = []
+    for index, op in enumerate(ops):
+        if not isinstance(op, dict):
+            results.append({"index": index, "success": False, "error": "op must be an object"})
+            continue
+        merged = {**p, **op}
+        merged.pop("ops", None)
+        out = _timeline_set_title_text(tl, merged)
+        out["index"] = index
+        results.append(out)
+    return {"results": results, "op_count": len(ops)}
 
 
 _TIMELINE_CONFORM_KERNEL_ACTIONS = [
@@ -8211,6 +8343,11 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       marker_thumbnail_review(max_samples?, analysis_root?) -> {path, samples, review_guidance}
       edit_kernel_capabilities() -> {supported, partially_supported, unsupported}
       probe_edit_kernel_item(clip_ids? selected? timeline_item?) -> {items, count}
+      title_property_scan(clip_id|timeline_item_id|timeline_item) -> {properties, text_key_candidates, fusion_comp_count, ...}
+        — Undocumented generator/Text+ GetProperty map on an item (keys are not in public API docs).
+      set_title_text(clip_id|..., text, property_key?, as_styled_xml?, try_plain_first?, try_heuristic_keys?, readback?) -> {success, property_key?, attempts}
+        — SetProperty on a heuristic or explicit key; tries plain string then minimal styled XML unless as_styled_xml=True.
+      bulk_set_title_text(ops, ...) -> {results, op_count}  — list of set_title_text payloads (same params per op).
       create_compound_clip(clip_ids, info?) -> {success}
       create_fusion_clip(clip_ids) -> {success}
       import_into_timeline(path, options?) -> {success}
@@ -8404,6 +8541,12 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         return _timeline_edit_kernel_capabilities()
     elif action == "probe_edit_kernel_item":
         return _timeline_probe_edit_kernel_item(tl, p)
+    elif action == "title_property_scan":
+        return _timeline_title_property_scan(tl, p)
+    elif action == "set_title_text":
+        return _timeline_set_title_text(tl, p)
+    elif action == "bulk_set_title_text":
+        return _timeline_bulk_set_title_text(tl, p)
     elif action == "create_compound_clip":
         ids_set = set(p["clip_ids"])
         found = []
@@ -8663,7 +8806,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         if mp_err:
             return mp_err
         return _fairlight_boundary_report(proj, mp, tl, p)
-    return _unknown(action, ["list","get_current","set_current","get_name","set_name","get_start_frame","get_end_frame","get_start_timecode","set_start_timecode","get_track_count","add_track","delete_track","get_track_sub_type","set_track_enable","get_track_enabled","set_track_lock","get_track_locked","get_track_name","set_track_name","get_items","delete_clips","set_clips_linked","duplicate","duplicate_clips","copy_clips","move_clips","copy_range","duplicate_range","overwrite_range","lift_range","story_spine_report","create_variant_from_ranges","bulk_set_item_properties","apply_look_to_items","thumbnail_contact_sheet","marker_thumbnail_review","edit_kernel_capabilities","probe_edit_kernel_item","create_compound_clip","create_fusion_clip","import_into_timeline","export","get_setting","set_setting","insert_generator","insert_fusion_generator","insert_fusion_composition","insert_ofx_generator","insert_title","insert_fusion_title","get_unique_id","get_node_graph","get_media_pool_item","get_mark_in_out","set_mark_in_out","clear_mark_in_out","convert_to_stereo","get_items_in_track","get_voice_isolation_state","set_voice_isolation_state","extract_source_frame_ranges","audio_mix_capability_report",*_TIMELINE_CONFORM_KERNEL_ACTIONS,*_TIMELINE_AUDIO_KERNEL_ACTIONS])
+    return _unknown(action, ["list","get_current","set_current","get_name","set_name","get_start_frame","get_end_frame","get_start_timecode","set_start_timecode","get_track_count","add_track","delete_track","get_track_sub_type","set_track_enable","get_track_enabled","set_track_lock","get_track_locked","get_track_name","set_track_name","get_items","delete_clips","set_clips_linked","duplicate","duplicate_clips","copy_clips","move_clips","copy_range","duplicate_range","overwrite_range","lift_range","story_spine_report","create_variant_from_ranges","bulk_set_item_properties","apply_look_to_items","thumbnail_contact_sheet","marker_thumbnail_review","edit_kernel_capabilities","probe_edit_kernel_item","title_property_scan","set_title_text","bulk_set_title_text","create_compound_clip","create_fusion_clip","import_into_timeline","export","get_setting","set_setting","insert_generator","insert_fusion_generator","insert_fusion_composition","insert_ofx_generator","insert_title","insert_fusion_title","get_unique_id","get_node_graph","get_media_pool_item","get_mark_in_out","set_mark_in_out","clear_mark_in_out","convert_to_stereo","get_items_in_track","get_voice_isolation_state","set_voice_isolation_state","extract_source_frame_ranges","audio_mix_capability_report",*_TIMELINE_CONFORM_KERNEL_ACTIONS,*_TIMELINE_AUDIO_KERNEL_ACTIONS])
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/utils/timeline_title_text.py
+++ b/src/utils/timeline_title_text.py
@@ -1,0 +1,83 @@
+"""Helpers for Edit-page Text+ / generator text via undocumented TimelineItem.GetProperty keys."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+TITLE_TEXT_KEY_HINTS = (
+    "styled text",
+    "styledtext",
+    "text+",
+    "rich text",
+    "caption",
+    "subtitle",
+)
+
+
+def flatten_timeline_item_properties(props: Any) -> Dict[str, Any]:
+    if props is None:
+        return {}
+    if isinstance(props, dict):
+        return {str(k): v for k, v in props.items()}
+    return {}
+
+
+def timeline_item_get_property_map(
+    item: Any, serialize_fn: Callable[[Any], Any]
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    last_err: Optional[str] = None
+    for getter in (lambda: item.GetProperty(""), lambda: item.GetProperty()):
+        try:
+            raw = getter()
+        except TypeError:
+            continue
+        except Exception as exc:
+            last_err = str(exc)
+            continue
+        return flatten_timeline_item_properties(serialize_fn(raw)), None
+    return {}, last_err or "GetProperty failed"
+
+
+def candidate_title_property_keys(flat: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Prefer dict keys that may hold Text+ / generator rich text (not in public API docs)."""
+    candidates: List[Dict[str, Any]] = []
+    for key, value in flat.items():
+        if not isinstance(value, str):
+            continue
+        stripped = value.strip()
+        if not stripped:
+            continue
+        lk = key.lower()
+        score = 0
+        for hint in TITLE_TEXT_KEY_HINTS:
+            if hint in lk:
+                score += 10
+        if stripped.startswith("<?xml") or ("<" in stripped and ">" in stripped):
+            score += 5
+        if lk == "text":
+            score += 8
+        if score > 0 or len(stripped) > 24:
+            preview = stripped[:200] + ("…" if len(stripped) > 200 else "")
+            candidates.append({"key": key, "score": score, "value_preview": preview})
+    candidates.sort(key=lambda row: (-row["score"], row["key"]))
+    return candidates
+
+
+def escape_xml_text_body(s: str) -> str:
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def plain_to_minimal_styled_xml(plain: str) -> str:
+    """Best-effort Text+ styled payload when only plain copy is available; Resolve may normalize."""
+    body = escape_xml_text_body(plain)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<StyledElement>"
+        f"<Paragraph><TextRun>{body}</TextRun></Paragraph>"
+        "</StyledElement>"
+    )

--- a/src/utils/timeline_title_text.py
+++ b/src/utils/timeline_title_text.py
@@ -26,7 +26,8 @@ def timeline_item_get_property_map(
     item: Any, serialize_fn: Callable[[Any], Any]
 ) -> Tuple[Dict[str, Any], Optional[str]]:
     last_err: Optional[str] = None
-    for getter in (lambda: item.GetProperty(""), lambda: item.GetProperty()):
+    saw_empty_success = False
+    for getter in (lambda: item.GetProperty(), lambda: item.GetProperty("")):
         try:
             raw = getter()
         except TypeError:
@@ -34,8 +35,11 @@ def timeline_item_get_property_map(
         except Exception as exc:
             last_err = str(exc)
             continue
-        return flatten_timeline_item_properties(serialize_fn(raw)), None
-    return {}, last_err or "GetProperty failed"
+        flat = flatten_timeline_item_properties(serialize_fn(raw))
+        if flat:
+            return flat, None
+        saw_empty_success = True
+    return {}, None if saw_empty_success else last_err or "GetProperty failed"
 
 
 def candidate_title_property_keys(flat: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/tests/test_timeline_title_text_utils.py
+++ b/tests/test_timeline_title_text_utils.py
@@ -1,0 +1,50 @@
+import unittest
+
+from src.utils.timeline_title_text import (
+    candidate_title_property_keys,
+    escape_xml_text_body,
+    flatten_timeline_item_properties,
+    plain_to_minimal_styled_xml,
+    timeline_item_get_property_map,
+)
+
+
+class PropItemStub:
+    def __init__(self, props):
+        self._props = props
+
+    def GetProperty(self, key=""):
+        if key == "":
+            return dict(self._props)
+        return self._props.get(key)
+
+
+class TimelineTitleTextUtilsTest(unittest.TestCase):
+    def test_flatten(self):
+        self.assertEqual(flatten_timeline_item_properties({"a": 1}), {"a": 1})
+        self.assertEqual(flatten_timeline_item_properties(None), {})
+
+    def test_get_property_map(self):
+        item = PropItemStub({"Styled Text": "<x/>", "Pan": 0.0})
+        flat, err = timeline_item_get_property_map(item, lambda x: x)
+        self.assertIsNone(err)
+        self.assertIn("Styled Text", flat)
+
+    def test_plain_to_minimal_and_escape(self):
+        s = plain_to_minimal_styled_xml('a < b & c "d"')
+        self.assertNotIn("< b", s)
+        self.assertIn("&lt;", s)
+        self.assertEqual(escape_xml_text_body("&"), "&amp;")
+
+    def test_candidate_keys_order(self):
+        flat = {
+            "Pan": "0",
+            "Styled Text": '<x/>',
+            "Foo": "x" * 30,
+        }
+        keys = [r["key"] for r in candidate_title_property_keys(flat)]
+        self.assertEqual(keys[0], "Styled Text")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timeline_title_text_utils.py
+++ b/tests/test_timeline_title_text_utils.py
@@ -19,6 +19,15 @@ class PropItemStub:
         return self._props.get(key)
 
 
+class NoArgPropertyMapStub:
+    def GetProperty(self, key=None):
+        if key is None:
+            return {"Styled Text": "<x/>", "Pan": 0.0}
+        if key == "":
+            return None
+        return None
+
+
 class TimelineTitleTextUtilsTest(unittest.TestCase):
     def test_flatten(self):
         self.assertEqual(flatten_timeline_item_properties({"a": 1}), {"a": 1})
@@ -27,6 +36,11 @@ class TimelineTitleTextUtilsTest(unittest.TestCase):
     def test_get_property_map(self):
         item = PropItemStub({"Styled Text": "<x/>", "Pan": 0.0})
         flat, err = timeline_item_get_property_map(item, lambda x: x)
+        self.assertIsNone(err)
+        self.assertIn("Styled Text", flat)
+
+    def test_get_property_map_prefers_documented_no_arg_call(self):
+        flat, err = timeline_item_get_property_map(NoArgPropertyMapStub(), lambda x: x)
         self.assertIsNone(err)
         self.assertIn("Styled Text", flat)
 


### PR DESCRIPTION
Add timeline.title_property_scan, set_title_text, and bulk_set_title_text to discover and set undocumented Text+ / generator fields via TimelineItem GetProperty/SetProperty when Resolve exposes them.

Extract helpers to src/utils/timeline_title_text.py with unit tests. Bump version to 2.17.2 and document in CHANGELOG.

Edit-page Text items may still return empty properties or reject SetProperty; Fusion titles remain the reliable path for automation.

Co-authored-by: Cursor <cursoragent@cursor.com>
