### PR TITLE
feat(fusion_comp): group-settings helpers + bulk_set_expressions (adapts #40)

### DIFF
--- a/docs/kernels/fusion-composition-kernel.md
+++ b/docs/kernels/fusion-composition-kernel.md
@@ -30,9 +30,39 @@ All actions are exposed through `fusion_comp`.
 | `safe_set_inputs` | Batch write inputs on one tool with optional readback classification. |
 | `safe_connect_tools` | Validate source/target tools before connecting a source output to a target input. |
 | `fusion_boundary_report` | Return graph capabilities plus a composition snapshot for the selected comp scope. |
+| `bulk_set_expressions` | Batch `SetExpression` across scoped timeline-item Fusion comps. Each op needs `tool_name`, `input_name`, `expression`, plus a timeline scope. Wraps each op in `StartUndo`/`EndUndo` + `comp.Lock`. |
+| `group_settings_export` | Save a named `GroupOperator`'s settings to a `.setting` file via `SaveSettings`, returning a parsed published-input summary. |
+| `group_settings_splice_inputs` | Replace the `Inputs = ordered() { ... }` block of `source_path` with the matching block from `template_path` and write `dest_path`. Read-only against Resolve; pure file operation. |
+| `group_settings_load` | Backup the current group state, then `LoadSettings` from a `.setting` file. Wrapped in `StartUndo`/`EndUndo` + `comp.Lock` so Fusion's Ctrl+Z can reverse it. Backup path is returned alongside any error. |
+| `probe_group_published_inputs` | Read live published `Input1..InputN` slots off a `GroupOperator`, optionally cross-referenced with a `.setting` file summary. |
 
 The pre-existing `bulk_set_inputs` action remains the batch path for applying
 input writes across multiple explicitly scoped timeline-item Fusion comps.
+
+### `group_settings_splice_inputs` notes
+
+The Fusion `.setting` format is a Lua-like nested structure: an InstanceInput
+commonly contains `UserControls = ordered() { Custom = { ... } }` tables, so any
+parsing that uses a flat regex will truncate bodies at the first inner `}`. This
+kernel uses balanced-brace scanning end-to-end. Practical implications:
+
+- The action only swaps the published `Inputs = ordered() { ... }` block. The
+  group's outer name, inner `Tools = ordered() { ... }` section, and surrounding
+  structure are preserved byte-for-byte.
+- You must provide the *new* layout as a real `.setting` file (typically
+  exported from a known-good group via `group_settings_export`). The kernel does
+  not ship hardcoded templates.
+- `template_group_name` is optional when the template file contains a single
+  `GroupOperator`; pass it when the template file contains multiple groups and
+  you want a specific one.
+
+### `group_settings_load` Edit-page caveat
+
+`LoadSettings` may update inner tool wiring but not refresh Edit-page
+`InstanceInput` order until the group is selected in Fusion and reloaded via UI.
+This is a Resolve quirk, not a kernel bug. The action always backs up the group
+to a timestamped sibling of `settings_path` first; the backup path is returned
+in success and in error responses.
 
 ## Scope Matrix
 

--- a/src/server.py
+++ b/src/server.py
@@ -93,6 +93,13 @@ from src.utils.timeline_title_text import (
     timeline_item_get_property_map as _timeline_item_get_property_map,
 )
 from src.utils.multicam import build_multicam_setup_plan
+from src.utils.fusion_group_settings import (
+    FUSION_COMMIT_CHECKLIST,
+    FUSION_GROUP_GUARDRAILS,
+    default_backup_path,
+    parse_setting_file,
+    splice_inputs_block,
+)
 from src.utils import analysis_runs as _analysis_runs
 from src.utils import brain_edits as _brain_edits
 from src.utils import media_pool_changes as _media_pool_changes
@@ -16864,6 +16871,304 @@ def color_group(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
 # TOOL 27: fusion_comp
 # ═══════════════════════════════════════════════════════════════════════════════
 
+_FUSION_GROUP_KERNEL_ACTIONS = [
+    "group_settings_export",
+    "group_settings_splice_inputs",
+    "group_settings_load",
+    "bulk_set_expressions",
+    "probe_group_published_inputs",
+]
+
+
+def _find_fusion_group(comp, group_name: str):
+    tool = comp.FindTool(group_name)
+    if tool:
+        attrs = tool.GetAttrs() or {}
+        if attrs.get("TOOLS_RegID") == "GroupOperator":
+            return tool
+    tool_list = comp.GetToolList(False, "GroupOperator") or {}
+    for idx in tool_list:
+        candidate = tool_list[idx]
+        attrs = candidate.GetAttrs() or {}
+        if attrs.get("TOOLS_Name") == group_name:
+            return candidate
+    return None
+
+
+def _resolve_setting_path(p: Dict[str, Any], key: str = "path") -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    raw = p.get(key)
+    if not raw or not str(raw).strip():
+        return None, _err(f"{key} is required")
+    return os.path.abspath(str(raw)), None
+
+
+def _fusion_group_advisory(include: bool) -> Dict[str, Any]:
+    if not include:
+        return {}
+    return {
+        "guardrails": list(FUSION_GROUP_GUARDRAILS),
+        "commit_checklist": list(FUSION_COMMIT_CHECKLIST),
+    }
+
+
+def _fusion_group_settings_export(comp, p: Dict[str, Any]) -> Dict[str, Any]:
+    group_name = p.get("group_name")
+    if not group_name:
+        return _err("group_name is required")
+    path, path_err = _resolve_setting_path(p)
+    if path_err:
+        return path_err
+    group = _find_fusion_group(comp, str(group_name))
+    if not group:
+        return _err(f"GroupOperator {group_name!r} not found in comp")
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    try:
+        group.SaveSettings(path)
+    except Exception as exc:
+        return _err(f"SaveSettings failed: {exc}")
+    if not os.path.isfile(path):
+        return _err(f"SaveSettings did not create file at {path!r}")
+    try:
+        parsed = parse_setting_file(path, group_name=str(group_name))
+    except Exception as exc:
+        return {
+            "success": True,
+            "path": path,
+            "group_name": group_name,
+            "parse_warning": f"saved, but summary parse failed: {exc}",
+            **_fusion_group_advisory(p.get("include_advisory", False)),
+        }
+    return {
+        "success": True,
+        "path": path,
+        "group_name": group_name,
+        "published_inputs": parsed["published_inputs"],
+        "input_count": parsed["input_count"],
+        **_fusion_group_advisory(p.get("include_advisory", False)),
+    }
+
+
+def _fusion_group_settings_splice_inputs(p: Dict[str, Any]) -> Dict[str, Any]:
+    source_path, src_err = _resolve_setting_path(p, "source_path")
+    if src_err:
+        return src_err
+    if not os.path.isfile(source_path):
+        return _err(f"source_path not found: {source_path}")
+    template_path, tpl_err = _resolve_setting_path(p, "template_path")
+    if tpl_err:
+        return tpl_err
+    if not os.path.isfile(template_path):
+        return _err(f"template_path not found: {template_path}")
+    dest_path = p.get("dest_path")
+    if dest_path:
+        dest_path = os.path.abspath(str(dest_path))
+    else:
+        root, ext = os.path.splitext(source_path)
+        dest_path = f"{root}.patched{ext or '.setting'}"
+    try:
+        summary = splice_inputs_block(
+            source_path,
+            template_path,
+            dest_path,
+            source_group_name=p.get("source_group_name") or p.get("group_name"),
+            template_group_name=p.get("template_group_name"),
+        )
+    except Exception as exc:
+        return _err(f"splice failed: {exc}")
+    return {
+        "success": True,
+        "dest_path": summary["dest_path"],
+        "summary": summary,
+        **_fusion_group_advisory(p.get("include_advisory", False)),
+    }
+
+
+def _fusion_group_settings_load(comp, p: Dict[str, Any]) -> Dict[str, Any]:
+    group_name = p.get("group_name")
+    if not group_name:
+        return _err("group_name is required")
+    settings_path, path_err = _resolve_setting_path(p, "settings_path")
+    if path_err:
+        return path_err
+    if not os.path.isfile(settings_path):
+        return _err(f"settings_path not found: {settings_path}")
+    group = _find_fusion_group(comp, str(group_name))
+    if not group:
+        return _err(f"GroupOperator {group_name!r} not found in comp")
+    backup_path = p.get("backup_path")
+    if backup_path:
+        backup_path = os.path.abspath(str(backup_path))
+    else:
+        backup_path = default_backup_path(settings_path)
+    try:
+        os.makedirs(os.path.dirname(backup_path) or ".", exist_ok=True)
+        group.SaveSettings(backup_path)
+    except Exception as exc:
+        return _err(f"backup SaveSettings failed: {exc}")
+
+    undo_name = p.get("undo_name", f"MCP group_settings_load {group_name}")
+    undo_started = False
+    keep_undo = False
+    error_message: Optional[str] = None
+    try:
+        try:
+            comp.StartUndo(undo_name)
+            undo_started = True
+        except Exception:
+            undo_started = False
+        comp.Lock()
+        try:
+            group.LoadSettings(settings_path)
+            keep_undo = True
+        finally:
+            comp.Unlock()
+    except Exception as exc:
+        error_message = str(exc)
+    finally:
+        if undo_started:
+            try:
+                comp.EndUndo(keep_undo)
+            except Exception:
+                pass
+
+    if error_message is not None:
+        return _err(
+            f"LoadSettings failed: {error_message}",
+            remediation=f"Group state preserved by backup at {backup_path}",
+        )
+    return {
+        "success": True,
+        "group_name": group_name,
+        "settings_path": settings_path,
+        "backup_path": backup_path,
+        "warning": (
+            "Group preserved. If Edit Controls don't refresh, select the group in "
+            "Fusion and use UI Load Settings to remap InstanceInput order."
+        ),
+        **_fusion_group_advisory(p.get("include_advisory", False)),
+    }
+
+
+def _fusion_comp_bulk_set_expressions(p: Dict[str, Any]) -> Dict[str, Any]:
+    ops = p.get("ops")
+    if not isinstance(ops, list) or not ops:
+        return _err(
+            "bulk_set_expressions requires params.ops: non-empty list of objects. "
+            "Each op must include tool_name, input_name, expression, and a timeline scope: "
+            "clip_id, timeline_item_id, or timeline_item={track_type, track_index, item_index}. "
+            "Optional per-op: comp_name, comp_index, time, undo_name."
+        )
+    results: List[Dict[str, Any]] = []
+    for index, op in enumerate(ops):
+        if not isinstance(op, dict):
+            results.append({"index": index, "error": "op must be an object"})
+            continue
+        if not _has_fusion_timeline_scope(op):
+            results.append({"index": index, "error": "timeline scope is required for bulk_set_expressions"})
+            continue
+        missing = [key for key in ("tool_name", "input_name", "expression") if key not in op]
+        if missing:
+            results.append({"index": index, "error": f"missing required field(s): {', '.join(missing)}"})
+            continue
+        comp, comp_err = _resolve_fusion_comp(op, require_timeline_scope=True)
+        if comp_err:
+            results.append({"index": index, "error": comp_err.get("error", str(comp_err))})
+            continue
+        tool = comp.FindTool(op["tool_name"])
+        if not tool:
+            results.append({"index": index, "error": f"Tool {op['tool_name']!r} not found"})
+            continue
+        undo_name = op.get("undo_name", f"MCP bulk_set_expressions #{index}")
+        undo_started = False
+        keep_undo = False
+        error_message: Optional[str] = None
+        try:
+            try:
+                comp.StartUndo(undo_name)
+                undo_started = True
+            except Exception:
+                undo_started = False
+            comp.Lock()
+            try:
+                time = op.get("time", 0)
+                inp = tool[op["input_name"]]
+                if not inp:
+                    raise ValueError(f"Input {op['input_name']!r} not found on {op['tool_name']!r}")
+                inp.SetExpression(str(op["expression"]), time)
+                keep_undo = True
+            finally:
+                comp.Unlock()
+        except Exception as exc:
+            error_message = str(exc)
+        finally:
+            if undo_started:
+                try:
+                    comp.EndUndo(keep_undo)
+                except Exception:
+                    pass
+        if error_message is not None:
+            results.append({"index": index, "error": error_message})
+        elif keep_undo:
+            results.append({"index": index, "success": True, "expression": op["expression"]})
+    return {"results": results, "op_count": len(ops)}
+
+
+def _fusion_probe_group_published_inputs(comp, p: Dict[str, Any]) -> Dict[str, Any]:
+    group_name = p.get("group_name")
+    if not group_name:
+        return _err("group_name is required")
+    group = _find_fusion_group(comp, str(group_name))
+    if not group:
+        return _err(f"GroupOperator {group_name!r} not found in comp")
+    max_inputs = p.get("max_inputs", 32)
+    try:
+        max_inputs = int(max_inputs)
+    except (TypeError, ValueError):
+        max_inputs = 32
+    time = p.get("time", 0)
+    live_inputs: List[Dict[str, Any]] = []
+    for index in range(1, max_inputs + 1):
+        slot = f"Input{index}"
+        try:
+            inp = group[slot]
+        except Exception:
+            break
+        if not inp:
+            break
+        row: Dict[str, Any] = {"slot": slot}
+        try:
+            attrs = inp.GetAttrs() or {}
+            row["name"] = attrs.get("INPS_Name", "")
+            row["type"] = attrs.get("INPS_DataType", "")
+        except Exception:
+            pass
+        try:
+            row["value"] = _ser(inp[time])
+        except Exception as exc:
+            row["value_error"] = str(exc)
+        try:
+            row["expression"] = inp.GetExpression(time)
+        except Exception:
+            row["expression"] = None
+        live_inputs.append(row)
+
+    file_summary: Optional[Dict[str, Any]] = None
+    settings_path = p.get("settings_path")
+    if settings_path and os.path.isfile(str(settings_path)):
+        try:
+            file_summary = parse_setting_file(str(settings_path), group_name=str(group_name))
+        except Exception as exc:
+            file_summary = {"error": str(exc)}
+
+    return {
+        "group_name": group_name,
+        "live_inputs": live_inputs,
+        "live_input_count": len(live_inputs),
+        "file_summary": file_summary,
+        **_fusion_group_advisory(p.get("include_advisory", False)),
+    }
+
+
 def _fusion_comp_bulk_set_inputs(p: Dict[str, Any]) -> Dict[str, Any]:
     """Apply set_input across many explicitly scoped timeline-item Fusion comps."""
     ops = p.get("ops")
@@ -17177,6 +17482,14 @@ def fusion_comp(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
       start_undo(name?) -> {success}
       end_undo(keep?) -> {success}
       bulk_set_inputs(ops) -> {results, op_count} — each op requires timeline scope plus tool_name, input_name, value
+      bulk_set_expressions(ops) -> {results, op_count} — each op requires timeline scope plus tool_name, input_name, expression
+      group_settings_export(group_name, path, include_advisory?) -> {path, published_inputs, input_count}
+      group_settings_splice_inputs(source_path, template_path, dest_path?, source_group_name?, template_group_name?) -> {dest_path, summary}
+        Replace a source .setting's `Inputs = ordered() { ... }` block with the matching block from template_path.
+        Both files are read; neither GroupOperator is loaded into Resolve. Inner tools and outer structure are preserved.
+      group_settings_load(group_name, settings_path, backup_path?, undo_name?) -> {settings_path, backup_path}
+        Wraps the LoadSettings call in StartUndo/EndUndo + comp.Lock for reversibility.
+      probe_group_published_inputs(group_name, settings_path?, max_inputs?, time?) -> {live_inputs, file_summary?}
       fusion_graph_capabilities(...) -> {supported, boundaries, common_tools}
       probe_fusion_comp(include_io?, max_tools?) -> {name, tool_count, tools}
       probe_fusion_tool(tool_name, include_io?) -> {found, tool}
@@ -17193,10 +17506,21 @@ def fusion_comp(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
 
     if action == "bulk_set_inputs":
         return _fusion_comp_bulk_set_inputs(p)
+    if action == "bulk_set_expressions":
+        return _fusion_comp_bulk_set_expressions(p)
+    if action == "group_settings_splice_inputs":
+        return _fusion_group_settings_splice_inputs(p)
 
     comp, comp_err = _resolve_fusion_comp(p)
     if comp_err:
         return comp_err
+
+    if action == "group_settings_export":
+        return _fusion_group_settings_export(comp, p)
+    if action == "group_settings_load":
+        return _fusion_group_settings_load(comp, p)
+    if action == "probe_group_published_inputs":
+        return _fusion_probe_group_published_inputs(comp, p)
 
     if action == "fusion_graph_capabilities":
         return _fusion_graph_capabilities(comp)
@@ -17449,6 +17773,8 @@ def fusion_comp(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
         "get_comp_info","set_frame_range","render",
         "start_undo","end_undo",
         "bulk_set_inputs",
+        "bulk_set_expressions",
+        *_FUSION_GROUP_KERNEL_ACTIONS,
         *_FUSION_KERNEL_ACTIONS,
     ])
 

--- a/src/utils/fusion_group_settings.py
+++ b/src/utils/fusion_group_settings.py
@@ -1,0 +1,323 @@
+"""Parse and patch Fusion GroupOperator .setting files.
+
+Fusion's .setting format is a Lua-like nested structure. Real-world group
+exports routinely contain InstanceInput blocks with nested UserControls /
+ControlGroup tables (>=2 levels of braces), so we cannot parse them with a
+flat regex. All structural scans here use balanced-brace matching.
+
+Public surface:
+  parse_setting_file(path, group_name=None) -> dict
+      Inspect a .setting file and return the published-input summary for a
+      named (or first) GroupOperator.
+
+  splice_inputs_block(source_path, template_path, dest_path,
+                      group_name=None) -> dict
+      Replace the `Inputs = ordered() { ... }` block of source_path with
+      the matching block from template_path and write to dest_path.
+      Returns a before/after diff summary.
+
+  default_backup_path(path) -> str
+      Generate a timestamped backup filename next to a target path.
+
+  FUSION_GROUP_GUARDRAILS, FUSION_COMMIT_CHECKLIST
+      Advisory text. Other modules may surface these on demand; this module
+      does not jam them into every return.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+
+FUSION_COMMIT_CHECKLIST: Tuple[str, ...] = (
+    "Open the Fusion page for the modified timeline item (or comp scope).",
+    "Select the group/macro node and nudge one published control so Resolve refreshes bindings.",
+    "Verify Edit-page controls respond (Text, Text Size, wrap, padding, corners).",
+    "Save the project (Ctrl+S / Cmd+S).",
+    "If InstanceInput order changed, confirm Edit Controls order in UI; LoadSettings may require manual UI 'Load Settings' on the group.",
+)
+
+FUSION_GROUP_GUARDRAILS: Tuple[str, ...] = (
+    "Do not call project_manager.load or switch projects mid Fusion edit — comp scope and undo stacks are lost.",
+    "Batch graph mutations: prefer bulk_set_inputs / bulk_set_expressions over many single-action calls.",
+    "InstanceInput remapping via LoadSettings may not refresh Edit-page control order until the group is selected and settings reloaded in Fusion UI.",
+    "Never delete a group via automation; group_settings_load only patches published inputs and inner settings.",
+    "After mutating a timeline-item Fusion comp, follow the commit checklist before expecting Edit-page updates.",
+)
+
+
+@dataclass
+class InstanceInputSummary:
+    slot: str
+    source_op: Optional[str] = None
+    source: Optional[str] = None
+    name: Optional[str] = None
+    max_scale: Optional[float] = None
+    default: Optional[str] = None
+    control_group: Optional[int] = None
+    raw_fields: Dict[str, Any] = field(default_factory=dict)
+
+
+# Used only to read shallow fields out of an InstanceInput body that we have
+# already isolated with balanced-brace scanning. We never use it to FIND the
+# bounds of a block.
+_FIELD_RE = re.compile(r'(\w+)\s*=\s*(?:"([^"]*)"|([\d.eE+-]+))')
+
+_INPUT_HEAD_RE = re.compile(r"(Input\d+)\s*=\s*InstanceInput\s*\{")
+
+
+def _find_balanced_brace(text: str, open_index: int) -> int:
+    """Return the index of the `}` that closes the `{` at open_index."""
+    depth = 0
+    for idx in range(open_index, len(text)):
+        ch = text[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return idx
+    raise ValueError("Unbalanced braces")
+
+
+def _iter_instance_input_blocks(inputs_inner: str) -> List[Tuple[str, str]]:
+    """Yield (slot, body) pairs by walking InstanceInput heads + balanced braces."""
+    blocks: List[Tuple[str, str]] = []
+    pos = 0
+    while True:
+        match = _INPUT_HEAD_RE.search(inputs_inner, pos)
+        if not match:
+            break
+        slot = match.group(1)
+        open_brace = match.end() - 1
+        try:
+            close_brace = _find_balanced_brace(inputs_inner, open_brace)
+        except ValueError:
+            break
+        body = inputs_inner[open_brace + 1 : close_brace]
+        blocks.append((slot, body))
+        pos = close_brace + 1
+    return blocks
+
+
+def _shallow_fields(body: str) -> Dict[str, Any]:
+    """Extract top-level `key = value` fields, skipping nested braces."""
+    fields: Dict[str, Any] = {}
+    i = 0
+    n = len(body)
+    while i < n:
+        ch = body[i]
+        if ch == "{":
+            try:
+                close = _find_balanced_brace(body, i)
+            except ValueError:
+                break
+            i = close + 1
+            continue
+        match = _FIELD_RE.match(body, i)
+        if match:
+            key, str_val, num_val = match.group(1), match.group(2), match.group(3)
+            if str_val is not None:
+                fields[key] = str_val
+            elif num_val is not None:
+                try:
+                    fields[key] = (
+                        float(num_val) if "." in num_val or "e" in num_val.lower() else int(num_val)
+                    )
+                except ValueError:
+                    fields[key] = num_val
+            i = match.end()
+        else:
+            i += 1
+    return fields
+
+
+def parse_instance_input_block(inputs_inner: str) -> List[InstanceInputSummary]:
+    summaries: List[InstanceInputSummary] = []
+    for slot, body in _iter_instance_input_blocks(inputs_inner):
+        fields = _shallow_fields(body)
+        max_scale = fields.get("MaxScale")
+        if isinstance(max_scale, (int, float)):
+            max_scale_f: Optional[float] = float(max_scale)
+        else:
+            max_scale_f = None
+        cg = fields.get("ControlGroup")
+        summaries.append(
+            InstanceInputSummary(
+                slot=slot,
+                source_op=fields.get("SourceOp"),
+                source=fields.get("Source"),
+                name=fields.get("Name"),
+                max_scale=max_scale_f,
+                default=str(fields["Default"]) if "Default" in fields else None,
+                control_group=int(cg) if isinstance(cg, int) else None,
+                raw_fields=fields,
+            )
+        )
+    summaries.sort(key=lambda row: _slot_key(row.slot))
+    return summaries
+
+
+def _slot_key(slot: str) -> int:
+    try:
+        return int(slot.replace("Input", ""))
+    except ValueError:
+        return 9999
+
+
+def _group_inputs_span(
+    content: str, group_name: Optional[str] = None
+) -> Tuple[int, int, str]:
+    """Return absolute (start, end_exclusive, inner) for the Inputs ordered block."""
+    if group_name:
+        pattern = re.compile(
+            rf"{re.escape(group_name)}\s*=\s*GroupOperator\s*\{{",
+            re.MULTILINE,
+        )
+        match = pattern.search(content)
+        if not match:
+            raise ValueError(f"GroupOperator {group_name!r} not found in .setting content")
+        group_open = match.end() - 1
+    else:
+        match = re.search(r"=\s*GroupOperator\s*\{", content)
+        if not match:
+            raise ValueError("No GroupOperator found in .setting content")
+        group_open = match.end() - 1
+
+    group_close = _find_balanced_brace(content, group_open)
+    group_body = content[group_open + 1 : group_close]
+    inputs_marker = re.search(r"Inputs\s*=\s*ordered\s*\(\s*\)\s*\{", group_body)
+    if not inputs_marker:
+        raise ValueError("GroupOperator has no Inputs = ordered() block")
+    abs_start = group_open + 1 + inputs_marker.start()
+    open_brace = group_open + 1 + inputs_marker.end() - 1
+    close_brace = _find_balanced_brace(content, open_brace)
+    replace_end = close_brace + 1
+    if replace_end < len(content) and content[replace_end] == ",":
+        replace_end += 1
+    return abs_start, replace_end, content[open_brace + 1 : close_brace]
+
+
+def parse_setting_file(path: str, group_name: Optional[str] = None) -> Dict[str, Any]:
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        content = handle.read()
+    _, _, inner = _group_inputs_span(content, group_name=group_name)
+    inputs = parse_instance_input_block(inner)
+    return {
+        "path": os.path.abspath(path),
+        "published_inputs": [
+            {
+                "slot": row.slot,
+                "name": row.name,
+                "source_op": row.source_op,
+                "source": row.source,
+                "max_scale": row.max_scale,
+                "default": row.default,
+                "control_group": row.control_group,
+            }
+            for row in inputs
+        ],
+        "input_count": len(inputs),
+    }
+
+
+def _read_template_inputs_block(
+    template_path: str, group_name: Optional[str] = None
+) -> str:
+    """Pull the full `Inputs = ordered() { ... },` block from a .setting file."""
+    with open(template_path, encoding="utf-8", errors="replace") as handle:
+        content = handle.read()
+    start, end, _ = _group_inputs_span(content, group_name=group_name)
+    return content[start:end]
+
+
+def _summary_dict(row: Optional[InstanceInputSummary]) -> Optional[Dict[str, Any]]:
+    if row is None:
+        return None
+    return {
+        "source_op": row.source_op,
+        "source": row.source,
+        "name": row.name,
+        "max_scale": row.max_scale,
+        "control_group": row.control_group,
+    }
+
+
+def _diff_inputs(
+    before: List[InstanceInputSummary], after: List[InstanceInputSummary]
+) -> List[Dict[str, Any]]:
+    before_by_slot = {row.slot: row for row in before}
+    after_by_slot = {row.slot: row for row in after}
+    all_slots = sorted(set(before_by_slot) | set(after_by_slot), key=_slot_key)
+    diff: List[Dict[str, Any]] = []
+    for slot in all_slots:
+        b = before_by_slot.get(slot)
+        a = after_by_slot.get(slot)
+        if b is None:
+            diff.append({"slot": slot, "change": "added", "after": _summary_dict(a)})
+        elif a is None:
+            diff.append({"slot": slot, "change": "removed", "before": _summary_dict(b)})
+        elif _summary_dict(b) != _summary_dict(a):
+            diff.append(
+                {
+                    "slot": slot,
+                    "change": "modified",
+                    "before": _summary_dict(b),
+                    "after": _summary_dict(a),
+                }
+            )
+    return diff
+
+
+def splice_inputs_block(
+    source_path: str,
+    template_path: str,
+    dest_path: str,
+    *,
+    source_group_name: Optional[str] = None,
+    template_group_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Replace source's `Inputs = ordered() { ... }` with template's, write dest.
+
+    source_path: .setting whose published inputs you want to replace.
+    template_path: .setting whose Inputs block defines the desired layout.
+    dest_path: where to write the spliced result.
+
+    Returns a summary with input counts before/after and a per-slot diff.
+    """
+    with open(source_path, encoding="utf-8", errors="replace") as handle:
+        source_content = handle.read()
+    src_start, src_end, src_inner = _group_inputs_span(
+        source_content, group_name=source_group_name
+    )
+    before_inputs = parse_instance_input_block(src_inner)
+    template_block = _read_template_inputs_block(
+        template_path, group_name=template_group_name
+    )
+
+    new_content = source_content[:src_start] + template_block + source_content[src_end:]
+    _, _, new_inner = _group_inputs_span(new_content, group_name=source_group_name)
+    after_inputs = parse_instance_input_block(new_inner)
+
+    os.makedirs(os.path.dirname(os.path.abspath(dest_path)) or ".", exist_ok=True)
+    with open(dest_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(new_content)
+
+    return {
+        "source_path": os.path.abspath(source_path),
+        "template_path": os.path.abspath(template_path),
+        "dest_path": os.path.abspath(dest_path),
+        "before_input_count": len(before_inputs),
+        "after_input_count": len(after_inputs),
+        "diff": _diff_inputs(before_inputs, after_inputs),
+    }
+
+
+def default_backup_path(base_path: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    root, ext = os.path.splitext(base_path)
+    return f"{root}.backup_{stamp}{ext or '.setting'}"

--- a/tests/test_fusion_group_settings.py
+++ b/tests/test_fusion_group_settings.py
@@ -1,0 +1,284 @@
+"""Offline tests for src/utils/fusion_group_settings.py.
+
+The fixtures intentionally include nested UserControls / ControlGroup tables
+because real-world Fusion GroupOperator exports almost always have them — a
+flat regex parser would silently truncate InstanceInput bodies at the first
+inner `}`.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.utils.fusion_group_settings import (
+    FUSION_COMMIT_CHECKLIST,
+    FUSION_GROUP_GUARDRAILS,
+    default_backup_path,
+    parse_instance_input_block,
+    parse_setting_file,
+    splice_inputs_block,
+)
+
+
+# A flat fixture (no nested braces) used to check basic parsing + slot ordering.
+FLAT_FIXTURE = """{
+\tTools = ordered() {
+\t\tAMZThoughtBubblev13 = GroupOperator {
+\t\t\tInputs = ordered() {
+\t\t\t\tInput2 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextBox",
+\t\t\t\t\tSource = "TextLineSpacing",
+\t\t\t\t},
+\t\t\t\tInput1 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextBox",
+\t\t\t\t\tSource = "TextSize",
+\t\t\t\t\tMaxScale = 0.1,
+\t\t\t\t},
+\t\t\t},
+\t\t\tTools = ordered() {
+\t\t\t\tTextBox = TextPlus { Inputs = {} },
+\t\t\t},
+\t\t},
+\t},
+}"""
+
+
+# A realistic fixture with nested UserControls (slider hint table) on Input1.
+# The original PR's flat regex truncates Input1 at the inner `}` and reports
+# only 1 of 3 inputs, with wrong fields.
+NESTED_FIXTURE = """{
+\tTools = ordered() {
+\t\tAMZThoughtBubblev13 = GroupOperator {
+\t\t\tInputs = ordered() {
+\t\t\t\tInput1 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextPlus1",
+\t\t\t\t\tSource = "Size",
+\t\t\t\t\tName = "Text Size",
+\t\t\t\t\tDefault = 0.08,
+\t\t\t\t\tPage = "Controls",
+\t\t\t\t\tUserControls = ordered() {
+\t\t\t\t\t\tCustom = {
+\t\t\t\t\t\t\tLINKID_DataType = "Number",
+\t\t\t\t\t\t\tINPID_InputControl = "SliderControl",
+\t\t\t\t\t\t\tINP_MinScale = 0,
+\t\t\t\t\t\t\tINP_MaxScale = 0.5,
+\t\t\t\t\t\t\tINP_Integer = false,
+\t\t\t\t\t\t},
+\t\t\t\t\t},
+\t\t\t\t},
+\t\t\t\tInput2 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextPlus1",
+\t\t\t\t\tSource = "StyledText",
+\t\t\t\t\tName = "Text",
+\t\t\t\t\tControlGroup = 1,
+\t\t\t\t},
+\t\t\t\tInput3 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextPlus1",
+\t\t\t\t\tSource = "Red1",
+\t\t\t\t\tName = "Text Color",
+\t\t\t\t\tControlGroup = 10,
+\t\t\t\t\tDefault = 0.1764705882353,
+\t\t\t\t},
+\t\t\t},
+\t\t\tTools = ordered() {
+\t\t\t\tTextPlus1 = TextPlus { Inputs = {} },
+\t\t\t},
+\t\t},
+\t},
+}"""
+
+
+# A template fixture: smaller, ordered, different inputs. Used to verify the
+# splice replaces the source's Inputs block end-to-end.
+TEMPLATE_FIXTURE = """{
+\tTools = ordered() {
+\t\tDummyTemplate = GroupOperator {
+\t\t\tInputs = ordered() {
+\t\t\t\tInput1 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextPlus1",
+\t\t\t\t\tSource = "StyledText",
+\t\t\t\t\tName = "Text",
+\t\t\t\t},
+\t\t\t\tInput2 = InstanceInput {
+\t\t\t\t\tSourceOp = "TextPlus1",
+\t\t\t\t\tSource = "Size",
+\t\t\t\t\tName = "Text Size",
+\t\t\t\t\tDefault = 0.06,
+\t\t\t\t},
+\t\t\t},
+\t\t\tTools = ordered() {
+\t\t\t\tNoOp = Note { Inputs = {} },
+\t\t\t},
+\t\t},
+\t},
+}"""
+
+
+def _write(tmp: str, name: str, content: str) -> str:
+    path = os.path.join(tmp, name)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+    return path
+
+
+class ParseFlatTest(unittest.TestCase):
+    def test_parse_sorts_slots_by_number(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, "flat.setting", FLAT_FIXTURE)
+            parsed = parse_setting_file(path, group_name="AMZThoughtBubblev13")
+            self.assertEqual(parsed["input_count"], 2)
+            self.assertEqual(parsed["published_inputs"][0]["slot"], "Input1")
+            self.assertEqual(parsed["published_inputs"][0]["source"], "TextSize")
+            self.assertEqual(parsed["published_inputs"][0]["max_scale"], 0.1)
+            self.assertEqual(parsed["published_inputs"][1]["slot"], "Input2")
+
+
+class ParseNestedTest(unittest.TestCase):
+    """These cases exercise the balanced-brace parser. A flat-regex parser
+    would mis-bound Input1's body at the first inner `}` and either report
+    fewer inputs or carry wrong field values."""
+
+    def test_nested_inputs_all_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, "nested.setting", NESTED_FIXTURE)
+            parsed = parse_setting_file(path, group_name="AMZThoughtBubblev13")
+            self.assertEqual(parsed["input_count"], 3)
+            slots = [row["slot"] for row in parsed["published_inputs"]]
+            self.assertEqual(slots, ["Input1", "Input2", "Input3"])
+
+    def test_nested_input1_fields_correct(self):
+        # The PR's flat regex would truncate Input1 at `INP_Integer = false,\n}`,
+        # losing the closing of the InstanceInput. The balanced parser keeps
+        # the shallow Source/Name/Default fields intact.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, "nested.setting", NESTED_FIXTURE)
+            parsed = parse_setting_file(path, group_name="AMZThoughtBubblev13")
+            input1 = parsed["published_inputs"][0]
+            self.assertEqual(input1["source"], "Size")
+            self.assertEqual(input1["source_op"], "TextPlus1")
+            self.assertEqual(input1["name"], "Text Size")
+            self.assertEqual(input1["default"], "0.08")
+
+    def test_shallow_fields_skip_nested_keys(self):
+        """Keys inside a nested table (LINKID_DataType, INPID_InputControl,
+        INP_MaxScale) must not leak into the InstanceInput's top-level fields."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, "nested.setting", NESTED_FIXTURE)
+            parsed = parse_setting_file(path, group_name="AMZThoughtBubblev13")
+            input1 = parsed["published_inputs"][0]
+            # The nested INP_MaxScale = 0.5 must NOT be reported as max_scale.
+            self.assertIsNone(input1["max_scale"])
+
+
+class SpliceTest(unittest.TestCase):
+    def test_splice_replaces_inputs_block_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, "nested.setting", NESTED_FIXTURE)
+            tpl = _write(tmp, "tpl.setting", TEMPLATE_FIXTURE)
+            dest = os.path.join(tmp, "out.setting")
+            summary = splice_inputs_block(
+                src, tpl, dest,
+                source_group_name="AMZThoughtBubblev13",
+                template_group_name="DummyTemplate",
+            )
+            self.assertTrue(os.path.isfile(dest))
+            self.assertEqual(summary["before_input_count"], 3)
+            self.assertEqual(summary["after_input_count"], 2)
+            with open(dest, encoding="utf-8") as handle:
+                content = handle.read()
+            # The source's outer GroupOperator name must be preserved.
+            self.assertIn("AMZThoughtBubblev13 = GroupOperator", content)
+            # The source's inner Tools section (TextPlus1) must be preserved.
+            self.assertIn("TextPlus1 = TextPlus", content)
+            # The template's Inputs must replace the source's Inputs.
+            new_inputs = parse_setting_file(dest, group_name="AMZThoughtBubblev13")
+            sources = [row["source"] for row in new_inputs["published_inputs"]]
+            self.assertEqual(sources, ["StyledText", "Size"])
+
+    def test_splice_diff_classifies_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, "nested.setting", NESTED_FIXTURE)
+            tpl = _write(tmp, "tpl.setting", TEMPLATE_FIXTURE)
+            dest = os.path.join(tmp, "out.setting")
+            summary = splice_inputs_block(
+                src, tpl, dest,
+                source_group_name="AMZThoughtBubblev13",
+                template_group_name="DummyTemplate",
+            )
+            changes = {row["slot"]: row["change"] for row in summary["diff"]}
+            # Input3 in the source has no counterpart in the 2-input template.
+            self.assertEqual(changes.get("Input3"), "removed")
+
+    def test_splice_missing_group_name_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, "nested.setting", NESTED_FIXTURE)
+            tpl = _write(tmp, "tpl.setting", TEMPLATE_FIXTURE)
+            dest = os.path.join(tmp, "out.setting")
+            with self.assertRaises(ValueError):
+                splice_inputs_block(
+                    src, tpl, dest,
+                    source_group_name="DoesNotExist",
+                    template_group_name="DummyTemplate",
+                )
+
+
+class InputBlockParseUnitTest(unittest.TestCase):
+    """Direct unit-level coverage of parse_instance_input_block — useful when
+    debugging the balanced-brace walker without round-tripping through a file."""
+
+    def test_three_inputs_with_nested_braces(self):
+        inputs_inner = """
+            Input1 = InstanceInput {
+                SourceOp = "A",
+                Source = "X",
+                UserControls = ordered() { Custom = { K = "v" } },
+            },
+            Input2 = InstanceInput {
+                SourceOp = "B",
+                Source = "Y",
+            },
+            Input3 = InstanceInput {
+                SourceOp = "C",
+                Source = "Z",
+                ControlGroup = 7,
+            },
+        """
+        parsed = parse_instance_input_block(inputs_inner)
+        self.assertEqual([row.slot for row in parsed], ["Input1", "Input2", "Input3"])
+        self.assertEqual(parsed[0].source_op, "A")
+        self.assertEqual(parsed[2].control_group, 7)
+
+
+class BackupPathTest(unittest.TestCase):
+    def test_backup_path_includes_timestamp_and_extension(self):
+        path = default_backup_path("/tmp/foo.setting")
+        self.assertTrue(path.startswith("/tmp/foo.backup_"))
+        self.assertTrue(path.endswith(".setting"))
+
+    def test_backup_path_handles_missing_extension(self):
+        path = default_backup_path("/tmp/foo")
+        self.assertTrue(path.endswith(".setting"))
+
+
+class AdvisoryConstantsTest(unittest.TestCase):
+    def test_guardrails_are_non_empty_strings(self):
+        self.assertGreater(len(FUSION_GROUP_GUARDRAILS), 0)
+        for line in FUSION_GROUP_GUARDRAILS:
+            self.assertIsInstance(line, str)
+            self.assertGreater(len(line), 10)
+
+    def test_checklist_mentions_save(self):
+        self.assertTrue(
+            any("Save" in step or "save" in step for step in FUSION_COMMIT_CHECKLIST)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adapts [#40](https://github.com/samuelgursky/davinci-resolve-mcp/pull/40) by @RaincloudTheDragon with hardening fixes. Closes #40 in favor of this branch.

Adds five `fusion_comp` actions for working with Fusion `GroupOperator` settings plus a `bulk_set_expressions` batch writer that mirrors the existing `bulk_set_inputs` shape.

## What changed vs PR #40

| Concern | PR #40 | This branch |
|---|---|---|
| `.setting` parser | Flat regex — truncates `InstanceInput` bodies at the first inner `}` (any macro with `UserControls = ordered() { ... }`) | Balanced-brace walker (`_iter_instance_input_blocks` + `_shallow_fields`) — correct on nested tables |
| `patch_controls` action | Hardcoded `THOUGHT_BUBBLE_SPEECH_ORDER_TEMPLATE` (only `template_key` accepted) | Renamed `splice_inputs` — caller supplies a real template `.setting` file; nothing baked in |
| `group_settings_load` | No undo wrap, no `comp.Lock` | Wrapped in `StartUndo`/`EndUndo` + `comp.Lock`; backup path returned in both success and error responses |
| `fusion_commit_hint` | Both a standalone action AND mixed into every response | Action dropped. Constants live in the util module; opt-in per call via `include_advisory=true` |
| Advisory mix-in | `_fusion_group_guardrails_note()` added ~600 bytes of static text to every response | Opt-in only |
| Tests | 4 (flat fixture only) | 12, including a nested-`UserControls` fixture that reproduces the regex bug |

## New actions on `fusion_comp`

- `group_settings_export(group_name, path)` — `SaveSettings` + parsed published-input summary
- `group_settings_splice_inputs(source_path, template_path, dest_path?)` — pure file op, swaps the `Inputs = ordered() { ... }` block
- `group_settings_load(group_name, settings_path, backup_path?)` — backup-first, undo-wrapped `LoadSettings`
- `bulk_set_expressions(ops)` — batch `SetExpression` with per-op `StartUndo`/`EndUndo` + `comp.Lock`
- `probe_group_published_inputs(group_name, settings_path?)` — live `Input1..InputN` enumeration, optional cross-ref with a `.setting` file

## Test plan

- [x] `python3 -m unittest tests.test_fusion_group_settings -v` — 12/12 pass
- [x] `python3 -m py_compile src/server.py` — clean
- [x] `python3 -m unittest discover tests` — 248 collected; 54 import errors are pre-existing on `main` (this shell's python doesn't have `anyio`), no regressions
- [ ] Live: against a Resolve project with a known `GroupOperator`, run `group_settings_export` → `group_settings_splice_inputs` (using another export as template) → `group_settings_load`, then nudge a published input in Fusion UI and confirm Ctrl+Z reverses to the backup state
- [ ] Live: against a multi-shot timeline, run `bulk_set_expressions` with mixed valid/invalid ops and confirm partial-success result shape + per-op undo

## Files

- `src/utils/fusion_group_settings.py` (new, 323 lines)
- `src/server.py` (+326 lines)
- `tests/test_fusion_group_settings.py` (new, 284 lines)
- `docs/kernels/fusion-composition-kernel.md` (+30 lines)