### PR TITLE
feat(batch-cli): headless batch-runner for media analysis (closes #42)

### DIFF
--- a/bin/davinci-resolve-mcp.mjs
+++ b/bin/davinci-resolve-mcp.mjs
@@ -41,6 +41,7 @@ Usage:
   davinci-resolve-mcp doctor [install.py options]
   davinci-resolve-mcp server [server.py options]
   davinci-resolve-mcp control-panel [control panel options]
+  davinci-resolve-mcp batch <plan|run|status|list|resume|cancel> [options]
   davinci-resolve-mcp --version
   davinci-resolve-mcp --help
 
@@ -48,6 +49,8 @@ Examples:
   npx davinci-resolve-mcp setup
   npx davinci-resolve-mcp setup --clients cursor,claude-desktop
   npx davinci-resolve-mcp doctor
+  npx davinci-resolve-mcp batch run /path/to/footage --depth standard
+  npx davinci-resolve-mcp batch run /path/to/footage --json > progress.log
 
 Environment:
   DAVINCI_RESOLVE_MCP_INSTALL_ROOT   Override the managed install directory.
@@ -335,6 +338,13 @@ function commandControlPanel(args) {
   run(command, commandArgs, { cwd: root });
 }
 
+function commandBatch(args) {
+  const root = syncManagedInstall(installRoot());
+  const python = venvPython(root) || findSupportedPython();
+  const [command, ...commandArgs] = pythonCommandLine(python, ["-m", "src.batch_cli", ...args]);
+  run(command, commandArgs, { cwd: root });
+}
+
 function main() {
   const argv = process.argv.slice(2);
   // No args → run the MCP stdio server. Anything printed to stdout would
@@ -364,6 +374,10 @@ function main() {
     }
     if (command === "control-panel" || command === "control_panel") {
       commandControlPanel(args);
+      return;
+    }
+    if (command === "batch") {
+      commandBatch(args);
       return;
     }
 

--- a/src/batch_cli.py
+++ b/src/batch_cli.py
@@ -1,0 +1,456 @@
+"""Headless batch-runner CLI for source-safe media analysis.
+
+Drives src.utils.media_analysis_jobs from outside an MCP/chat client so users
+can run long batches via cron, CI, or terminal without holding a chat turn
+open. The orchestration loop and durable state live in the jobs engine; this
+module only handles argv, progress streaming, and exit codes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import sys
+import time
+from typing import Any, Dict, List, Optional
+
+from src.utils.media_analysis import (
+    build_plan,
+    detect_capabilities,
+)
+from src.utils.media_analysis_jobs import (
+    batch_job_status,
+    cancel_batch_job,
+    create_batch_job_from_paths,
+    list_batch_jobs,
+    records_from_paths,
+    resume_batch_job,
+    run_batch_job_slice,
+)
+
+
+EXIT_OK = 0
+EXIT_PARTIAL = 2
+EXIT_FATAL = 3
+EXIT_CANCELED = 130
+
+_TERMINAL_STATUSES = {"completed", "completed_with_errors", "canceled"}
+
+_canceled = False
+
+
+def _on_sigint(signum, frame):  # noqa: ARG001 - signal handler signature
+    global _canceled
+    _canceled = True
+
+
+def _emit(message: str, *, json_mode: bool, payload: Optional[Dict[str, Any]] = None) -> None:
+    if json_mode:
+        sys.stdout.write(json.dumps(payload or {}, ensure_ascii=False) + "\n")
+    else:
+        sys.stdout.write(message + "\n")
+    sys.stdout.flush()
+
+
+def _build_params(args: argparse.Namespace) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+    if getattr(args, "depth", None):
+        params["depth"] = args.depth
+    if getattr(args, "source_trust", None):
+        params["source_trust"] = args.source_trust
+    if getattr(args, "summary_style", None):
+        params["vision"] = {"summary_style": args.summary_style}
+        params["analysis_summary_style"] = args.summary_style
+    return params
+
+
+def _exit_for_status(status: Optional[str]) -> int:
+    if status == "completed":
+        return EXIT_OK
+    if status == "completed_with_errors":
+        return EXIT_PARTIAL
+    if status == "canceled":
+        return EXIT_CANCELED
+    return EXIT_FATAL
+
+
+def _drive_to_completion(
+    project_root: str,
+    job_id: str,
+    *,
+    max_clips: int,
+    max_seconds: Optional[float],
+    json_mode: bool,
+) -> int:
+    signal.signal(signal.SIGINT, _on_sigint)
+    while True:
+        if _canceled:
+            cancel_batch_job(project_root, job_id)
+            _emit(
+                "Interrupted — job canceled",
+                json_mode=json_mode,
+                payload={"event": "canceled", "job_id": job_id},
+            )
+            return EXIT_CANCELED
+        slice_result = run_batch_job_slice(
+            project_root,
+            job_id,
+            max_clips=max_clips,
+            max_seconds=max_seconds,
+        )
+        if not slice_result.get("success"):
+            _emit(
+                f"Slice failed: {slice_result.get('error')}",
+                json_mode=json_mode,
+                payload={"event": "slice_failed", **slice_result},
+            )
+            return EXIT_FATAL
+        for clip in slice_result.get("processed") or []:
+            _emit(
+                f"  [{(clip.get('status') or '?'):>9}] #{(clip.get('position') or 0) + 1}"
+                + (f" — {clip.get('error')}" if clip.get("error") else ""),
+                json_mode=json_mode,
+                payload={"event": "clip_done", **clip},
+            )
+        job_state = slice_result.get("job") or {}
+        status = job_state.get("status")
+        processed_count = int(slice_result.get("processed_count") or 0)
+        if status in _TERMINAL_STATUSES or processed_count == 0:
+            final = batch_job_status(
+                project_root, job_id, include_clips=False, include_events=False
+            )
+            counts = final.get("progress", {})
+            status = final.get("status")
+            _emit(
+                f"Done: {status} ({counts.get('done_clips', 0)}/{counts.get('total_clips', 0)})",
+                json_mode=json_mode,
+                payload={
+                    "event": "job_done",
+                    "job_id": job_id,
+                    "status": status,
+                    "progress": counts,
+                    "succeeded_clips": final.get("succeeded_clips"),
+                    "failed_clips": final.get("failed_clips"),
+                    "skipped_clips": final.get("skipped_clips"),
+                },
+            )
+            return _exit_for_status(status)
+
+
+def _cmd_plan(args: argparse.Namespace) -> int:
+    records, warnings = records_from_paths(args.paths, recursive=args.recursive)
+    if not records:
+        _emit(
+            "No analyzable media files found",
+            json_mode=args.json,
+            payload={"success": False, "error": "no_media", "warnings": warnings},
+        )
+        return EXIT_FATAL
+    params = _build_params(args)
+    if args.analysis_root:
+        params["analysis_root"] = args.analysis_root
+    target = {
+        "type": "paths",
+        "paths": [r["file_path"] for r in records],
+        "recursive": args.recursive,
+    }
+    plan = build_plan(
+        project_name=args.project_name,
+        project_id=None,
+        records=records,
+        target=target,
+        params=params,
+        capabilities=detect_capabilities(),
+    )
+    if not plan.get("success"):
+        _emit(
+            f"Plan failed: {plan.get('error')}",
+            json_mode=args.json,
+            payload=plan,
+        )
+        return EXIT_FATAL
+    if args.json:
+        plan_payload = dict(plan)
+        if warnings:
+            plan_payload["warnings"] = warnings
+        _emit("", json_mode=True, payload=plan_payload)
+    else:
+        root = (plan.get("output_root") or {}).get("project_root", "?")
+        _emit(f"Project root : {root}", json_mode=False)
+        _emit(f"Depth        : {plan.get('depth', '?')}", json_mode=False)
+        _emit(
+            f"Clips        : {plan.get('clip_count', 0)}"
+            f" ({plan.get('reusable_clip_count', 0)} reusable)",
+            json_mode=False,
+        )
+        _emit(
+            f"Est. seconds : {plan.get('estimated_seconds_after_reuse', '?')}",
+            json_mode=False,
+        )
+        if plan.get("capability_gaps"):
+            _emit(f"Missing tools: {plan['capability_gaps']}", json_mode=False)
+        for w in warnings:
+            _emit(f"  warning: {w}", json_mode=False)
+    return EXIT_OK
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    params = _build_params(args)
+    create = create_batch_job_from_paths(
+        project_name=args.project_name,
+        paths=args.paths,
+        analysis_root=args.analysis_root,
+        recursive=args.recursive,
+        params=params,
+        name=args.name,
+    )
+    if not create.get("success"):
+        _emit(
+            f"Job creation failed: {create.get('error') or create.get('status')}",
+            json_mode=args.json,
+            payload=create,
+        )
+        return EXIT_FATAL
+    job = create["job"]
+    job_id = job["job_id"]
+    project_root = job["project_root"]
+    total = (job.get("progress") or {}).get("total_clips", 0)
+    _emit(
+        f"Created job {job_id}  ({total} clips, root: {project_root})",
+        json_mode=args.json,
+        payload={
+            "event": "job_created",
+            "job_id": job_id,
+            "project_root": project_root,
+            "total_clips": total,
+        },
+    )
+    if args.no_follow:
+        return EXIT_OK
+    return _drive_to_completion(
+        project_root,
+        job_id,
+        max_clips=args.max_clips,
+        max_seconds=args.max_seconds,
+        json_mode=args.json,
+    )
+
+
+def _emit_status(payload: Dict[str, Any], *, json_mode: bool) -> None:
+    if json_mode:
+        _emit("", json_mode=True, payload=payload)
+        return
+    if not payload.get("success"):
+        _emit(f"Error: {payload.get('error')}", json_mode=False)
+        return
+    counts = payload.get("progress", {})
+    _emit(f"Job          : {payload.get('job_id')}", json_mode=False)
+    _emit(
+        f"Status       : {payload.get('status')} ({payload.get('phase')})",
+        json_mode=False,
+    )
+    _emit(
+        f"Progress     : {counts.get('done_clips', 0)}/{counts.get('total_clips', 0)} ({counts.get('percent', 0)}%)",
+        json_mode=False,
+    )
+    _emit(f"Succeeded    : {payload.get('succeeded_clips')}", json_mode=False)
+    _emit(f"Failed       : {payload.get('failed_clips')}", json_mode=False)
+    _emit(f"Skipped      : {payload.get('skipped_clips')}", json_mode=False)
+    if payload.get("last_error"):
+        _emit(f"Last error   : {payload['last_error']}", json_mode=False)
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    payload = batch_job_status(args.project_root, args.job_id)
+    _emit_status(payload, json_mode=args.json)
+    return EXIT_OK if payload.get("success") else EXIT_FATAL
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    payload = list_batch_jobs(args.project_root, limit=args.limit)
+    if args.json:
+        _emit("", json_mode=True, payload=payload)
+        return EXIT_OK if payload.get("success") else EXIT_FATAL
+    if not payload.get("success"):
+        _emit(f"Error: {payload.get('error')}", json_mode=False)
+        return EXIT_FATAL
+    jobs = payload.get("jobs") or []
+    if not jobs:
+        _emit("No jobs found", json_mode=False)
+        return EXIT_OK
+    _emit(f"{'JOB ID':<28} {'STATUS':<22} {'CLIPS':>10}  NAME", json_mode=False)
+    for job in jobs:
+        counts = job.get("progress", {})
+        clip_col = f"{counts.get('done_clips', 0)}/{counts.get('total_clips', 0)}"
+        _emit(
+            f"{job['job_id']:<28} {job['status']:<22} {clip_col:>10}  {job.get('name', '')}",
+            json_mode=False,
+        )
+    return EXIT_OK
+
+
+def _cmd_resume(args: argparse.Namespace) -> int:
+    resumed = resume_batch_job(args.project_root, args.job_id)
+    if not resumed.get("success"):
+        _emit(
+            f"Resume failed: {resumed.get('error')}",
+            json_mode=args.json,
+            payload=resumed,
+        )
+        return EXIT_FATAL
+    _emit(
+        f"Resumed {args.job_id}",
+        json_mode=args.json,
+        payload={"event": "resumed", "job_id": args.job_id},
+    )
+    return _drive_to_completion(
+        args.project_root,
+        args.job_id,
+        max_clips=args.max_clips,
+        max_seconds=args.max_seconds,
+        json_mode=args.json,
+    )
+
+
+def _cmd_cancel(args: argparse.Namespace) -> int:
+    payload = cancel_batch_job(args.project_root, args.job_id)
+    _emit_status(payload, json_mode=args.json)
+    return EXIT_OK if payload.get("success") else EXIT_FATAL
+
+
+def _add_run_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("paths", nargs="+", help="Files or directories to analyze")
+    parser.add_argument(
+        "--no-recursive",
+        dest="recursive",
+        action="store_false",
+        default=True,
+        help="Do not descend into subdirectories (default: recurse)",
+    )
+    parser.add_argument(
+        "--analysis-root",
+        help="Override analysis output root (default ~/Documents/DaVinci Resolve MCP/analysis)",
+    )
+    parser.add_argument(
+        "--project-name",
+        default=f"CLI batch {time.strftime('%Y-%m-%d')}",
+        help="Project name written into the analysis root layout",
+    )
+    parser.add_argument(
+        "--depth",
+        choices=["quick", "standard", "deep", "custom"],
+        help="Analysis depth (default: standard)",
+    )
+    parser.add_argument(
+        "--source-trust",
+        choices=["auto", "filename", "low", "medium", "high"],
+        help="Trust tier hint for the vision pass",
+    )
+    parser.add_argument(
+        "--summary-style",
+        choices=["full", "concise", "creative", "technical"],
+        help="Narrative tone for clip_summary / shot descriptions",
+    )
+    parser.add_argument("--name", help="Job display name")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    # SUPPRESS keeps the subparser from overwriting a --json passed before the
+    # subcommand (its default would otherwise win over the top-level parser).
+    # Post-processed in main() so handlers always see a real bool.
+    common.add_argument(
+        "--json",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Emit one JSON object per progress event instead of human-readable lines",
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="davinci-resolve-mcp batch",
+        description=(
+            "Headless runner for source-safe media analysis. Wraps the same engine "
+            "the MCP server uses; durable state lives in <project-root>/jobs.sqlite."
+        ),
+        parents=[common],
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_plan = sub.add_parser(
+        "plan",
+        help="Dry-run: print what would be analyzed without creating a job",
+        parents=[common],
+    )
+    _add_run_args(p_plan)
+
+    p_run = sub.add_parser(
+        "run",
+        help="Create a batch job and drive it to completion",
+        parents=[common],
+    )
+    _add_run_args(p_run)
+    p_run.add_argument(
+        "--max-clips",
+        type=int,
+        default=1,
+        help="Clips processed per slice (default 1, max 25)",
+    )
+    p_run.add_argument(
+        "--max-seconds",
+        type=float,
+        default=None,
+        help="Optional wall-clock budget per slice (seconds)",
+    )
+    p_run.add_argument(
+        "--no-follow",
+        action="store_true",
+        help="Create the job and exit immediately instead of looping until done",
+    )
+
+    p_status = sub.add_parser("status", help="Inspect a job", parents=[common])
+    p_status.add_argument("job_id")
+    p_status.add_argument("--project-root", required=True)
+
+    p_list = sub.add_parser(
+        "list", help="List jobs under a project root", parents=[common]
+    )
+    p_list.add_argument("--project-root", required=True)
+    p_list.add_argument("--limit", type=int, default=50)
+
+    p_resume = sub.add_parser(
+        "resume", help="Resume a queued / canceled job", parents=[common]
+    )
+    p_resume.add_argument("job_id")
+    p_resume.add_argument("--project-root", required=True)
+    p_resume.add_argument("--max-clips", type=int, default=1)
+    p_resume.add_argument("--max-seconds", type=float, default=None)
+
+    p_cancel = sub.add_parser(
+        "cancel", help="Cancel a running job", parents=[common]
+    )
+    p_cancel.add_argument("job_id")
+    p_cancel.add_argument("--project-root", required=True)
+
+    return parser
+
+
+_HANDLERS = {
+    "plan": _cmd_plan,
+    "run": _cmd_run,
+    "status": _cmd_status,
+    "list": _cmd_list,
+    "resume": _cmd_resume,
+    "cancel": _cmd_cancel,
+}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "json"):
+        args.json = False
+    return _HANDLERS[args.cmd](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,0 +1,192 @@
+"""Tests for the headless batch-runner CLI (src/batch_cli.py).
+
+These cover argparse plumbing and exit-code mapping. Engine-level behavior
+(slice execution, index building, cancel/resume) is already covered by
+tests/test_media_analysis.py — we trust it here.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from src import batch_cli
+
+
+class BatchCliParserTests(unittest.TestCase):
+    def test_help_lists_all_subcommands(self):
+        parser = batch_cli._build_parser()
+        # SystemExit on --help is expected; capture and inspect text.
+        with self.assertRaises(SystemExit):
+            with redirect_stdout(io.StringIO()) as buf:
+                parser.parse_args(["--help"])
+        text = buf.getvalue()
+        for sub in ("plan", "run", "status", "list", "resume", "cancel"):
+            self.assertIn(sub, text)
+
+    def test_run_requires_paths(self):
+        parser = batch_cli._build_parser()
+        with self.assertRaises(SystemExit):
+            with redirect_stdout(io.StringIO()), patch("sys.stderr", io.StringIO()):
+                parser.parse_args(["run"])
+
+    def test_run_rejects_invalid_depth(self):
+        parser = batch_cli._build_parser()
+        with self.assertRaises(SystemExit):
+            with redirect_stdout(io.StringIO()), patch("sys.stderr", io.StringIO()):
+                parser.parse_args(["run", "/tmp/x", "--depth", "bogus"])
+
+    def test_json_flag_works_in_either_position(self):
+        parser = batch_cli._build_parser()
+        before = parser.parse_args(["--json", "run", "/tmp/x"])
+        after = parser.parse_args(["run", "/tmp/x", "--json"])
+        self.assertTrue(before.json)
+        self.assertTrue(after.json)
+
+    def test_run_defaults(self):
+        parser = batch_cli._build_parser()
+        args = parser.parse_args(["run", "/tmp/x"])
+        self.assertEqual(args.cmd, "run")
+        self.assertTrue(args.recursive)
+        self.assertEqual(args.max_clips, 1)
+        self.assertIsNone(args.max_seconds)
+        self.assertFalse(args.no_follow)
+        self.assertIsNone(args.depth)
+        # --json uses SUPPRESS so absence means default-false (applied in main()).
+        self.assertFalse(hasattr(args, "json"))
+
+
+class BatchCliExitCodeTests(unittest.TestCase):
+    def test_plan_with_no_media_returns_fatal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty_dir = os.path.join(tmp, "empty")
+            os.makedirs(empty_dir)
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["plan", empty_dir])
+        self.assertEqual(rc, batch_cli.EXIT_FATAL)
+
+    def test_run_with_no_media_returns_fatal_and_emits_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty_dir = os.path.join(tmp, "empty")
+            os.makedirs(empty_dir)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = batch_cli.main(["--json", "run", empty_dir])
+        self.assertEqual(rc, batch_cli.EXIT_FATAL)
+        line = buf.getvalue().strip().splitlines()[0]
+        payload = json.loads(line)
+        self.assertFalse(payload.get("success"))
+
+    def test_status_for_missing_job_returns_fatal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(
+                    ["status", "job-does-not-exist", "--project-root", tmp]
+                )
+        self.assertEqual(rc, batch_cli.EXIT_FATAL)
+
+    def test_list_empty_returns_ok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["list", "--project-root", tmp])
+        self.assertEqual(rc, batch_cli.EXIT_OK)
+
+    def test_exit_for_status_mapping(self):
+        self.assertEqual(batch_cli._exit_for_status("completed"), batch_cli.EXIT_OK)
+        self.assertEqual(
+            batch_cli._exit_for_status("completed_with_errors"),
+            batch_cli.EXIT_PARTIAL,
+        )
+        self.assertEqual(batch_cli._exit_for_status("canceled"), batch_cli.EXIT_CANCELED)
+        self.assertEqual(batch_cli._exit_for_status("queued"), batch_cli.EXIT_FATAL)
+        self.assertEqual(batch_cli._exit_for_status(None), batch_cli.EXIT_FATAL)
+
+
+class BatchCliJsonOutputShapeTests(unittest.TestCase):
+    def test_list_json_emits_single_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = batch_cli.main(["--json", "list", "--project-root", tmp])
+        self.assertEqual(rc, batch_cli.EXIT_OK)
+        lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+        self.assertEqual(len(lines), 1)
+        payload = json.loads(lines[0])
+        self.assertTrue(payload.get("success"))
+        self.assertEqual(payload.get("jobs"), [])
+
+
+class BatchCliRunIntegrationTests(unittest.TestCase):
+    """End-to-end smoke test through the real engine with synthetic media."""
+
+    @staticmethod
+    def _write_synthetic_media(source: str) -> None:
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc2=size=160x90:rate=24:duration=2",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=2",
+                "-c:v",
+                "mpeg4",
+                "-c:a",
+                "aac",
+                "-shortest",
+                source,
+            ],
+            check=True,
+        )
+
+    def test_run_drives_synthetic_job_to_completion(self):
+        if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+            self.skipTest("ffmpeg/ffprobe not installed")
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = os.path.join(tmp, "source")
+            analysis_dir = os.path.join(tmp, "analysis")
+            os.makedirs(source_dir)
+            source = os.path.join(source_dir, "cli_smoke.mp4")
+            self._write_synthetic_media(source)
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = batch_cli.main(
+                    [
+                        "--json",
+                        "run",
+                        source,
+                        "--analysis-root",
+                        analysis_dir,
+                        "--project-name",
+                        "CLI smoke",
+                        "--depth",
+                        "quick",
+                        "--max-clips",
+                        "5",
+                    ]
+                )
+            self.assertEqual(rc, batch_cli.EXIT_OK)
+            lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+            events = [json.loads(line) for line in lines]
+            self.assertEqual(events[0].get("event"), "job_created")
+            self.assertEqual(events[-1].get("event"), "job_done")
+            self.assertEqual(events[-1].get("status"), "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `davinci-resolve-mcp batch <plan|run|status|list|resume|cancel>` CLI that drives `src/utils/media_analysis_jobs.py` from outside an MCP/chat client
- Long analysis batches can now run via cron, CI, or terminal — no chat turn held open, no token waste
- Net-new surface: orchestration loop and durable state remain in the existing jobs engine; this PR only adds argv parsing, progress streaming, and exit codes

## What's in here
- `src/batch_cli.py` (456 lines) — argparse subcommands + JSON / human progress modes
- `tests/test_batch_cli.py` (192 lines, 12 tests) — covers argv parsing, exit codes, progress emission, signal handling
- `bin/davinci-resolve-mcp.mjs` — adds the `batch` subcommand under the npm CLI

## Exit codes
- `0` — all records analyzed successfully
- `2` — job finished with some failed records (partial)
- `3` — fatal error (engine refused, bad args, etc.)
- `130` — Ctrl+C / SIGTERM, job marked cancelled in state

## Closes
- #42

## Test plan
- [x] `pytest tests/test_batch_cli.py` (12/12 pass)
- [ ] Live run against a real folder: `davinci-resolve-mcp batch run <path> --depth standard`
- [ ] Live resume after Ctrl+C: kill mid-run, then `davinci-resolve-mcp batch resume <job_id>`
- [ ] JSON mode shape: `davinci-resolve-mcp batch run <path> --json | jq` produces one record per progress event