### PR TITLE
fix: count analyzed clips after Media Pool rename (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.27.2
+
+**Control panel under-counted analyzed clips after a Media Pool rename (issue
+#51)** — with every clip analyzed (e.g. 303/303 reports on disk), the overview
+and Media tab could report something like "108 / 303 analyzed". The panel only
+recognized a report when a folder's name exactly matched the clip's *current*
+display name, so renaming clips after analysis hid their existing reports even
+though the underlying media was unchanged.
+
+Root cause and fix:
+
+- **Lookups are keyed by a rename-stable hash, not the display-name folder.**
+  Report folders are named `<display-slug>-<hash>`; the count now matches on the
+  trailing hash (and the ids inside each report), so a renamed clip still
+  resolves to its existing folder. Both the disk path and the jobs-DB fallback
+  were corrected.
+- **The hash is now anchored to the normalized file path (canonical basis).**
+  Previously the basis was a `clip_id`-first cascade, so the same media hashed
+  differently depending on which fields a record carried — Resolve inventory
+  (clip_id) vs path-based batch jobs (file path) disagreed on the same clip.
+  Anchoring to the file path removes that cross-basis mismatch. Legacy folders
+  (clip_id-based, or raw-path-based) still resolve via a migration-safe set of
+  candidate hashes, so **no on-disk migration is required**.
+- **Writes reuse an existing report folder** (matched by canonical or legacy
+  hash) instead of minting a new `<newslug>-<hash>` directory, eliminating
+  orphaned duplicate folders when a renamed clip is re-analyzed.
+- **A persisted clip index (`clips/index.json`)** maps every stable id found in
+  a report (normalized + raw file path, clip_id, media_id) to its folder, so the
+  count can still match a clip by any id it carries — including an offline clip
+  that no longer reports a file path but retains its clip_id. The index is
+  refreshed only when a report is added, removed, or rewritten (cheap signature
+  check), so the recurring poll stays inexpensive.
+
+No public MCP tool surface changed. Adds regression tests in
+`tests/test_media_analysis.py` covering rename, cross-basis, legacy-folder reuse,
+the jobs-DB fallback, and the offline/no-path case.
+
 ## What's New in v2.27.1
 
 **Faster control-panel startup with network source media (issue #50)** — on

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DaVinci Resolve MCP Server
 
-[![Version](https://img.shields.io/badge/version-2.27.1-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.27.2-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-32%20(329%20full)-blue.svg)](#server-modes)

--- a/install.py
+++ b/install.py
@@ -35,7 +35,7 @@ from src.utils.update_check import (
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.27.1"
+VERSION = "2.27.2"
 # Only hard floor: mcp[cli] requires Python 3.10+. There is no upper bound —
 # Resolve's scripting bridge loads into newer interpreters on recent builds
 # (Python 3.14 verified against Resolve Studio 20.3.2). Older Resolve builds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "description": "NPM bootstrapper for the DaVinci Resolve MCP Server.",
   "license": "MIT",
   "author": "Samuel Gursky <samgursky@gmail.com>",

--- a/src/analysis_dashboard.py
+++ b/src/analysis_dashboard.py
@@ -27,7 +27,10 @@ from src.utils.media_analysis import (
     detect_capabilities,
     query_analysis_index,
     resolve_output_root,
+    clip_directory_hash,
+    load_clip_index,
     stable_clip_directory,
+    stable_clip_match_hashes,
 )
 from src.utils.media_analysis_jobs import (
     MEDIA_EXTENSIONS,
@@ -10912,11 +10915,32 @@ def _analysis_status_by_clip(project_root: str, records: List[Dict[str, Any]]) -
     status_by_key: Dict[str, Dict[str, Any]] = {}
     if not keys:
         return status_by_key
+
+    # Resolve each clip to its report via the persisted clip index, which maps
+    # every stable id found in a report (normalized + raw file path, clip_id,
+    # media_id) to its folder. This survives a Media Pool rename, a legacy hash
+    # basis, AND an offline clip that no longer reports a file path but still
+    # carries its clip_id — none of which a folder-name scan can match. See #51.
+    clips_root = os.path.join(project_root, "clips")
+    hash_to_folder = load_clip_index(project_root).get("hash_to_folder") or {}
+
     for record in records:
         clip_key = record.get("clip_key")
         if not clip_key:
             continue
         report_path = os.path.join(project_root, "clips", str(clip_key), "analysis.json")
+        if not os.path.isfile(report_path):
+            # Renamed/legacy/offline clip: the recomputed clip_key no longer
+            # matches the folder on disk. Fall back to any of the clip's stable
+            # hashes via the index.
+            for clip_hash in stable_clip_match_hashes(record):
+                folder = hash_to_folder.get(clip_hash)
+                if not folder:
+                    continue
+                candidate = os.path.join(clips_root, folder, "analysis.json")
+                if os.path.isfile(candidate):
+                    report_path = candidate
+                    break
         if os.path.isfile(report_path):
             status_by_key[str(clip_key)] = {
                 "analysis_status": "analyzed",
@@ -10926,32 +10950,24 @@ def _analysis_status_by_clip(project_root: str, records: List[Dict[str, Any]]) -
     db_path = os.path.join(project_root, "jobs.sqlite")
     if not os.path.isfile(db_path):
         return status_by_key
-    placeholders = ",".join("?" for _ in keys)
-    try:
-        conn = sqlite3.connect(db_path)
-        conn.row_factory = sqlite3.Row
-        rows = conn.execute(
-            f"""
-            SELECT jc.clip_key, jc.status, jc.cache_status, jc.report_path, jc.error,
-                   j.job_id, j.name AS job_name, j.updated_at
-            FROM job_clips jc
-            JOIN jobs j ON j.job_id = jc.job_id
-            WHERE jc.clip_key IN ({placeholders})
-            ORDER BY jc.updated_at DESC
-            """,
-            keys,
-        ).fetchall()
-    except Exception:
-        return status_by_key
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-    for row in rows:
-        clip_key = str(row["clip_key"])
-        if clip_key in status_by_key and status_by_key[clip_key].get("analysis_status") == "analyzed":
+
+    # The jobs DB stores each clip under the clip_key it had when analyzed. A
+    # clip renamed afterwards produces a new clip_key, so an exact-key match
+    # misses its job row. Index unresolved records by their rename-stable hash
+    # so a DB row recorded under the old name (e.g. a reused batch report living
+    # outside the local clips/ dir) still maps back to the current clip. #51.
+    key_set = {str(k) for k in keys}
+    pending_hash_to_key: Dict[str, str] = {}
+    for record in records:
+        clip_key = record.get("clip_key")
+        if not clip_key or str(clip_key) in status_by_key:
             continue
+        for folder_hash in stable_clip_match_hashes(record):
+            pending_hash_to_key.setdefault(folder_hash, str(clip_key))
+
+    def _apply_row(row: sqlite3.Row, target_key: str) -> None:
+        if status_by_key.get(target_key, {}).get("analysis_status") == "analyzed":
+            return
         db_status = row["status"]
         report_path = row["report_path"]
         # In media_analysis_jobs, 'succeeded' = fresh analysis written this run,
@@ -10969,7 +10985,7 @@ def _analysis_status_by_clip(project_root: str, records: List[Dict[str, Any]]) -
         normalized = db_status
         if db_status in ("succeeded", "skipped") and report_resolves:
             normalized = "analyzed"
-        status_by_key[clip_key] = {
+        status_by_key[target_key] = {
             "analysis_status": normalized,
             "job_status": db_status,
             "cache_status": row["cache_status"],
@@ -10979,6 +10995,45 @@ def _analysis_status_by_clip(project_root: str, records: List[Dict[str, Any]]) -
             "job_name": row["job_name"],
             "job_updated_at": row["updated_at"],
         }
+
+    select_cols = (
+        "SELECT jc.clip_key, jc.status, jc.cache_status, jc.report_path, jc.error, "
+        "j.job_id, j.name AS job_name, j.updated_at "
+        "FROM job_clips jc JOIN jobs j ON j.job_id = jc.job_id"
+    )
+    placeholders = ",".join("?" for _ in keys)
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            f"{select_cols} WHERE jc.clip_key IN ({placeholders}) ORDER BY jc.updated_at DESC",
+            keys,
+        ).fetchall()
+        for row in rows:
+            _apply_row(row, str(row["clip_key"]))
+        # Only pay for the unfiltered scan when a rename actually left a record
+        # unresolved by the disk pass and exact-key match above.
+        unresolved = {
+            h: k for h, k in pending_hash_to_key.items() if k not in status_by_key
+        }
+        if unresolved:
+            for row in conn.execute(
+                f"{select_cols} ORDER BY jc.updated_at DESC"
+            ).fetchall():
+                raw_key = str(row["clip_key"])
+                if raw_key in key_set:
+                    continue
+                row_hash = clip_directory_hash(raw_key)
+                target_key = unresolved.get(row_hash) if row_hash else None
+                if target_key:
+                    _apply_row(row, target_key)
+    except Exception:
+        return status_by_key
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
     return status_by_key
 
 

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -80,7 +80,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.27.1"
+VERSION = "2.27.2"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 329-tool granular server instead
 """
 
-VERSION = "2.27.1"
+VERSION = "2.27.2"
 
 import base64
 import os

--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -739,16 +739,225 @@ def project_directory_name(project_name: Any, project_id: Any = None) -> str:
     return f"{slugify(project_name, 'project')}-{short_hash(basis)}"
 
 
-def stable_clip_directory(record: Dict[str, Any]) -> str:
-    basis = (
+def stable_clip_basis(record: Dict[str, Any]) -> str:
+    """Return the canonical rename-stable identity used to hash a report folder.
+
+    The canonical basis is the *normalized file path*: it is present on both
+    Resolve-derived and path-based batch records, it survives a Media Pool
+    rename, and a genuine relink to a different file is handled separately as a
+    superseded source. Resolve-internal ids (clip_id/media_id) are absent from
+    path-based records and not portable across project copies, so they are only
+    used when no file path is available; the display name is the last resort.
+
+    Folder *resolution* (matching an existing report) must tolerate the legacy
+    bases too — see :func:`stable_clip_match_hashes`.
+    """
+    file_path = record.get("file_path")
+    if file_path:
+        return normalize_path(file_path)
+    return str(
         record.get("clip_id")
         or record.get("media_id")
-        or record.get("file_path")
         or record.get("clip_name")
         or "clip"
     )
+
+
+def stable_clip_hash(record: Dict[str, Any]) -> str:
+    """Return the canonical 12-char hash that anchors a clip's report folder."""
+    return short_hash(stable_clip_basis(record), 12)
+
+
+def stable_clip_match_hashes(record: Dict[str, Any]) -> List[str]:
+    """All folder hashes that could identify this clip's existing report.
+
+    Returns the canonical hash first, followed by legacy bases so reports
+    written before the canonical file-path scheme (clip_id-first, or a raw
+    un-normalized path) still resolve without an on-disk migration. The display
+    name is only used when nothing more unique is available, so two different
+    clips that merely share a name are never matched to the same report.
+    """
+    hashes: List[str] = []
+    seen: set = set()
+
+    def add(value: Any) -> None:
+        if not value:
+            return
+        digest = short_hash(value, 12)
+        if digest not in seen:
+            seen.add(digest)
+            hashes.append(digest)
+
+    file_path = record.get("file_path")
+    if file_path:
+        add(normalize_path(file_path))  # canonical
+        add(str(file_path))             # legacy: raw, un-normalized path
+    add(record.get("clip_id"))          # legacy: clip_id-first scheme
+    add(record.get("media_id"))
+    if not hashes:
+        add(record.get("clip_name") or "clip")
+    return hashes
+
+
+def clip_directory_hash(name: Any) -> Optional[str]:
+    """Extract the trailing stable hash from a clip report folder name.
+
+    Folder names are ``<label>-<hash>`` where ``<label>`` is the (rename-prone)
+    display slug and ``<hash>`` is :func:`stable_clip_hash`. A bare ``<hash>``
+    folder (no slug) is also accepted. Returns the hash, or ``None`` if the
+    trailing token is not a 12-char hex hash.
+    """
+    base = os.path.basename(str(name or "").rstrip("/\\"))
+    suffix = base.rsplit("-", 1)[-1]
+    if re.fullmatch(r"[0-9a-f]{12}", suffix):
+        return suffix
+    return None
+
+
+def stable_clip_directory(record: Dict[str, Any]) -> str:
     label = slugify(record.get("clip_name") or Path(str(record.get("file_path") or "clip")).stem, "clip")
-    return f"{label}-{short_hash(basis, 12)}"
+    return f"{label}-{stable_clip_hash(record)}"
+
+
+def resolve_clip_directory(project_root: str, record: Dict[str, Any]) -> str:
+    """Return the report directory for a clip, reusing an existing one if found.
+
+    Writes go through here so a clip that was renamed, or analyzed under a legacy
+    hash basis (e.g. clip_id-first, or a path-based batch report), reuses its
+    existing folder instead of orphaning it under a freshly minted name. Matches
+    by canonical hash first, then any legacy hash; falls back to the canonical
+    new path when nothing exists yet.
+    """
+    clips_root = os.path.join(project_root, "clips")
+    # Fast path: the canonical folder already exists by exact name. This is the
+    # steady state (re-analysis of an already-canonical clip) and avoids a full
+    # directory scan per clip on a batch run.
+    canonical_dir = os.path.join(clips_root, stable_clip_directory(record))
+    if os.path.isdir(canonical_dir):
+        return normalize_path(canonical_dir)
+    match = stable_clip_match_hashes(record)
+    if match and os.path.isdir(clips_root):
+        canonical = match[0]
+        match_set = set(match)
+        legacy_hit: Optional[str] = None
+        try:
+            entries = sorted(os.listdir(clips_root))
+        except OSError:
+            entries = []
+        for entry in entries:
+            candidate = os.path.join(clips_root, entry)
+            if not os.path.isdir(candidate):
+                continue
+            folder_hash = clip_directory_hash(entry)
+            if not folder_hash:
+                continue
+            if folder_hash == canonical:
+                return normalize_path(candidate)
+            if folder_hash in match_set and legacy_hit is None:
+                legacy_hit = candidate
+        if legacy_hit:
+            return normalize_path(legacy_hit)
+    return normalize_path(os.path.join(clips_root, stable_clip_directory(record)))
+
+
+CLIP_INDEX_SCHEMA_VERSION = 1
+
+
+def clip_index_path(project_root: str) -> str:
+    """Path of the per-project clip index (a sidecar under clips/)."""
+    return os.path.join(project_root, "clips", "index.json")
+
+
+def _clip_dir_signature(clips_root: str) -> str:
+    """Cheap fingerprint of the analyzed clip dirs (each analysis.json's name,
+    mtime, and size) so the persisted index can be reused until a report is
+    added, removed, or rewritten — without reparsing every report each poll."""
+    parts: List[str] = []
+    try:
+        entries = sorted(os.listdir(clips_root))
+    except OSError:
+        return "0:none"
+    for entry in entries:
+        report = os.path.join(clips_root, entry, "analysis.json")
+        try:
+            stat = os.stat(report)
+        except OSError:
+            continue
+        parts.append(f"{entry}:{stat.st_mtime_ns}:{stat.st_size}")
+    return f"{len(parts)}:{short_hash('|'.join(parts), 16)}"
+
+
+def build_clip_index(project_root: str) -> Dict[str, Any]:
+    """Build and persist a hash -> folder index for the project's reports.
+
+    Unlike a folder-name scan (which only knows the single hash baked into each
+    directory name), this reads each report's ``clip`` block and indexes ALL of
+    its stable ids (normalized + raw file path, clip_id, media_id). That lets the
+    analyzed-count match a clip by any id it still carries — e.g. an offline clip
+    that no longer reports a file path but still has its clip_id. See #51.
+    """
+    clips_root = os.path.join(project_root, "clips")
+    hash_to_folder: Dict[str, str] = {}
+    if os.path.isdir(clips_root):
+        try:
+            entries = sorted(os.listdir(clips_root))
+        except OSError:
+            entries = []
+        for entry in entries:
+            report_path = os.path.join(clips_root, entry, "analysis.json")
+            if not os.path.isfile(report_path):
+                continue
+            try:
+                report = _read_json(report_path)
+            except (OSError, json.JSONDecodeError):
+                continue
+            clip_block = report.get("clip") if isinstance(report.get("clip"), dict) else {}
+            hashes = set(stable_clip_match_hashes(clip_block))
+            folder_hash = clip_directory_hash(entry)  # the hash baked into the name
+            if folder_hash:
+                hashes.add(folder_hash)
+            for digest in hashes:
+                hash_to_folder.setdefault(digest, entry)
+    payload = {
+        "schema_version": CLIP_INDEX_SCHEMA_VERSION,
+        "signature": _clip_dir_signature(clips_root),
+        "hash_to_folder": hash_to_folder,
+    }
+    if os.path.isdir(clips_root):
+        try:
+            _write_json(clip_index_path(project_root), payload)
+        except OSError:
+            pass
+    return payload
+
+
+def load_clip_index(project_root: str, *, rebuild_if_stale: bool = True) -> Dict[str, Any]:
+    """Load the persisted clip index, rebuilding it if missing or stale.
+
+    Freshness is decided by the cheap directory signature, so the common poll
+    pays a stat-per-report instead of a full JSON reparse; a rebuild only happens
+    when a report is added, removed, or rewritten.
+    """
+    clips_root = os.path.join(project_root, "clips")
+    current_sig = _clip_dir_signature(clips_root)
+    try:
+        data = _read_json(clip_index_path(project_root))
+    except (OSError, json.JSONDecodeError):
+        data = None
+    if (
+        isinstance(data, dict)
+        and data.get("schema_version") == CLIP_INDEX_SCHEMA_VERSION
+        and data.get("signature") == current_sig
+        and isinstance(data.get("hash_to_folder"), dict)
+    ):
+        return data
+    if rebuild_if_stale:
+        return build_clip_index(project_root)
+    return {
+        "schema_version": CLIP_INDEX_SCHEMA_VERSION,
+        "signature": current_sig,
+        "hash_to_folder": {},
+    }
 
 
 def normalize_path(path: Any) -> str:
@@ -1681,7 +1890,7 @@ def _bounded_frame_count(depth: str, requested: Any = None) -> int:
 
 
 def _artifact_paths(project_root: str, record: Dict[str, Any], depth: str, options: Dict[str, Any]) -> Dict[str, Any]:
-    clip_dir = normalize_path(os.path.join(project_root, "clips", stable_clip_directory(record)))
+    clip_dir = resolve_clip_directory(project_root, record)
     artifacts: Dict[str, Any] = {
         "clip_dir": clip_dir,
         "analysis_json": os.path.join(clip_dir, "analysis.json"),

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -36,6 +36,7 @@ from src.analysis_dashboard import (
     get_analyzed_clip_shot,
     get_clip_frame_path,
     read_clip_corrections,
+    _analysis_status_by_clip,
 )
 from src.utils import update_check
 from src.utils.media_analysis import (
@@ -61,7 +62,14 @@ from src.utils.media_analysis import (
     resolve_output_root,
     _sample_times,
     summarize_reports,
+    build_clip_index,
+    clip_directory_hash,
+    clip_index_path,
+    load_clip_index,
+    resolve_clip_directory,
     stable_clip_directory,
+    stable_clip_hash,
+    stable_clip_match_hashes,
     update_analysis_registry,
     vision_is_pending_host_analysis,
 )
@@ -442,6 +450,268 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
         self.assertNotIn("..", dirname)
         self.assertNotIn("/", dirname)
         self.assertTrue(dirname.startswith("a001-c001.mov-"))
+
+    def test_stable_clip_hash_survives_media_pool_rename(self):
+        """The folder hash is anchored to stable Resolve ids, not the display name."""
+        before = {
+            "clip_name": "c0001.mp4",
+            "clip_id": "clip-123",
+            "file_path": "/Volumes/Media/c0001.mp4",
+        }
+        after = dict(before, clip_name="ice_c0001.mp4")
+
+        # The leading slug changes, but the trailing hash is identical.
+        self.assertNotEqual(stable_clip_directory(before), stable_clip_directory(after))
+        self.assertEqual(stable_clip_hash(before), stable_clip_hash(after))
+        self.assertEqual(
+            clip_directory_hash(stable_clip_directory(before)),
+            clip_directory_hash(stable_clip_directory(after)),
+        )
+
+    def test_clip_directory_hash_extracts_trailing_hex_only(self):
+        self.assertEqual(clip_directory_hash("c0001.mp4-c923852545ed"), "c923852545ed")
+        self.assertEqual(clip_directory_hash("ice_c0001.mp4-c923852545ed"), "c923852545ed")
+        # A bare hash folder (no slug) is also a valid clip report folder.
+        self.assertEqual(clip_directory_hash("c923852545ed"), "c923852545ed")
+        # No trailing 12-char hex token -> not a clip report folder.
+        self.assertIsNone(clip_directory_hash("not-a-clip-folder"))
+        self.assertIsNone(clip_directory_hash("plainname"))
+
+    def test_canonical_hash_agrees_across_resolve_and_path_based_records(self):
+        """Same media -> same canonical hash whether or not clip_id is present.
+
+        The Resolve inventory carries clip_id; path-based batch records do not.
+        Anchoring the canonical hash to the (normalized) file path removes that
+        cross-basis mismatch so both surfaces agree on one folder.
+        """
+        resolve_record = {
+            "clip_name": "c0001.mp4",
+            "clip_id": "clip-123",
+            "media_id": "media-9",
+            "file_path": "/Volumes/Media/c0001.mp4",
+        }
+        path_based = {
+            "clip_name": "c0001.mp4",
+            "clip_id": None,
+            "media_id": None,
+            "file_path": "/Volumes/Media/c0001.mp4",
+        }
+        self.assertEqual(stable_clip_hash(resolve_record), stable_clip_hash(path_based))
+        # Each record can still resolve the other's folder via the match set.
+        self.assertIn(stable_clip_hash(path_based), stable_clip_match_hashes(resolve_record))
+        self.assertIn(stable_clip_hash(resolve_record), stable_clip_match_hashes(path_based))
+
+    def test_resolve_clip_directory_reuses_legacy_clip_id_folder(self):
+        """Migration: a folder written under the old clip_id-first basis is
+        reused on the next write instead of being orphaned under a new name."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            record = {
+                "clip_name": "c0001.mp4",
+                "clip_id": "clip-123",
+                "file_path": "/Volumes/Media/c0001.mp4",
+            }
+            # Legacy folder name: slug + hash(clip_id) (pre-canonical scheme).
+            from src.utils.media_analysis import short_hash
+            legacy_dir = os.path.join(
+                project_root, "clips", f"c0001.mp4-{short_hash('clip-123', 12)}"
+            )
+            os.makedirs(legacy_dir, exist_ok=True)
+
+            resolved = resolve_clip_directory(project_root, record)
+            self.assertEqual(os.path.realpath(resolved), os.path.realpath(legacy_dir))
+
+    def test_resolve_clip_directory_reuses_folder_after_rename(self):
+        """A renamed clip writes back into its existing folder (no orphan)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            record = {
+                "clip_name": "c0001.mp4",
+                "clip_id": "clip-123",
+                "file_path": "/Volumes/Media/c0001.mp4",
+            }
+            original = resolve_clip_directory(project_root, record)
+            os.makedirs(original, exist_ok=True)
+
+            renamed = dict(record, clip_name="ice_c0001.mp4")
+            self.assertEqual(
+                os.path.realpath(resolve_clip_directory(project_root, renamed)),
+                os.path.realpath(original),
+            )
+
+    def test_resolve_clip_directory_mints_canonical_path_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            record = {
+                "clip_name": "c0001.mp4",
+                "clip_id": "clip-123",
+                "file_path": "/Volumes/Media/c0001.mp4",
+            }
+            resolved = resolve_clip_directory(project_root, record)
+            self.assertEqual(
+                os.path.basename(resolved.rstrip("/")), stable_clip_directory(record)
+            )
+
+    def _write_report(self, project_root, folder, clip_block):
+        clip_dir = os.path.join(project_root, "clips", folder)
+        os.makedirs(clip_dir, exist_ok=True)
+        with open(os.path.join(clip_dir, "analysis.json"), "w", encoding="utf-8") as handle:
+            json.dump({"clip": clip_block}, handle)
+        return clip_dir
+
+    def test_clip_index_indexes_all_stable_ids_from_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            self._write_report(
+                project_root,
+                "c0001.mp4-deadbeef0001",
+                {"clip_id": "clip-123", "media_id": "media-9",
+                 "file_path": "/Volumes/Media/c0001.mp4", "clip_name": "c0001.mp4"},
+            )
+            index = build_clip_index(project_root)
+            self.assertTrue(os.path.isfile(clip_index_path(project_root)))
+            h2f = index["hash_to_folder"]
+            # Every stable id of the clip resolves to the same folder.
+            for record in (
+                {"file_path": "/Volumes/Media/c0001.mp4"},
+                {"clip_id": "clip-123"},
+                {"media_id": "media-9"},
+            ):
+                hashes = stable_clip_match_hashes(record)
+                self.assertTrue(any(h in h2f for h in hashes), record)
+                folders = {h2f[h] for h in hashes if h in h2f}
+                self.assertEqual(folders, {"c0001.mp4-deadbeef0001"})
+
+    def test_clip_index_matches_offline_clip_without_file_path(self):
+        """The edge the manifest exists for: a clip analyzed while online (folder
+        hashed on file path) that the live inventory later reports offline with
+        no file path, only a clip_id. The index still resolves it. #51."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            online = {
+                "clip_name": "c0001.mp4",
+                "clip_id": "clip-123",
+                "file_path": "/Volumes/Media/c0001.mp4",
+            }
+            folder = stable_clip_directory(online)
+            self._write_report(project_root, folder, dict(online))
+
+            # Live record went offline: no file_path, basis falls back to clip_id.
+            offline = {"clip_name": "c0001.mp4", "clip_id": "clip-123", "file_path": None}
+            offline["clip_key"] = stable_clip_directory(offline)
+            self.assertNotEqual(offline["clip_key"], folder)
+            self.assertNotIn(
+                stable_clip_hash(online), stable_clip_match_hashes(offline)
+            )  # a folder-name scan would miss it
+
+            status = _analysis_status_by_clip(project_root, [offline])
+            entry = status.get(offline["clip_key"])
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry["analysis_status"], "analyzed")
+
+    def test_clip_index_rebuilds_when_report_added(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            self._write_report(
+                project_root, "a-aaaaaaaa0001",
+                {"clip_id": "clip-a", "file_path": "/m/a.mp4", "clip_name": "a.mp4"},
+            )
+            first = load_clip_index(project_root)
+            self.assertEqual(len(first["hash_to_folder"]) >= 1, True)
+
+            # Add a second report; a stale signature must trigger a rebuild.
+            self._write_report(
+                project_root, "b-bbbbbbbb0002",
+                {"clip_id": "clip-b", "file_path": "/m/b.mp4", "clip_name": "b.mp4"},
+            )
+            second = load_clip_index(project_root)
+            self.assertNotEqual(first["signature"], second["signature"])
+            self.assertIn(stable_clip_hash({"clip_id": "clip-b", "file_path": "/m/b.mp4"}),
+                          second["hash_to_folder"])
+
+    def test_analysis_status_counts_renamed_clip_as_analyzed(self):
+        """Issue #51: a clip renamed after analysis still counts as analyzed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "project-root")
+            record = {
+                "clip_name": "c0001.mp4",
+                "clip_id": "clip-123",
+                "file_path": "/Volumes/Media/c0001.mp4",
+            }
+            # Report was written under the ORIGINAL name.
+            original_dir = os.path.join(project_root, "clips", stable_clip_directory(record))
+            os.makedirs(original_dir, exist_ok=True)
+            with open(os.path.join(original_dir, "analysis.json"), "w", encoding="utf-8") as handle:
+                json.dump({"clip": {"clip_id": "clip-123"}}, handle)
+
+            # The clip is now renamed in the Media Pool; clip_key is recomputed
+            # from the NEW name (as resolve_media_inventory would do).
+            renamed = dict(record, clip_name="ice_c0001.mp4")
+            renamed["clip_key"] = stable_clip_directory(renamed)
+            self.assertFalse(
+                os.path.isdir(os.path.join(project_root, "clips", renamed["clip_key"]))
+            )
+
+            status = _analysis_status_by_clip(project_root, [renamed])
+            entry = status.get(renamed["clip_key"])
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry["analysis_status"], "analyzed")
+            self.assertTrue(os.path.isfile(entry["analysis_report_path"]))
+
+    def test_analysis_status_counts_renamed_clip_from_reused_job_report(self):
+        """Issue #51: rename also resolves via the jobs DB when the report is
+        a reused batch report living outside the local clips/ dir."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = os.path.join(tmp, "active-root")
+            os.makedirs(project_root, exist_ok=True)
+            record = {
+                "clip_name": "c0001.mp4",
+                "clip_id": "clip-123",
+                "file_path": "/Volumes/Media/c0001.mp4",
+            }
+            old_key = stable_clip_directory(record)
+
+            # The actual report lives in a *different* project root (batch reuse),
+            # not under {project_root}/clips/.
+            source_dir = os.path.join(tmp, "source-root", "clips", old_key)
+            os.makedirs(source_dir, exist_ok=True)
+            report_path = os.path.join(source_dir, "analysis.json")
+            with open(report_path, "w", encoding="utf-8") as handle:
+                json.dump({"clip": {"clip_id": "clip-123"}}, handle)
+
+            # The jobs DB recorded the clip under its OLD clip_key.
+            conn = sqlite3.connect(os.path.join(project_root, "jobs.sqlite"))
+            try:
+                conn.execute(
+                    "CREATE TABLE jobs (job_id TEXT, name TEXT, updated_at TEXT)"
+                )
+                conn.execute(
+                    "CREATE TABLE job_clips (job_id TEXT, clip_key TEXT, status TEXT, "
+                    "cache_status TEXT, report_path TEXT, error TEXT, updated_at TEXT)"
+                )
+                conn.execute(
+                    "INSERT INTO jobs (job_id, name, updated_at) VALUES (?, ?, ?)",
+                    ("job-1", "batch", "2026-06-01T10:00:00Z"),
+                )
+                conn.execute(
+                    "INSERT INTO job_clips (job_id, clip_key, status, cache_status, "
+                    "report_path, error, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    ("job-1", old_key, "skipped", "reused", report_path, None,
+                     "2026-06-01T10:00:00Z"),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+            # Clip renamed in the Media Pool -> clip_key recomputed from new name.
+            renamed = dict(record, clip_name="ice_c0001.mp4")
+            renamed["clip_key"] = stable_clip_directory(renamed)
+            self.assertNotEqual(renamed["clip_key"], old_key)
+
+            status = _analysis_status_by_clip(project_root, [renamed])
+            entry = status.get(renamed["clip_key"])
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry["analysis_status"], "analyzed")
 
     def test_capability_detection_never_installs(self):
         caps = detect_capabilities(env={})


### PR DESCRIPTION
## Summary

Fixes #51 — the control panel under-counted analyzed clips after a Media Pool rename. With every clip analyzed (e.g. 303/303 reports on disk), the overview and Media tab could show something like **108 / 303 analyzed**, because the count only recognized a report when a folder's name exactly matched the clip's *current* display name.

## Root cause

Report folders are named `<display-slug>-<hash>`. The hash is rename-stable, but the lookup compared the **full** folder name against the recomputed (post-rename) name, so a renamed clip never matched its existing folder.

## Changes

- **Match by the rename-stable hash**, not the display-name folder — on both the disk path and the jobs-DB fallback.
- **Canonical hash basis = normalized file path.** Previously a `clip_id`-first cascade meant Resolve inventory (clip_id) and path-based batch jobs (file path) hashed the *same* clip differently. Anchoring to the file path removes that cross-basis mismatch. Legacy folders (clip_id- or raw-path-based) still resolve via a migration-safe candidate-hash set — **no on-disk migration required**.
- **Write-time folder reuse** — a re-analyzed renamed clip writes back into its existing folder instead of orphaning a new `<newslug>-<hash>` directory.
- **Persisted `clips/index.json`** mapping every stable id in a report (normalized + raw file path, clip_id, media_id) to its folder, so an offline clip that no longer reports a file path still matches by clip_id. Rebuilt only when reports change (cheap signature check), keeping the 2s poll inexpensive.

No public MCP tool surface changed.

## Tests

Adds regression tests in `tests/test_media_analysis.py` for rename, cross-basis agreement, legacy-folder reuse, the jobs-DB fallback, and the offline/no-path case. **149 passing** across `test_media_analysis`, `test_analysis_runs`, `test_analysis_caps`, `test_caps_integration`, `test_provenance`.

## Validation

- `tests/test_import.py`, `scripts/audit_api_parity.py`, `node bin/davinci-resolve-mcp.mjs --help/--version`, `npm pack --dry-run`, `git diff --check` — all clean.
- No Resolve scripting behavior changed (the fix is local report-folder resolution), so live Resolve validation is not required per the release process.
