### PR TITLE
feat(media-analysis): frame-sampling modes with first-run default (#46)

### DIFF
--- a/docs/guides/media-analysis-guide.md
+++ b/docs/guides/media-analysis-guide.md
@@ -93,6 +93,33 @@ FFprobe is required. If missing:
   via host_chat_paths (finalized per clip with commit_vision, ~2-5 minutes per
   file plus host-chat read time)
 
+`depth` controls *which layers run*. How many frames each clip gets for visual
+analysis is a separate axis — the **sampling mode** — because a fixed frame count
+over-samples short clips and under-covers long ones.
+
+### 3b. Frame-sampling mode
+
+Pass `sampling_mode` on any analyze action, or set a standing default in the
+control panel (Preferences → Frame sampling mode). The mode owns frame count and
+thus token cost; `analysis_caps.frames_per_clip` is now a safety ceiling above it,
+not the primary dial.
+
+- **Economy** (`fixed`) — flat N frames (depth-derived, default 8) regardless of
+  clip length. Cheapest and most predictable; good for proxies/triage.
+- **Balanced** (`per_minute`) — `frames = clamp(minutes × frames_per_minute, floor,
+  ceiling)` (defaults 4/min, 3–80). Cost is linear in footage length; content-blind.
+- **Thorough** (`adaptive_capped`, **recommended**) — content-aware: samples shot
+  boundaries, representatives, and flash candidates, bounded to `[floor, ceiling]`
+  (3–80). Best coverage with a bounded cost.
+- **Thorough (uncapped)** (`adaptive`) — content-aware with no per-clip ceiling
+  (up to the absolute 512-frame hard cap). Use only when clips are short or few.
+
+Tunables (`frames_per_minute`, `frame_floor`, `frame_ceiling`) apply to Balanced
+and Thorough. The first time you analyze without a saved default, the tool returns
+a `confirmation_required` response with a `sampling_mode_prompt`; re-run with
+`sampling_mode=<choice>` (which saves it as your default) or pick it in the panel.
+Pass `sampling_mode` explicitly any time for a one-off that doesn't change the default.
+
 ---
 
 ## Analysis Commands

--- a/src/analysis_dashboard.py
+++ b/src/analysis_dashboard.py
@@ -4272,6 +4272,21 @@ HTML = r"""<!doctype html>
             </select>
           </label>
           <label>Default sample frames <input id="prefFrames" type="number" min="0" max="48" value="8"></label>
+          <label>Frame sampling mode
+            <select id="prefSamplingMode" onchange="updateSamplingModeHint()">
+              <option value="ask">ask · choose on first analysis</option>
+              <option value="fixed">Economy · flat frames, cheapest &amp; most predictable</option>
+              <option value="per_minute">Balanced · frames scale with duration (linear cost)</option>
+              <option value="adaptive_capped">Thorough · content-aware, bounded cost (recommended)</option>
+              <option value="adaptive">Thorough (uncapped) · content-aware, up to 512 frames</option>
+            </select>
+          </label>
+          <small class="pref-hint" id="samplingModeHint" style="display:block;margin:-4px 0 8px;opacity:0.75;"></small>
+          <div class="pref-inline-row" style="display:flex;gap:10px;flex-wrap:wrap;">
+            <label>Frames / minute <input id="prefSamplingRate" type="number" min="0.1" step="0.5" value="4" oninput="updateSamplingModeHint()"></label>
+            <label>Frame floor <input id="prefSamplingFloor" type="number" min="1" value="3" oninput="updateSamplingModeHint()"></label>
+            <label>Frame ceiling <input id="prefSamplingCeiling" type="number" min="1" value="80" oninput="updateSamplingModeHint()"></label>
+          </div>
           <label>Persistence
             <select id="prefAnalysisPersistence">
               <option value="session_only">session only</option>
@@ -4755,6 +4770,10 @@ HTML = r"""<!doctype html>
       prefVisionDefault: 'Controls whether visual frame analysis is used by default when an operation supports it.',
       prefTranscriptionDefault: 'Sets the default answer for transcript generation on audio-bearing clips.',
       prefSlateDetectionDefault: 'Controls whether slate detection should run or ask before adding slate-informed context.',
+      prefSamplingMode: 'Chooses how many frames each clip gets for visual analysis: Economy (flat), Balanced (scales with duration), or Thorough (content-aware, bounded). Drives both coverage and token cost.',
+      prefSamplingRate: 'Frames sampled per minute in Balanced mode (also seeds Thorough on short clips).',
+      prefSamplingFloor: 'Minimum frames per clip for duration/content-scaled modes.',
+      prefSamplingCeiling: 'Maximum frames per clip for Balanced and Thorough modes (the Thorough per-clip cap).',
       prefAnalysisPersistence: 'Chooses whether analysis artifacts stay session-only or keep reusable reports and frames.',
       prefAnalysisSummaryStyle: 'Tunes the language of generated summaries for editorial, QC, producer, or full-detail review.',
       prefReportFormat: 'Chooses compact readable reports, full reports, or machine-readable output for downstream agents.',
@@ -9088,6 +9107,12 @@ HTML = r"""<!doctype html>
       setControlValue('prefSourceTrust', media.source_trust || 'auto');
       setControlValue('prefDepth', media.default_depth || 'standard');
       setControlValue('prefFrames', media.default_sample_frames ?? 8);
+      // sampling_mode_default is null when unset → show "ask".
+      setControlValue('prefSamplingMode', media.sampling_mode_default || 'ask');
+      setControlValue('prefSamplingRate', media.sampling_frames_per_minute ?? 4);
+      setControlValue('prefSamplingFloor', media.sampling_frame_floor ?? 3);
+      setControlValue('prefSamplingCeiling', media.sampling_frame_ceiling ?? 80);
+      updateSamplingModeHint();
       setControlValue('prefAnalysisPersistence', media.analysis_persistence);
       const legacySummaryMap = { assistant_editor: 'creative', producer: 'creative', qc: 'technical' };
       const summaryStyle = legacySummaryMap[media.analysis_summary_style] || media.analysis_summary_style || 'concise';
@@ -9182,6 +9207,38 @@ HTML = r"""<!doctype html>
       };
     }
 
+    // Rough per-frame vision cost for the estimate (≈768px frame at typical
+    // tokenization). The engine's pre-call refusal estimates more conservatively.
+    const SAMPLING_TOKENS_PER_FRAME = 450;
+    function _fmtTokens(frames) {
+      const k = (frames * SAMPLING_TOKENS_PER_FRAME) / 1000;
+      return k >= 1 ? `~${k.toFixed(k < 10 ? 1 : 0)}k tokens` : `~${Math.round(k * 1000)} tokens`;
+    }
+    function updateSamplingModeHint() {
+      const hintEl = document.getElementById('samplingModeHint');
+      if (!hintEl) return;
+      const mode = ($('prefSamplingMode') || {}).value || 'ask';
+      const rate = Number(($('prefSamplingRate') || {}).value) || 4;
+      const floor = Number(($('prefSamplingFloor') || {}).value) || 3;
+      const ceil = Number(($('prefSamplingCeiling') || {}).value) || 80;
+      const fixed = Number(($('prefFrames') || {}).value) || 8;
+      let msg = '';
+      if (mode === 'ask') {
+        msg = 'You will be asked to pick a mode the first time you analyze. Recommended: Thorough.';
+      } else if (mode === 'fixed') {
+        msg = `Economy — flat ${fixed} frames per clip regardless of length (${_fmtTokens(fixed)}/clip). Most predictable.`;
+      } else if (mode === 'per_minute') {
+        const oneMin = Math.max(floor, Math.min(ceil, Math.round(rate)));
+        const tenMin = Math.max(floor, Math.min(ceil, Math.round(rate * 10)));
+        msg = `Balanced — ${rate}/min, bounded ${floor}–${ceil}. ~${oneMin}f (${_fmtTokens(oneMin)}) for 1 min · ~${tenMin}f (${_fmtTokens(tenMin)}) for 10 min. Linear cost.`;
+      } else if (mode === 'adaptive_capped') {
+        msg = `Thorough — content-aware (shot boundaries + flashes), bounded ${floor}–${ceil} frames/clip (${_fmtTokens(floor)}–${_fmtTokens(ceil)}). Best coverage, bounded cost.`;
+      } else if (mode === 'adaptive') {
+        msg = `Thorough (uncapped) — content-aware, no per-clip ceiling (up to 512 frames, ${_fmtTokens(512)}). Use only for short/few clips.`;
+      }
+      hintEl.textContent = msg;
+    }
+
     function setupPreferencePayload() {
       let markerColors = {};
       try {
@@ -9197,6 +9254,10 @@ HTML = r"""<!doctype html>
           source_trust: $('prefSourceTrust').value,
           default_depth: $('prefDepth').value,
           default_sample_frames: Number($('prefFrames').value || 8),
+          sampling_mode_default: $('prefSamplingMode').value,
+          sampling_frames_per_minute: Number($('prefSamplingRate').value || 4),
+          sampling_frame_floor: Number($('prefSamplingFloor').value || 3),
+          sampling_frame_ceiling: Number($('prefSamplingCeiling').value || 80),
           analysis_persistence: $('prefAnalysisPersistence').value,
           analysis_summary_style: $('prefAnalysisSummaryStyle').value,
           report_format: $('prefReportFormat').value,
@@ -13299,6 +13360,27 @@ class Handler(BaseHTTPRequestHandler):
                 "cleanup_frames": True,
                 "reuse_project_roots": self.state.related_project_roots(),
             }
+            # Honor the saved frame-sampling mode (or an explicit per-job override)
+            # so batch runs match the user's chosen coverage/cost. Falls back to the
+            # recommended mode when the user hasn't set a default yet (batch jobs
+            # shouldn't block on the first-run prompt).
+            try:
+                from src.server import (
+                    _media_analysis_effective_preferences as _ma_eff_prefs,
+                )
+                from src.utils import media_analysis as _ma_mod
+                _ma_prefs = _ma_eff_prefs()
+                params["sampling_mode"] = (
+                    body.get("sampling_mode")
+                    or _ma_prefs.get("sampling_mode_default")
+                    or _ma_mod.RECOMMENDED_SAMPLING_MODE
+                )
+                params["frames_per_minute"] = body.get("frames_per_minute") or _ma_prefs.get("sampling_frames_per_minute")
+                params["frame_floor"] = body.get("frame_floor") or _ma_prefs.get("sampling_frame_floor")
+                params["frame_ceiling"] = body.get("frame_ceiling") or _ma_prefs.get("sampling_frame_ceiling")
+            except Exception:
+                # Best-effort; the engine still applies its own defaults.
+                pass
             with self.state.lock:
                 created = create_batch_job_from_paths(
                     project_name=self.state.project_name,

--- a/src/server.py
+++ b/src/server.py
@@ -6312,6 +6312,18 @@ _MEDIA_ANALYSIS_DEFAULT_PREFS = {
     "source_trust": "auto",
     "default_depth": "standard",
     "default_sample_frames": 8,
+    # Frame-sampling mode — how many frames a clip gets for visual analysis.
+    # "ask" prompts the user to choose a standing default the first time they
+    # analyze; the choice is then saved here. Canonical modes (see
+    # media_analysis.SAMPLING_MODES): fixed (Economy), per_minute (Balanced),
+    # adaptive_capped (Thorough, recommended), adaptive (Thorough uncapped).
+    "sampling_mode_default": "ask",
+    # Tunables shared by Balanced + Thorough modes. frames_per_minute drives the
+    # Balanced target; frame_floor/frame_ceiling bound every duration/content
+    # scaled mode (the ceiling is also the Thorough per-clip cap).
+    "sampling_frames_per_minute": 4.0,
+    "sampling_frame_floor": 3,
+    "sampling_frame_ceiling": 80,
     "preferred_analysis_root": None,
     "preferred_generated_media_folder": None,
     "default_post_operation_page": "stay_put",
@@ -6580,6 +6592,29 @@ def _media_analysis_effective_preferences() -> Dict[str, Any]:
     except (TypeError, ValueError):
         sample_frames_int = 8
     effective["default_sample_frames"] = max(0, min(48, sample_frames_int))
+    # sampling_mode_default normalizes to a canonical mode, or None when unset /
+    # "ask" (None means "not yet chosen" → first-run prompt fires).
+    effective["sampling_mode_default"] = _normalize_sampling_mode_default(effective.get("sampling_mode_default"))
+
+    def _pos_number(value: Any, fallback: float) -> float:
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            return fallback
+        return f if f > 0 else fallback
+
+    effective["sampling_frames_per_minute"] = _pos_number(
+        effective.get("sampling_frames_per_minute"), _media_analysis_module.DEFAULT_FRAMES_PER_MINUTE
+    )
+    effective["sampling_frame_floor"] = int(_pos_number(
+        effective.get("sampling_frame_floor"), _media_analysis_module.DEFAULT_FRAME_FLOOR
+    ))
+    ceiling = int(_pos_number(
+        effective.get("sampling_frame_ceiling"), _media_analysis_module.DEFAULT_FRAME_CEILING
+    ))
+    if ceiling < effective["sampling_frame_floor"]:
+        ceiling = effective["sampling_frame_floor"]
+    effective["sampling_frame_ceiling"] = ceiling
     effective["default_post_operation_page"] = _normalize_setup_choice(
         effective.get("default_post_operation_page"),
         ["stay_put", "media", "cut", "edit", "fusion", "color", "fairlight", "deliver"],
@@ -6739,6 +6774,148 @@ def _media_analysis_timed_marker_decision(p: Dict[str, Any]) -> Dict[str, Any]:
         "source": source,
         "prompt_required": source == "prompt_required" or choice == "ask",
         "saved_default": saved or (saved_default if saved_default in {"yes", "no"} else None),
+        "preferences_path": _media_analysis_preferences_path(),
+    }
+
+
+def _normalize_sampling_mode_default(value: Any) -> Optional[str]:
+    """Resolve a stored sampling_mode_default to a canonical mode, or None.
+
+    None means "not chosen yet" — covers an unset value and the "ask" sentinel,
+    both of which should trigger the first-run prompt.
+    """
+    if value is None:
+        return None
+    raw = str(value).strip().lower()
+    if raw in {"", "ask", "prompt", "ask_me", "ask_user", "none", "unset", "default"}:
+        return None
+    return _media_analysis_module.normalize_sampling_mode(value, default=None)
+
+
+def _sampling_mode_choice_from_params(p: Dict[str, Any]) -> Optional[str]:
+    """Read an explicit sampling-mode choice from analysis params.
+
+    Returns a canonical mode, the "ask" sentinel, or None when unspecified.
+    """
+    raw = _first_param(
+        p,
+        "sampling_mode",
+        "samplingMode",
+        "frame_sampling_mode",
+        "frameSamplingMode",
+        "analysis_mode",
+        "analysisMode",
+    )
+    if raw is None and isinstance(p.get("sampling"), dict):
+        raw = _first_param(p["sampling"], "mode", "sampling_mode", "samplingMode")
+    if raw is None:
+        return None
+    if str(raw).strip().lower() in {"ask", "prompt", "ask_me", "ask_user"}:
+        return "ask"
+    return _media_analysis_module.normalize_sampling_mode(raw, default=None)
+
+
+def _media_analysis_sampling_mode_prompt() -> Dict[str, Any]:
+    """First-run prompt offering the four sampling modes (Thorough recommended).
+
+    Each option saves the chosen mode as the standing default (save_sampling_default)
+    so the user is only asked once. Pass `sampling_mode` alone, without the save
+    flag, for a one-off run that doesn't change the default.
+    """
+    return {
+        "question": (
+            "How should frames be sampled for visual analysis? This sets your "
+            "default for future runs (pass sampling_mode per-call for a one-off)."
+        ),
+        "default_behavior": "Recommended: Thorough — content-aware coverage with a bounded, predictable cost.",
+        "options": [
+            {
+                "id": "fixed",
+                "label": "Economy",
+                "description": (
+                    "Flat ~8 frames per clip regardless of length. Cheapest and most "
+                    "predictable; good for proxies, triage, or known-short clips."
+                ),
+                "params": {"sampling_mode": "fixed", "save_sampling_default": True},
+            },
+            {
+                "id": "per_minute",
+                "label": "Balanced",
+                "description": (
+                    "Frames scale with duration (~4/min, bounded 3–80). Cost is linear "
+                    "in footage length and easy to predict; content-blind."
+                ),
+                "params": {"sampling_mode": "per_minute", "save_sampling_default": True},
+            },
+            {
+                "id": "adaptive_capped",
+                "label": "Thorough (recommended)",
+                "description": (
+                    "Content-aware: samples shot boundaries, representatives, and flash "
+                    "frames, bounded 3–80 per clip. Best coverage with a bounded cost."
+                ),
+                "params": {"sampling_mode": "adaptive_capped", "save_sampling_default": True},
+            },
+            {
+                "id": "adaptive",
+                "label": "Thorough (uncapped)",
+                "description": (
+                    "Content-aware with no per-clip ceiling (up to 512 frames). Use only "
+                    "when clips are known to be short or few — cost can grow fast."
+                ),
+                "params": {"sampling_mode": "adaptive", "save_sampling_default": True},
+            },
+        ],
+        "recommended": _media_analysis_module.RECOMMENDED_SAMPLING_MODE,
+    }
+
+
+def _media_analysis_sampling_mode_decision(p: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve the frame-sampling mode for an analysis run.
+
+    Resolution order:
+      1. Explicit `sampling_mode` param → one-off (persisted only if save flag set).
+      2. Saved `sampling_mode_default` preference → used silently.
+      3. Otherwise → prompt_required (first run); falls back to the recommended
+         mode so previews/automation still work, but the entry point surfaces the
+         prompt and blocks real execution.
+    """
+    choice = _sampling_mode_choice_from_params(p)
+    save_default = _media_analysis_bool(
+        _first_param(p, "save_sampling_default", "saveSamplingDefault", "set_sampling_default", "setSamplingDefault"),
+        False,
+    )
+    preferences = _read_media_analysis_preferences()
+    explicit_saved = "sampling_mode_default" in preferences
+    saved_default = _media_analysis_effective_preferences().get("sampling_mode_default")
+
+    recommended = _media_analysis_module.RECOMMENDED_SAMPLING_MODE
+    saved = None
+
+    if choice and choice != "ask":
+        mode = choice
+        source = "explicit"
+        if save_default:
+            saved = mode
+            preferences["sampling_mode_default"] = mode
+            preferences["sampling_mode_default_updated_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            _write_media_analysis_preferences(preferences)
+            source = "saved_default"
+    elif choice == "ask":
+        mode = recommended
+        source = "prompt_required"
+    elif saved_default:
+        mode = saved_default
+        source = "saved_default" if explicit_saved else "default"
+    else:
+        mode = recommended
+        source = "prompt_required"
+
+    return {
+        "mode": mode,
+        "source": source,
+        "prompt_required": source == "prompt_required",
+        "saved_default": saved or saved_default,
         "preferences_path": _media_analysis_preferences_path(),
     }
 
@@ -8086,6 +8263,23 @@ def _media_analysis_apply_setup_defaults(action: str, p: Dict[str, Any]) -> Dict
                     )
                     applied["transcription_default"] = transcription_default
 
+    # Frame-sampling mode: resolve from explicit param > saved default > first-run
+    # prompt (recommended fallback). Inject mode + tunables so the analysis engine
+    # picks them up via _resolve_sampling_config; stash the decision so the entry
+    # point can surface the first-run prompt.
+    if action in {"plan", "analyze_file", "analyze_clip", "analyze_bin", "analyze_project", "analyze_timeline", "analyze_sequence", "start_batch_job"}:
+        sampling_decision = _media_analysis_sampling_mode_decision(out)
+        if not _has_any_param(out, "sampling_mode", "samplingMode", "frame_sampling_mode", "frameSamplingMode"):
+            out["sampling_mode"] = sampling_decision["mode"]
+            applied["sampling_mode"] = sampling_decision["mode"]
+        if not _has_any_param(out, "frames_per_minute", "framesPerMinute"):
+            out["frames_per_minute"] = prefs.get("sampling_frames_per_minute")
+        if not _has_any_param(out, "frame_floor", "frameFloor"):
+            out["frame_floor"] = prefs.get("sampling_frame_floor")
+        if not _has_any_param(out, "frame_ceiling", "frameCeiling"):
+            out["frame_ceiling"] = prefs.get("sampling_frame_ceiling")
+        out["_sampling_mode_decision"] = sampling_decision
+
     if action in {"plan", "analyze_file", "analyze_clip", "analyze_bin", "analyze_project", "analyze_timeline", "analyze_sequence", "start_batch_job", "publish_clip_metadata"}:
         if not _has_any_param(
             out,
@@ -9391,7 +9585,9 @@ def _setup_media_analysis_defaults() -> Dict[str, Any]:
             "source_trust": ["auto", "filename", "low", "medium", "high"],
             "default_depth": ["quick", "standard", "deep"],
             "default_post_operation_page": ["stay_put", "media", "cut", "edit", "fusion", "color", "fairlight", "deliver"],
+            "sampling_mode_default": ["ask", "fixed", "per_minute", "adaptive_capped", "adaptive"],
         },
+        "sampling_mode_labels": dict(_media_analysis_module.SAMPLING_MODE_LABELS),
     }
 
 
@@ -9512,6 +9708,24 @@ def _setup_set_media_analysis_defaults(media_defaults: Dict[str, Any], dry_run: 
         "defaultsampleframes": "default_sample_frames",
         "sample_frames": "default_sample_frames",
         "sampleframes": "default_sample_frames",
+        "sampling_mode_default": "sampling_mode_default",
+        "samplingmodedefault": "sampling_mode_default",
+        "sampling_mode": "sampling_mode_default",
+        "samplingmode": "sampling_mode_default",
+        "analysis_mode": "sampling_mode_default",
+        "analysismode": "sampling_mode_default",
+        "sampling_frames_per_minute": "sampling_frames_per_minute",
+        "samplingframesperminute": "sampling_frames_per_minute",
+        "frames_per_minute": "sampling_frames_per_minute",
+        "framesperminute": "sampling_frames_per_minute",
+        "sampling_frame_floor": "sampling_frame_floor",
+        "samplingframefloor": "sampling_frame_floor",
+        "frame_floor": "sampling_frame_floor",
+        "framefloor": "sampling_frame_floor",
+        "sampling_frame_ceiling": "sampling_frame_ceiling",
+        "samplingframeceiling": "sampling_frame_ceiling",
+        "frame_ceiling": "sampling_frame_ceiling",
+        "frameceiling": "sampling_frame_ceiling",
     }
 
     requested: Dict[str, Any] = {}
@@ -9640,6 +9854,37 @@ def _setup_set_media_analysis_defaults(media_defaults: Dict[str, Any], dry_run: 
             except (TypeError, ValueError):
                 return _err("default_sample_frames must be an integer between 0 and 48.")
             set_or_clear(key, raw_value, max(0, min(48, frames_int)))
+        elif key == "sampling_mode_default":
+            # "ask" clears the saved default so the first-run prompt fires again;
+            # otherwise normalize a canonical key or friendly label.
+            if _setup_text_key(raw_value) in {"ask", "prompt", "askme", "askuser"}:
+                next_preferences.pop("sampling_mode_default", None)
+                next_preferences.pop("sampling_mode_default_updated_at", None)
+                updates[key] = {"before": before.get(key), "after": None, "cleared": True}
+            else:
+                normalized = _media_analysis_module.normalize_sampling_mode(raw_value, default=None)
+                if normalized is None:
+                    return _err(
+                        "Unsupported sampling_mode_default. Use ask, fixed/economy, "
+                        "per_minute/balanced, adaptive_capped/thorough, or adaptive."
+                    )
+                set_or_clear(key, raw_value, normalized)
+        elif key == "sampling_frames_per_minute":
+            try:
+                rate = float(raw_value)
+            except (TypeError, ValueError):
+                return _err("sampling_frames_per_minute must be a positive number.")
+            if rate <= 0:
+                return _err("sampling_frames_per_minute must be greater than 0.")
+            set_or_clear(key, raw_value, rate)
+        elif key in {"sampling_frame_floor", "sampling_frame_ceiling"}:
+            try:
+                n = int(raw_value) if not isinstance(raw_value, bool) else 0
+            except (TypeError, ValueError):
+                return _err(f"{key} must be a positive integer.")
+            if n <= 0:
+                return _err(f"{key} must be a positive integer.")
+            set_or_clear(key, raw_value, n)
         elif key == "default_post_operation_page":
             normalized = _normalize_setup_choice(
                 raw_value,
@@ -9797,6 +10042,10 @@ def _setup_clear_defaults(keys: Any, dry_run: bool) -> Dict[str, Any]:
         "metadata_writeback_default": "media_analysis.metadata_writeback_default",
         "ask_before_metadata_publish": "media_analysis.ask_before_metadata_publish",
         "dry_run_first_default": "media_analysis.dry_run_first_default",
+        "sampling_mode_default": "media_analysis.sampling_mode_default",
+        "sampling_frames_per_minute": "media_analysis.sampling_frames_per_minute",
+        "sampling_frame_floor": "media_analysis.sampling_frame_floor",
+        "sampling_frame_ceiling": "media_analysis.sampling_frame_ceiling",
     }
     media_payload: Dict[str, Any] = {}
     if clear_all or "media_analysis" in normalized_keys:
@@ -9899,6 +10148,14 @@ def setup(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
                 "media_analysis.metadata_writeback_default": {"values": [True, False], "storage": _media_analysis_preferences_path()},
                 "media_analysis.ask_before_metadata_publish": {"values": [True, False], "storage": _media_analysis_preferences_path()},
                 "media_analysis.dry_run_first_default": {"values": [True, False], "storage": _media_analysis_preferences_path()},
+                "media_analysis.sampling_mode_default": {
+                    "description": "Frame-sampling mode for visual analysis. 'ask' prompts on first analysis to set a standing default. fixed=Economy (flat frames), per_minute=Balanced (duration-scaled), adaptive_capped=Thorough (content-aware, bounded — recommended), adaptive=Thorough uncapped.",
+                    "values": ["ask", "fixed", "per_minute", "adaptive_capped", "adaptive"],
+                    "storage": _media_analysis_preferences_path(),
+                },
+                "media_analysis.sampling_frames_per_minute": {"description": "Frames per minute for Balanced mode (also seeds Thorough on short clips).", "values": "number > 0 (default 4)", "storage": _media_analysis_preferences_path()},
+                "media_analysis.sampling_frame_floor": {"description": "Minimum frames per clip for duration/content-scaled modes.", "values": "integer > 0 (default 3)", "storage": _media_analysis_preferences_path()},
+                "media_analysis.sampling_frame_ceiling": {"description": "Maximum frames per clip for Balanced + Thorough modes (the Thorough per-clip cap).", "values": "integer > 0 (default 80)", "storage": _media_analysis_preferences_path()},
                 "updates.mode": {
                     "description": "Local MCP update policy.",
                     "values": sorted(_SETUP_UPDATE_MODES),
@@ -13190,6 +13447,31 @@ async def media_analysis(action: str, params: Optional[Dict[str, Any]] = None, c
     model is vision-capable; no sampling/createMessage support required.
     """
     p = _media_analysis_apply_setup_defaults(action, dict(params or {}))
+
+    # First-run frame-sampling prompt: if the user has never chosen a sampling
+    # mode (and didn't pass one this call), ask before spending any vision
+    # tokens. Re-running with sampling_mode=<choice> saves it as the default;
+    # passing sampling_mode explicitly any time is a one-off that skips this.
+    _sampling_decision = p.get("_sampling_mode_decision") if isinstance(p, dict) else None
+    if (
+        isinstance(_sampling_decision, dict)
+        and _sampling_decision.get("prompt_required")
+        and action in {"analyze_clip", "analyze_file", "analyze_bin", "analyze_project", "analyze_sequence", "analyze_timeline", "start_batch_job"}
+    ):
+        return {
+            "success": True,
+            "status": "confirmation_required",
+            "confirmation_required": True,
+            "sampling_mode_prompt": _media_analysis_sampling_mode_prompt(),
+            "recommended_sampling_mode": _media_analysis_module.RECOMMENDED_SAMPLING_MODE,
+            "message": (
+                "Choose a frame-sampling mode for visual analysis. Re-run with "
+                "sampling_mode set to one of fixed/per_minute/adaptive_capped/adaptive "
+                "(the chosen value is saved as your default), or set it in the control "
+                "panel under Analysis Modes. Pass sampling_mode per-call any time for a one-off."
+            ),
+            "preferences_path": _media_analysis_preferences_path(),
+        }
 
     # E2 — capture original action + scope before the dispatch may rewrite
     # `action` (e.g. analyze_clip → plan). Used by _e2_wrap below to attach

--- a/src/utils/analysis_caps.py
+++ b/src/utils/analysis_caps.py
@@ -18,17 +18,26 @@ deferred a "$ cost cap" axis. Token budgets are the unit of currency here.
 
 | Dimension | minimal | standard | generous | unlimited |
 |-----------|--------:|---------:|---------:|----------:|
-| response_chars                | 5,000   | 25,000    | 100,000    | None |
-| vision_tokens_per_clip        | 5,000   | 25,000    | 100,000    | None |
-| frames_per_clip               | 4       | 8         | 24         | None |
-| vision_tokens_per_job         | 50,000  | 250,000   | 1,000,000  | None |
-| vision_tokens_per_day         | 100,000 | 500,000   | 2,000,000  | None |
-| wall_clock_seconds_per_call   | 30      | 90        | 300        | None |
-| max_frame_dim_pixels          | 512     | 768       | 1280       | None |
+| response_chars                | 5,000   | 25,000     | 100,000    | None |
+| vision_tokens_per_clip        | 16,000  | 100,000    | 250,000    | None |
+| frames_per_clip               | 12      | 80         | 200        | None |
+| vision_tokens_per_job         | 60,000  | 1,000,000  | 3,000,000  | None |
+| vision_tokens_per_day         | 150,000 | 2,000,000  | 6,000,000  | None |
+| wall_clock_seconds_per_call   | 30      | 90         | 300        | None |
+| max_frame_dim_pixels          | 512     | 768        | 1280       | None |
 
 `minimal` = preview/triage mode. `standard` = realistic per-project default.
 `generous` = high-fidelity analysis on a few specific clips. `unlimited` = all
 guards off; use only when you're certain about the input size.
+
+NOTE on `frames_per_clip`: this is a *safety ceiling*, not the primary frame
+dial. How many frames a clip actually gets is chosen by the `sampling_mode`
+(Economy/Balanced/Thorough — see media_analysis.SAMPLING_MODES), which is
+duration- and content-aware. `frames_per_clip` only clips the result if the mode
+would exceed it. The standard ceiling (80) matches the default Thorough ceiling
+so the mode is never silently truncated; lower it to hard-cap cost, raise it for
+unusually long/cutty clips. (Before sampling modes existed this defaulted to 8
+and *was* the frame dial — that flat cap is what made long clips under-covered.)
 """
 
 from __future__ import annotations
@@ -74,30 +83,30 @@ CAP_PRESETS: Dict[str, Caps] = {
     PRESET_MINIMAL: Caps(
         preset=PRESET_MINIMAL,
         response_chars=5_000,
-        vision_tokens_per_clip=5_000,
-        frames_per_clip=4,
-        vision_tokens_per_job=50_000,
-        vision_tokens_per_day=100_000,
+        vision_tokens_per_clip=16_000,
+        frames_per_clip=12,
+        vision_tokens_per_job=60_000,
+        vision_tokens_per_day=150_000,
         wall_clock_seconds_per_call=30,
         max_frame_dim_pixels=512,
     ),
     PRESET_STANDARD: Caps(
         preset=PRESET_STANDARD,
         response_chars=25_000,
-        vision_tokens_per_clip=25_000,
-        frames_per_clip=8,
-        vision_tokens_per_job=250_000,
-        vision_tokens_per_day=500_000,
+        vision_tokens_per_clip=100_000,
+        frames_per_clip=80,
+        vision_tokens_per_job=1_000_000,
+        vision_tokens_per_day=2_000_000,
         wall_clock_seconds_per_call=90,
         max_frame_dim_pixels=768,
     ),
     PRESET_GENEROUS: Caps(
         preset=PRESET_GENEROUS,
         response_chars=100_000,
-        vision_tokens_per_clip=100_000,
-        frames_per_clip=24,
-        vision_tokens_per_job=1_000_000,
-        vision_tokens_per_day=2_000_000,
+        vision_tokens_per_clip=250_000,
+        frames_per_clip=200,
+        vision_tokens_per_job=3_000_000,
+        vision_tokens_per_day=6_000_000,
         wall_clock_seconds_per_call=300,
         max_frame_dim_pixels=1280,
     ),

--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -624,6 +624,103 @@ FRAME_CAPS = {
 }
 HARD_FRAME_CAP = 512
 
+# ── Frame-sampling modes ─────────────────────────────────────────────────────
+# How many frames a clip gets is governed by a `sampling_mode`. `depth` still
+# governs *which* analysis layers run; the mode governs frame coverage + cost.
+#
+#   fixed           "Economy"            — flat N frames (depth-derived / max_analysis_frames),
+#                                          independent of clip length. Most predictable cost.
+#   per_minute      "Balanced"           — N = clamp(minutes * frames_per_minute, floor, ceiling).
+#                                          Cost is linear in footage length; content-blind.
+#   adaptive_capped "Thorough"           — content-aware (per-shot boundaries + flashes), bounded
+#                                          by [floor, frame_ceiling]. Best coverage, bounded cost.
+#   adaptive        "Thorough (uncapped)" — content-aware, bounded only by the absolute HARD_FRAME_CAP.
+#                                          Use only when clips are known to be short/few.
+#
+# The math-layer default is `adaptive` so any caller that doesn't thread a
+# sampling config keeps the legacy demand-driven behaviour. The *product*
+# default (what new analysis runs use) is resolved at the preference layer in
+# server.py and recommends "adaptive_capped" (Thorough).
+SAMPLING_MODES = {"fixed", "per_minute", "adaptive", "adaptive_capped"}
+DEFAULT_SAMPLING_MODE = "adaptive"
+RECOMMENDED_SAMPLING_MODE = "adaptive_capped"
+DEFAULT_FRAMES_PER_MINUTE = 4.0
+DEFAULT_FRAME_FLOOR = 3
+DEFAULT_FRAME_CEILING = 80
+
+# Thoroughness ranking — used for cache reuse: a richer prior report satisfies a
+# cheaper mode, but switching *up* forces a re-sample.
+SAMPLING_MODE_RANK = {"fixed": 0, "per_minute": 1, "adaptive_capped": 2, "adaptive": 3}
+
+# User-facing labels (prompt + control panel).
+SAMPLING_MODE_LABELS = {
+    "fixed": "Economy",
+    "per_minute": "Balanced",
+    "adaptive_capped": "Thorough",
+    "adaptive": "Thorough (uncapped)",
+}
+
+_SAMPLING_MODE_ALIASES = {
+    "economy": "fixed", "fixed": "fixed", "flat": "fixed",
+    "balanced": "per_minute", "per_minute": "per_minute", "perminute": "per_minute",
+    "per-minute": "per_minute", "duration": "per_minute",
+    "thorough": "adaptive_capped", "adaptive_capped": "adaptive_capped",
+    "adaptive-capped": "adaptive_capped", "capped": "adaptive_capped",
+    "thorough_uncapped": "adaptive", "thorough (uncapped)": "adaptive",
+    "adaptive": "adaptive", "uncapped": "adaptive",
+}
+
+
+def normalize_sampling_mode(value: Any, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a user-supplied mode string (label or key) to a canonical mode."""
+    raw = str(value or "").strip().lower().replace("_", "_")
+    return _SAMPLING_MODE_ALIASES.get(raw, default)
+
+
+def _resolve_sampling_config(params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Read sampling mode + tunables from analysis params, applying defaults."""
+    params = params or {}
+
+    def _first(*keys: str) -> Any:
+        for key in keys:
+            if key in params and params[key] is not None:
+                return params[key]
+        return None
+
+    mode = normalize_sampling_mode(
+        _first("sampling_mode", "samplingMode"), default=DEFAULT_SAMPLING_MODE
+    ) or DEFAULT_SAMPLING_MODE
+
+    def _pos_float(value: Any, fallback: float) -> float:
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            return fallback
+        return f if f > 0 else fallback
+
+    rate = _pos_float(_first("frames_per_minute", "framesPerMinute"), DEFAULT_FRAMES_PER_MINUTE)
+    floor = int(_pos_float(_first("frame_floor", "frameFloor"), DEFAULT_FRAME_FLOOR))
+    ceiling = int(_pos_float(_first("frame_ceiling", "frameCeiling"), DEFAULT_FRAME_CEILING))
+    if ceiling < floor:
+        ceiling = floor
+    return {
+        "mode": mode,
+        "frames_per_minute": rate,
+        "frame_floor": floor,
+        "frame_ceiling": ceiling,
+    }
+
+
+def _clamp_int(value: Any, low: int, high: int) -> int:
+    if high < low:
+        high = low
+    v = int(value)
+    if v < low:
+        return low
+    if v > high:
+        return high
+    return v
+
 
 def slugify(value: Any, fallback: str = "untitled") -> str:
     raw = str(value or "").strip().lower()
@@ -1441,13 +1538,14 @@ def analysis_request_signature(
     depth: str,
     options: Dict[str, Any],
     frame_count: int,
+    sampling: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Return the cache signature for a requested analysis profile."""
     transcription = options.get("transcription") or {}
     vision = options.get("vision") or {}
     marker_plan = options.get("marker_plan") or {}
     vision_prompt = vision.get("prompt") or DEFAULT_VISION_ANALYSIS_PROMPT
-    return {
+    signature = {
         "analysis_version": ANALYSIS_VERSION,
         "depth": depth,
         "analysis_keyframe_budget": int(frame_count or 0),
@@ -1506,6 +1604,16 @@ def analysis_request_signature(
             },
         }),
     }
+    # Recorded outside signature_hash so it doesn't bust pre-existing caches;
+    # mode changes are reconciled by thoroughness rank in _report_cache_state.
+    if sampling:
+        signature["analysis_sampling"] = {
+            "mode": sampling.get("mode"),
+            "frames_per_minute": sampling.get("frames_per_minute"),
+            "frame_floor": sampling.get("frame_floor"),
+            "frame_ceiling": sampling.get("frame_ceiling"),
+        }
+    return signature
 
 
 def _timestamp_from_analyzed_at(value: Any) -> Optional[float]:
@@ -1659,6 +1767,7 @@ def build_plan(
     }
     gaps = _required_capability_gaps(depth, options, caps)
     frame_count = _bounded_frame_count(depth, params.get("max_analysis_frames"))
+    sampling_config = _resolve_sampling_config(params)
     transcription_enabled = _coerce_bool((options.get("transcription") or {}).get("enabled"), default=DEFAULT_TRANSCRIPTION_ENABLED)
     notes = [
         "Plans describe analysis before execution.",
@@ -1721,11 +1830,12 @@ def build_plan(
     clip_plans = []
     for record in records:
         artifacts = _artifact_paths(root["project_root"], record, depth, options)
-        request_signature = analysis_request_signature(record, depth, options, frame_count)
+        request_signature = analysis_request_signature(record, depth, options, frame_count, sampling=sampling_config)
         existing: Optional[Dict[str, Any]] = None
         clip_plan = {
             "record": record,
             "analysis_keyframe_budget": frame_count,
+            "sampling": sampling_config,
             "analysis_signature": request_signature,
             "cache_status": "not_checked",
             "artifacts": artifacts,
@@ -1853,6 +1963,8 @@ def build_plan(
         "estimated_seconds": per_clip_seconds * len(records),
         "estimated_seconds_after_reuse": per_clip_seconds * max(0, len(records) - reusable_count),
         "analysis_keyframe_budget_per_clip": frame_count,
+        "sampling": sampling_config,
+        "sampling_mode": sampling_config.get("mode"),
         "reuse_existing": reuse_existing,
         "force_refresh": force_refresh,
         "reuse_policy": reuse_policy,
@@ -2414,24 +2526,19 @@ def _cut_boundary_analysis(
     }
 
 
-def _compute_demand_driven_budget(
-    requested_budget: int,
-    cut_analysis: Optional[Dict[str, Any]],
+def _demand_frame_count(
+    cut_analysis: Dict[str, Any],
     duration_seconds: Optional[float],
 ) -> int:
-    """Compute the effective frame-sampling budget driven by analysis demand.
+    """Frames the content *demands* so vision can populate the per-shot schema.
 
-    Demand sources (so vision can populate the V2 per-shot schema):
+    Demand sources:
       - Per shot: 1 representative (midpoint) + 2 boundary frames + duration-scaled extras
         (+1 for shots >5s, +1 for shots >15s, +1 per additional 15s beyond 30s)
       - Per flash_candidate: 1 mid-frame for vision adjudication (preserve all)
       - Per cut_point: a small buffer for cuts not covered by shot boundaries
-
-    Safety ceiling: HARD_FRAME_CAP capped by duration so a 10s clip cannot request 500 frames.
+      - Clip-level: first_usable, last_usable, midpoint
     """
-    if not isinstance(cut_analysis, dict):
-        return min(max(int(requested_budget or 0), 0), HARD_FRAME_CAP)
-
     per_shot_demand = 0
     for shot in cut_analysis.get("shot_ranges") or []:
         if not isinstance(shot, dict):
@@ -2458,13 +2565,84 @@ def _compute_demand_driven_budget(
     # Clip-level frames (first_usable, last_usable, midpoint)
     clip_buffer = 4
 
-    demand = per_shot_demand + flash_count + cut_buffer + clip_buffer
+    return per_shot_demand + flash_count + cut_buffer + clip_buffer
 
-    # Duration-scaled safety ceiling: clips can't request hundreds of frames per second.
-    # Floor at 64 so short clips still have headroom; ceiling at HARD_FRAME_CAP.
-    duration_cap = max(64, min(HARD_FRAME_CAP, int((duration_seconds or 0) * 2)))
 
-    return min(max(int(requested_budget or 0), demand), duration_cap)
+def _compute_demand_driven_budget(
+    requested_budget: int,
+    cut_analysis: Optional[Dict[str, Any]],
+    duration_seconds: Optional[float],
+    sampling: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Resolve the effective frame-sampling budget for the active sampling mode.
+
+    Modes (see SAMPLING_MODES):
+      - fixed:           flat `requested_budget`, duration-independent.
+      - per_minute:      clamp(minutes * frames_per_minute, floor, ceiling); content-blind.
+      - adaptive_capped: content demand (see _demand_frame_count), clamped to [floor, ceiling].
+      - adaptive:        content demand, clamped only by a generous duration-scaled HARD_FRAME_CAP
+                         (legacy behaviour; the default when no sampling config is threaded).
+
+    `requested_budget` (depth-derived / max_analysis_frames) acts as a floor for the
+    adaptive modes so an explicit request is never undercut.
+    """
+    sampling = sampling or {}
+    mode = normalize_sampling_mode(sampling.get("mode"), default=DEFAULT_SAMPLING_MODE) or DEFAULT_SAMPLING_MODE
+    rate = sampling.get("frames_per_minute") or DEFAULT_FRAMES_PER_MINUTE
+    floor = int(sampling.get("frame_floor") or DEFAULT_FRAME_FLOOR)
+    ceiling = int(sampling.get("frame_ceiling") or DEFAULT_FRAME_CEILING)
+    if ceiling < floor:
+        ceiling = floor
+    requested = max(int(requested_budget or 0), 0)
+    minutes = max(0.0, float(duration_seconds or 0) / 60.0)
+    per_minute_count = int(round(minutes * float(rate)))
+
+    if mode == "fixed":
+        return min(requested, HARD_FRAME_CAP)
+
+    if mode == "per_minute":
+        return _clamp_int(per_minute_count, floor, min(ceiling, HARD_FRAME_CAP))
+
+    # Adaptive modes need shot/cut analysis. Without it, fall back to a duration
+    # estimate (adaptive_capped) or the legacy requested-only budget (adaptive).
+    if not isinstance(cut_analysis, dict):
+        if mode == "adaptive_capped":
+            return _clamp_int(max(requested, per_minute_count), floor, min(ceiling, HARD_FRAME_CAP))
+        return min(max(requested, 0), HARD_FRAME_CAP)
+
+    demand = _demand_frame_count(cut_analysis, duration_seconds)
+    target = max(requested, demand, floor)
+
+    if mode == "adaptive_capped":
+        return _clamp_int(target, floor, min(ceiling, HARD_FRAME_CAP))
+
+    # adaptive (uncapped): only the absolute hard cap, scaled by duration so a
+    # 10s clip cannot request 500 frames. Floor at 64 for short-clip headroom.
+    duration_cap = max(64, min(HARD_FRAME_CAP, int(float(duration_seconds or 0) * 2)))
+    return _clamp_int(target, floor, duration_cap)
+
+
+def _even_interval_samples(
+    duration: float,
+    count: int,
+    frame_step: float,
+) -> List[Dict[str, Any]]:
+    """Content-blind evenly-spaced samples (Economy / Balanced modes).
+
+    Returns exactly `count` frames at the midpoints of `count` equal slices of
+    [0, duration], so cost is a clean function of `count` and never inflated by
+    shot/cut demand. Used when the user has chosen a predictable, content-blind mode.
+    """
+    if count <= 0 or duration <= 0:
+        return []
+    out: List[Dict[str, Any]] = []
+    for i in range(count):
+        t = duration * (i + 0.5) / count
+        out.append({
+            "time_seconds": _clamp_sample_time(float(t), duration),
+            "selection_reason": "interval",
+        })
+    return out
 
 
 def _sample_times(
@@ -2474,21 +2652,25 @@ def _sample_times(
     *,
     fps: Optional[float] = None,
     cut_analysis: Optional[Dict[str, Any]] = None,
+    sampling: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
-    """Two-pass frame allocation.
+    """Frame allocation. Content-blind for Economy/Balanced; demand-driven otherwise.
 
-    Pass 1 (reservations, always allocated — demand-driven, not budget-bounded):
-      - Per shot: shot_representative (midpoint), shot_start, shot_end boundaries,
-        duration-scaled progress samples (+1 for shots >5s, +1 for shots >15s,
-        +1 per 15s beyond 30s).
-      - Per flash_candidate: mid-frame for vision adjudication.
+    Economy (fixed) / Balanced (per_minute): exactly `budget` evenly-spaced frames
+    (see _even_interval_samples) — predictable cost, ignores shot structure.
 
-    Pass 2 (priority fill, consumes remaining budget):
-      - cut_before/cut_after pairs (for cuts not covered by shot boundaries)
-      - first_usable, last_usable, scene_change, midpoint, interval fillers
+    Thorough (adaptive / adaptive_capped) — two-pass demand-driven allocation:
+      Pass 1 (reservations, always allocated — demand-driven, not budget-bounded):
+        - Per shot: shot_representative (midpoint), shot_start, shot_end boundaries,
+          duration-scaled progress samples (+1 for shots >5s, +1 for shots >15s,
+          +1 per 15s beyond 30s).
+        - Per flash_candidate: mid-frame for vision adjudication.
+      Pass 2 (priority fill, consumes remaining budget):
+        - cut_before/cut_after pairs (for cuts not covered by shot boundaries)
+        - first_usable, last_usable, scene_change, midpoint, interval fillers
 
-    The caller passes `budget` as the soft target. Reservations always land
-    (demand-driven); priority fill is what `budget` constrains.
+      The caller passes `budget` as the soft target. Reservations always land
+      (demand-driven); priority fill is what `budget` constrains.
 
     Returns a time-sorted list of sample candidates.
     """
@@ -2497,6 +2679,12 @@ def _sample_times(
     duration = duration or 0
     cut_analysis = cut_analysis if isinstance(cut_analysis, dict) else {}
     frame_step = _frame_step_seconds(fps)
+
+    # Content-blind modes: even-interval sampling of exactly `budget` frames so
+    # cost stays predictable and is not inflated by per-shot reservations.
+    mode = normalize_sampling_mode((sampling or {}).get("mode"), default=DEFAULT_SAMPLING_MODE) or DEFAULT_SAMPLING_MODE
+    if mode in {"fixed", "per_minute"}:
+        return _even_interval_samples(duration, budget, frame_step)
 
     # ===================== Pass 1: Reservations =====================
     reserved: List[Dict[str, Any]] = []
@@ -2729,6 +2917,7 @@ def _motion_and_keyframes(
     fps: Optional[float] = None,
     cut_analysis: Optional[Dict[str, Any]] = None,
     write_frames: bool = True,
+    sampling: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     sampled = []
     previous_raw = None
@@ -2736,8 +2925,8 @@ def _motion_and_keyframes(
     if isinstance(cut_analysis, dict):
         required_boundary_frames += len(cut_analysis.get("cut_points") or []) * 2
         required_boundary_frames += len(cut_analysis.get("flash_frame_candidates") or [])
-    effective_budget = _compute_demand_driven_budget(budget, cut_analysis, duration)
-    times = _sample_times(duration, scene_items, effective_budget, fps=fps, cut_analysis=cut_analysis)
+    effective_budget = _compute_demand_driven_budget(budget, cut_analysis, duration, sampling=sampling)
+    times = _sample_times(duration, scene_items, effective_budget, fps=fps, cut_analysis=cut_analysis, sampling=sampling)
     frames_dir = artifacts.get("frames_dir")
     for index, sample in enumerate(times, 1):
         time_seconds = float(sample.get("time_seconds") or 0.0)
@@ -2970,6 +3159,15 @@ def _report_cache_state(
     request_budget = int(request_signature.get("analysis_keyframe_budget") or 0)
     if report_budget < request_budget:
         issues.append("analysis_keyframe_budget_lower_than_requested")
+
+    # Sampling-mode reconciliation: a prior report sampled under a less-thorough
+    # mode can't satisfy a request for a more-thorough one. The reverse (richer
+    # report, cheaper request) is reused as a free upgrade.
+    report_mode = (report_signature.get("analysis_sampling") or {}).get("mode")
+    request_mode = (request_signature.get("analysis_sampling") or {}).get("mode")
+    if request_mode and report_mode and request_mode != report_mode:
+        if SAMPLING_MODE_RANK.get(request_mode, 0) > SAMPLING_MODE_RANK.get(report_mode, 0):
+            issues.append("sampling_mode_increased")
 
     report_layers = report_signature.get("layers") or {}
     request_layers = request_signature.get("layers") or {}
@@ -4747,6 +4945,7 @@ async def execute_plan_async(
                 fps=fps,
                 cut_analysis=readthrough.get("cut_analysis"),
                 write_frames=keep_frame_artifacts_for_vision or not _coerce_bool(params.get("cleanup_frames"), default=False),
+                sampling=clip_plan.get("sampling"),
             )
             if artifacts.get("motion_json"):
                 _write_json(artifacts["motion_json"], motion)

--- a/tests/test_analysis_caps.py
+++ b/tests/test_analysis_caps.py
@@ -37,7 +37,7 @@ class PresetResolution(unittest.TestCase):
         self.assertEqual(caps.vision_tokens_per_clip, 12345)
         self.assertEqual(caps.max_frame_dim_pixels, 256)
         # Other fields untouched.
-        self.assertEqual(caps.frames_per_clip, 8)
+        self.assertEqual(caps.frames_per_clip, 80)
 
     def test_unlimited_string_override_lifts_cap(self) -> None:
         caps = analysis_caps.resolve_caps(
@@ -97,10 +97,10 @@ class BudgetEnforcement(unittest.TestCase):
 
     def test_per_clip_cap_blocks_when_exceeded(self) -> None:
         caps = analysis_caps.resolve_caps(analysis_caps.PRESET_MINIMAL)
-        # minimal.vision_tokens_per_clip = 5000.
+        # minimal.vision_tokens_per_clip = 16000.
         analysis_caps.record_usage(
             project_root=self.project_root, scope=analysis_caps.SCOPE_CLIP,
-            scope_key="c1", vision_tokens=4500,
+            scope_key="c1", vision_tokens=15_500,
         )
         # Need 1000 more, only 500 left.
         decision = analysis_caps.check_budget(
@@ -113,13 +113,13 @@ class BudgetEnforcement(unittest.TestCase):
 
     def test_per_day_cap_blocks_when_exceeded(self) -> None:
         caps = analysis_caps.resolve_caps(analysis_caps.PRESET_MINIMAL)
-        # minimal.vision_tokens_per_day = 100_000. Spend 99k under DAY scope.
+        # minimal.vision_tokens_per_day = 150_000. Spend 149k under DAY scope.
         analysis_caps.record_usage(
             project_root=self.project_root, scope=analysis_caps.SCOPE_DAY,
-            scope_key=None, vision_tokens=99_000,
+            scope_key=None, vision_tokens=149_000,
         )
-        # Try to spend 2k — would push to 101k (over day). Pass no clip_id so the
-        # check doesn't trip the smaller clip cap (5k) first.
+        # Try to spend 2k — would push to 151k (over day). Pass no clip_id so the
+        # check doesn't trip the smaller clip cap first.
         decision = analysis_caps.check_budget(
             project_root=self.project_root, caps=caps,
             estimated_vision_tokens=2_000,
@@ -144,12 +144,12 @@ class BudgetEnforcement(unittest.TestCase):
         caps = analysis_caps.resolve_caps(analysis_caps.PRESET_MINIMAL)
         analysis_caps.record_usage(
             project_root=self.project_root, scope=analysis_caps.SCOPE_DAY,
-            scope_key=None, vision_tokens=50_000,
+            scope_key=None, vision_tokens=75_000,
         )
         rollup = analysis_caps.get_usage_rollup(
             project_root=self.project_root, caps=caps,
         )
-        # 50000 / 100000 = 50%
+        # 75000 / 150000 = 50% (minimal.vision_tokens_per_day = 150_000)
         self.assertAlmostEqual(rollup["percent_consumed"]["day"], 50.0)
 
 

--- a/tests/test_caps_integration.py
+++ b/tests/test_caps_integration.py
@@ -46,10 +46,10 @@ class PreCallRefusal(unittest.TestCase):
         self.assertIsNone(result, msg=f"unexpected refusal: {result}")
 
     def test_pre_call_check_refuses_when_over_clip_cap(self) -> None:
-        # minimal preset = 5_000 tokens per clip; record 4500 then ask 1000.
+        # minimal preset = 16_000 tokens per clip; record 15500 then ask 1000.
         analysis_caps.record_usage(
             project_root=self.project_root, scope=analysis_caps.SCOPE_CLIP,
-            scope_key="c1", vision_tokens=4500,
+            scope_key="c1", vision_tokens=15_500,
         )
         result = media_analysis._check_caps_pre_call(
             project_root=self.project_root,

--- a/tests/test_sampling_modes.py
+++ b/tests/test_sampling_modes.py
@@ -1,0 +1,293 @@
+"""Unit tests for frame-sampling modes + the first-run "ask" preference flow.
+
+Covers:
+  - media_analysis._resolve_sampling_config / normalize_sampling_mode
+  - media_analysis._compute_demand_driven_budget across all four modes
+  - media_analysis._report_cache_state sampling-mode reuse rank
+  - server-side sampling-mode decision (explicit / saved / first-run prompt)
+  - server-side preference setter validation + effective-preferences normalization
+  - media_analysis entry-point first-run confirmation short-circuit
+"""
+
+import asyncio
+import os
+import tempfile
+import unittest
+
+from src.utils import media_analysis as m
+from src import server as srv
+
+
+def _ca(shots, *, flashes=0, cuts=0):
+    """Build a synthetic cut_analysis with `shots` 10s shots."""
+    return {
+        "shot_ranges": [
+            {"index": i, "start": i * 10.0, "end": i * 10.0 + 10.0} for i in range(shots)
+        ],
+        "flash_frame_candidates": [{} for _ in range(flashes)],
+        "cut_points": [{} for _ in range(cuts)],
+    }
+
+
+class NormalizeAndResolve(unittest.TestCase):
+    def test_aliases_map_to_canonical(self):
+        self.assertEqual(m.normalize_sampling_mode("Economy"), "fixed")
+        self.assertEqual(m.normalize_sampling_mode("balanced"), "per_minute")
+        self.assertEqual(m.normalize_sampling_mode("per-minute"), "per_minute")
+        self.assertEqual(m.normalize_sampling_mode("Thorough"), "adaptive_capped")
+        self.assertEqual(m.normalize_sampling_mode("thorough (uncapped)"), "adaptive")
+        self.assertEqual(m.normalize_sampling_mode("adaptive"), "adaptive")
+
+    def test_unknown_returns_default(self):
+        self.assertIsNone(m.normalize_sampling_mode("banana"))
+        self.assertEqual(m.normalize_sampling_mode("banana", default="fixed"), "fixed")
+
+    def test_resolve_config_defaults(self):
+        cfg = m._resolve_sampling_config(None)
+        self.assertEqual(cfg["mode"], m.DEFAULT_SAMPLING_MODE)
+        self.assertEqual(cfg["frames_per_minute"], m.DEFAULT_FRAMES_PER_MINUTE)
+        self.assertEqual(cfg["frame_floor"], m.DEFAULT_FRAME_FLOOR)
+        self.assertEqual(cfg["frame_ceiling"], m.DEFAULT_FRAME_CEILING)
+
+    def test_resolve_config_reads_params_and_aliases(self):
+        cfg = m._resolve_sampling_config(
+            {"samplingMode": "Thorough", "framesPerMinute": 6, "frameFloor": 5, "frameCeiling": 40}
+        )
+        self.assertEqual(cfg["mode"], "adaptive_capped")
+        self.assertEqual(cfg["frames_per_minute"], 6.0)
+        self.assertEqual(cfg["frame_floor"], 5)
+        self.assertEqual(cfg["frame_ceiling"], 40)
+
+    def test_resolve_config_ceiling_floored(self):
+        cfg = m._resolve_sampling_config({"frame_floor": 50, "frame_ceiling": 10})
+        self.assertGreaterEqual(cfg["frame_ceiling"], cfg["frame_floor"])
+
+    def test_resolve_config_rejects_nonpositive(self):
+        cfg = m._resolve_sampling_config({"frames_per_minute": 0, "frame_floor": -3})
+        self.assertEqual(cfg["frames_per_minute"], m.DEFAULT_FRAMES_PER_MINUTE)
+        self.assertEqual(cfg["frame_floor"], m.DEFAULT_FRAME_FLOOR)
+
+
+class BudgetByMode(unittest.TestCase):
+    def _budget(self, mode, requested, ca, dur, **over):
+        cfg = m._resolve_sampling_config({"sampling_mode": mode, **over})
+        return m._compute_demand_driven_budget(requested, ca, dur, sampling=cfg)
+
+    def test_fixed_is_duration_independent(self):
+        ca = _ca(6, flashes=2, cuts=5)
+        self.assertEqual(self._budget("fixed", 8, ca, 60.0), 8)
+        self.assertEqual(self._budget("fixed", 8, ca, 3600.0), 8)
+        self.assertEqual(self._budget("fixed", 24, ca, 15.0), 24)
+
+    def test_per_minute_scales_linearly_and_clamps(self):
+        # 1 min @ 4/min = 4; 10 min = 40; 30 min = 80 (ceiling); 5s -> floor.
+        self.assertEqual(self._budget("per_minute", 8, _ca(1), 60.0), 4)
+        self.assertEqual(self._budget("per_minute", 8, _ca(1), 600.0), 40)
+        self.assertEqual(self._budget("per_minute", 8, _ca(1), 1800.0), 80)
+        self.assertEqual(self._budget("per_minute", 8, _ca(1), 5.0), m.DEFAULT_FRAME_FLOOR)
+
+    def test_adaptive_capped_follows_demand_bounded_by_ceiling(self):
+        ca = _ca(6, flashes=2, cuts=5)
+        demand = m._demand_frame_count(ca, 60.0)
+        got = self._budget("adaptive_capped", 8, ca, 60.0)
+        self.assertEqual(got, min(demand, m.DEFAULT_FRAME_CEILING))
+        # A heavy clip is clamped to the ceiling.
+        heavy = _ca(90, flashes=10, cuts=89)
+        self.assertEqual(self._budget("adaptive_capped", 8, heavy, 1800.0), m.DEFAULT_FRAME_CEILING)
+
+    def test_adaptive_uncapped_exceeds_ceiling(self):
+        heavy = _ca(90, flashes=10, cuts=89)
+        got = self._budget("adaptive", 8, heavy, 1800.0)
+        self.assertGreater(got, m.DEFAULT_FRAME_CEILING)
+        self.assertLessEqual(got, m.HARD_FRAME_CAP)
+
+    def test_floor_applies_to_adaptive_modes(self):
+        tiny = _ca(1)
+        self.assertGreaterEqual(self._budget("adaptive_capped", 1, tiny, 5.0), m.DEFAULT_FRAME_FLOOR)
+
+    def test_legacy_default_without_config(self):
+        # No sampling config → legacy demand-driven (adaptive) behaviour.
+        ca = _ca(6, flashes=2, cuts=5)
+        legacy = m._compute_demand_driven_budget(8, ca, 60.0)
+        adaptive = self._budget("adaptive", 8, ca, 60.0)
+        self.assertEqual(legacy, adaptive)
+
+    def test_no_cut_analysis_fixed_and_adaptive(self):
+        self.assertEqual(
+            m._compute_demand_driven_budget(8, None, 60.0, sampling=m._resolve_sampling_config({"sampling_mode": "fixed"})),
+            8,
+        )
+        # legacy adaptive with no cut analysis falls back to requested.
+        self.assertEqual(m._compute_demand_driven_budget(8, None, 60.0), 8)
+
+
+class SampleTimesByMode(unittest.TestCase):
+    """Economy/Balanced must be content-blind (exactly `budget` even-interval
+    frames); Thorough must be demand-driven (covers shot structure). Regression
+    guard for the live-test finding that reservations were overriding the budget
+    in the content-blind modes."""
+
+    def setUp(self):
+        # 3 shots in a 52s clip — enough that demand-driven > a small fixed budget.
+        self.ca = {
+            "shot_ranges": [
+                {"index": 0, "start": 0.0, "end": 11.0},
+                {"index": 1, "start": 11.0, "end": 31.0},
+                {"index": 2, "start": 31.0, "end": 52.0},
+            ],
+            "flash_frame_candidates": [],
+            "cut_points": [{"time": 11.0}, {"time": 31.0}],
+        }
+        self.dur = 52.0
+
+    def _times(self, mode, budget):
+        cfg = m._resolve_sampling_config({"sampling_mode": mode})
+        return m._sample_times(self.dur, [], budget, fps=25.0, cut_analysis=self.ca, sampling=cfg)
+
+    def test_fixed_is_exactly_budget_and_interval_only(self):
+        times = self._times("fixed", 8)
+        self.assertEqual(len(times), 8)
+        self.assertEqual({t["selection_reason"] for t in times}, {"interval"})
+
+    def test_per_minute_is_exactly_budget(self):
+        times = self._times("per_minute", 3)
+        self.assertEqual(len(times), 3)
+        self.assertEqual({t["selection_reason"] for t in times}, {"interval"})
+
+    def test_thorough_is_demand_driven_and_covers_shots(self):
+        times = self._times("adaptive_capped", 8)
+        # Demand-driven: more than the raw 8 "budget", and covers every shot.
+        self.assertGreater(len(times), 8)
+        reps = [t for t in times if t["selection_reason"] == "shot_representative"]
+        self.assertEqual(len(reps), 3)
+
+
+class CacheReuseRank(unittest.TestCase):
+    def _state(self, report_mode, request_mode):
+        report = {
+            "analysis_signature": {
+                "analysis_version": m.ANALYSIS_VERSION,
+                "analysis_keyframe_budget": 8,
+                "source_file": {"path": "/x.mov", "size_bytes": 1, "mtime_ns": 1},
+                "analysis_sampling": {"mode": report_mode},
+            }
+        }
+        request_sig = {
+            "analysis_version": m.ANALYSIS_VERSION,
+            "analysis_keyframe_budget": 8,
+            "source_file": {"path": "/x.mov", "size_bytes": 1, "mtime_ns": 1},
+            "analysis_sampling": {"mode": request_mode},
+        }
+        return m._report_cache_state(report, request_sig)
+
+    def test_increasing_thoroughness_invalidates(self):
+        issues, _ = self._state("fixed", "adaptive_capped")
+        self.assertIn("sampling_mode_increased", issues)
+
+    def test_decreasing_thoroughness_reuses(self):
+        issues, _ = self._state("adaptive", "fixed")
+        self.assertNotIn("sampling_mode_increased", issues)
+
+    def test_same_mode_reuses(self):
+        issues, _ = self._state("adaptive_capped", "adaptive_capped")
+        self.assertNotIn("sampling_mode_increased", issues)
+
+
+class _PrefsIsolated(unittest.TestCase):
+    """Base that points the media-analysis prefs file at a temp location."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="sampling_prefs_")
+        self._prev = os.environ.get("DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS")
+        os.environ["DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS"] = os.path.join(self._tmp, "prefs.json")
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS", None)
+        else:
+            os.environ["DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS"] = self._prev
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
+class SamplingModeDecision(_PrefsIsolated):
+    def test_first_run_prompts(self):
+        d = srv._media_analysis_sampling_mode_decision({})
+        self.assertTrue(d["prompt_required"])
+        self.assertEqual(d["mode"], m.RECOMMENDED_SAMPLING_MODE)
+
+    def test_explicit_one_off_does_not_persist(self):
+        d = srv._media_analysis_sampling_mode_decision({"sampling_mode": "balanced"})
+        self.assertFalse(d["prompt_required"])
+        self.assertEqual(d["mode"], "per_minute")
+        self.assertEqual(d["source"], "explicit")
+        # Nothing written to disk.
+        self.assertFalse(os.path.exists(os.environ["DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS"]))
+
+    def test_save_default_persists_and_silences_prompt(self):
+        d = srv._media_analysis_sampling_mode_decision(
+            {"sampling_mode": "thorough", "save_sampling_default": True}
+        )
+        self.assertEqual(d["mode"], "adaptive_capped")
+        self.assertEqual(d["source"], "saved_default")
+        # Subsequent call uses the saved default with no prompt.
+        d2 = srv._media_analysis_sampling_mode_decision({})
+        self.assertFalse(d2["prompt_required"])
+        self.assertEqual(d2["mode"], "adaptive_capped")
+        self.assertEqual(srv._media_analysis_effective_preferences()["sampling_mode_default"], "adaptive_capped")
+
+    def test_apply_setup_defaults_injects_mode_and_tunables(self):
+        out = srv._media_analysis_apply_setup_defaults("analyze_clip", {"clip_id": "c1"})
+        self.assertEqual(out["sampling_mode"], m.RECOMMENDED_SAMPLING_MODE)
+        self.assertTrue(out["_sampling_mode_decision"]["prompt_required"])
+        self.assertEqual(out["frames_per_minute"], m.DEFAULT_FRAMES_PER_MINUTE)
+        self.assertEqual(out["frame_floor"], m.DEFAULT_FRAME_FLOOR)
+        self.assertEqual(out["frame_ceiling"], m.DEFAULT_FRAME_CEILING)
+
+
+class SamplingModeEntryShortCircuit(_PrefsIsolated):
+    def test_first_analysis_returns_confirmation(self):
+        resp = asyncio.run(srv.media_analysis("analyze_clip", {"clip_id": "c1"}))
+        self.assertTrue(resp.get("confirmation_required"))
+        self.assertEqual(resp.get("status"), "confirmation_required")
+        self.assertIn("sampling_mode_prompt", resp)
+        ids = {o["id"] for o in resp["sampling_mode_prompt"]["options"]}
+        self.assertEqual(ids, {"fixed", "per_minute", "adaptive_capped", "adaptive"})
+
+    def test_explicit_mode_skips_confirmation(self):
+        # With an explicit mode the sampling prompt must not block; the call
+        # proceeds past the short-circuit (and fails later for lack of a real
+        # Resolve clip, which is fine — we only assert it isn't the sampling prompt).
+        resp = asyncio.run(srv.media_analysis("analyze_clip", {"clip_id": "c1", "sampling_mode": "fixed"}))
+        self.assertNotIn("sampling_mode_prompt", resp)
+
+
+class SamplingModeSetter(_PrefsIsolated):
+    def test_setter_persists_canonical_mode(self):
+        srv._setup_set_media_analysis_defaults({"sampling_mode_default": "balanced"}, dry_run=False)
+        self.assertEqual(srv._media_analysis_effective_preferences()["sampling_mode_default"], "per_minute")
+
+    def test_ask_resets_to_unset(self):
+        srv._setup_set_media_analysis_defaults({"sampling_mode_default": "thorough"}, dry_run=False)
+        srv._setup_set_media_analysis_defaults({"sampling_mode_default": "ask"}, dry_run=False)
+        self.assertIsNone(srv._media_analysis_effective_preferences()["sampling_mode_default"])
+
+    def test_invalid_mode_rejected(self):
+        res = srv._setup_set_media_analysis_defaults({"sampling_mode_default": "banana"}, dry_run=False)
+        self.assertTrue(res.get("error") or res.get("success") is False)
+
+    def test_tunables_persist(self):
+        srv._setup_set_media_analysis_defaults(
+            {"sampling_frames_per_minute": 6, "sampling_frame_ceiling": 120}, dry_run=False
+        )
+        eff = srv._media_analysis_effective_preferences()
+        self.assertEqual(eff["sampling_frames_per_minute"], 6.0)
+        self.assertEqual(eff["sampling_frame_ceiling"], 120)
+
+    def test_negative_tunable_rejected(self):
+        res = srv._setup_set_media_analysis_defaults({"sampling_frame_floor": -2}, dry_run=False)
+        self.assertTrue(res.get("error") or res.get("success") is False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #46.

## Summary
Frame coverage per clip is now governed by a **`sampling_mode`**, decoupled from `depth`. The key finding: the demand-driven engine already scaled by duration/content, but the caps layer flat-truncated its output back to 8 frames — that flat cap was what under-covered long clips.

## Four modes (organized by cost behavior)
| Mode | Name | Frames | Cost |
|---|---|---|---|
| `fixed` | Economy | flat N (even-interval, content-blind) | constant |
| `per_minute` | Balanced | `clamp(minutes×rate, floor, ceiling)` | linear in duration |
| `adaptive_capped` | **Thorough** (default) | content-aware, bounded `[floor, ceiling]` | adaptive, bounded |
| `adaptive` | Thorough (uncapped) | content-aware up to 512 | unbounded |

Economy/Balanced are content-blind even-interval sampling (predictable, exact budget); only Thorough uses the reservation engine.

## First-run flow
Mirrors `timed_markers_default`: `sampling_mode_default="ask"` → first analyze returns `confirmation_required` + `sampling_mode_prompt`; choosing a mode saves it as the default. Explicit `sampling_mode` per call = one-off.

## Other changes
- **Caps retune**: `frames_per_clip` is now a safety ceiling (12/80/200), not the dial; token caps raised so default Thorough isn't refused.
- **Control panel**: Preferences → Frame sampling mode selector + frames/min, floor, ceiling + live token estimate. Batch jobs honor the saved default.
- **Cache reuse**: re-samples only when switching *up* the thoroughness rank.

## Validation
- `tests/test_sampling_modes.py` (30 tests) + updated caps assertions; 155 focused tests pass.
- Static checks (test_import, audit_api_parity, npm pack, node CLI) clean.
- **Live-tested** on a synthetic 6-shot clip with real ffmpeg frame extraction — caught and fixed a bug where reservations overrode the Economy/Balanced budgets. No DaVinci Resolve scripting behavior changed (ffmpeg sampling + preference plumbing only).