### PR TITLE
v2.28.0: timeline diff engine, declarative project spec, lint, clip_where

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.28.0
+
+This release adds a structural timeline-diff engine, a declarative project spec
+you can `apply` like infrastructure-as-code, a project health `lint`, a clip
+query DSL, and a machine-readable `state` field on error responses.
+
+**Timeline version diff — see exactly what an edit changed.** Comparing two
+archived timeline versions now reports clips that were **added, removed, moved,
+and trimmed**, plus summary counts and before/after clip totals. A new reusable
+diff engine aligns clips by a rename-stable identity (so a reordered or renamed
+clip reads as a move/change, not a delete-and-re-add).
+
+- `timeline_versioning(action="diff_versions", timeline_name, from_version, to_version)`
+  now returns `{added, removed, moved, trimmed, summary}` (the previous
+  `added`/`removed`/`moved` keys are unchanged).
+- Dashboard endpoint `GET /api/timeline_versions/diff?timeline_name=&from_version=&to_version=`
+  exposes the same diff to the control panel.
+
+**Declarative project spec + `apply` — reproducible project setup.** Describe a
+project's desired settings, color preset, timelines, and markers in a
+`project.dvr.yaml` (or `.json`), then reconcile the live project toward it. Runs
+are **idempotent** — applying twice is a no-op — and a dry run previews every
+change before anything is touched.
+
+- New MCP actions on `project_manager`:
+  - `diff_to_spec(spec_path | spec)` — preview drift without mutating.
+  - `plan_spec(spec_path | spec)` — the ordered action list (dry run).
+  - `apply_spec(spec_path | spec, dry_run?, run_hooks?, continue_on_error?)` —
+    reconcile. Color/HDR settings apply in dependency order; markers are only
+    added when absent; an explicit `color_preset` can be overridden by explicit
+    `settings`. Failures can abort on first error or accumulate.
+- New headless CLI commands: `davinci-resolve-mcp batch plan-spec SPEC` and
+  `davinci-resolve-mcp batch apply SPEC [--dry-run] [--run-hooks] [--continue-on-error]`.
+  Exit codes follow the existing convention (`0` ok, `2` partial, `3` fatal).
+- Optional before/after shell **hooks** in the spec run only when `run_hooks` is
+  passed (opt-in).
+
+**Project health `lint` — a pre-flight before editing.** `project_manager(action="lint")`
+returns a graded issue list (errors / warnings / info) covering: no project, no
+current timeline, mixed frame rates across timelines, empty timelines, unset
+render format, unmanaged color science, offline media, and unanalyzed clips.
+
+**Clip query DSL — find clips in one call.** `timeline(action="clip_where", ...)`
+returns the clips on the current timeline matching named filters (AND), instead
+of enumerating tracks by hand. Live filters: `track_type`, `track_index`,
+`name_contains`, `duration_lt`, `duration_gt`. A typo'd filter name is rejected
+rather than silently matching everything.
+
+**Machine-readable error context.** Structured error responses can now carry an
+optional `state` object — a snapshot of the relevant values at failure time
+(e.g. which filter was unknown, which spec failed and where) — so an agent can
+react without parsing prose. Existing error fields are unchanged.
+
 ## What's New in v2.27.2
 
 **Control panel under-counted analyzed clips after a Media Pool rename (issue

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DaVinci Resolve MCP Server
 
-[![Version](https://img.shields.io/badge/version-2.27.2-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.28.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-32%20(329%20full)-blue.svg)](#server-modes)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -355,6 +355,26 @@ lifecycle, settings, database, preset, and archive boundary helpers:
 - `preset_lifecycle_probe`
 - `project_boundary_report`
 
+Health check and declarative spec (v2.28.0+):
+
+- `lint` — graded project health pre-flight returning `{ok, counts, issues}`.
+  Issues (error / warning / info) cover: no project, no current timeline, mixed
+  frame rates across timelines, empty timeline, render format unset, color
+  science unmanaged, offline media, and unanalyzed clips. Composed from existing
+  probes; safe read-only.
+- `diff_to_spec(spec_path | spec)` — preview drift between a declarative spec and
+  the live project WITHOUT mutating. Returns `{actions, diff, change_count}`.
+- `plan_spec(spec_path | spec)` — the ordered action list as a dry run.
+- `apply_spec(spec_path | spec, dry_run?, run_hooks?, continue_on_error?)` —
+  reconcile the project toward the spec. Idempotent (re-runs are no-ops); color/
+  HDR settings apply in dependency order; markers added only when absent; explicit
+  `settings` override a named `color_preset`; before/after shell hooks run only
+  with `run_hooks=true`. The spec is YAML or JSON:
+  `{project, color_preset?, settings?, timelines:[{name, fps?, settings?, markers?}], hooks?}`.
+  Note: `apply_spec` reconciles the **currently open or already-existing** project;
+  creating a brand-new project from a spec depends on Resolve's `CreateProject`
+  succeeding (it can return None when an unsaved project blocks the switch).
+
 Safe project actions require `_mcp_` names and temp paths by default. Database
 switching dry-runs by default because Resolve closes open projects when
 switching databases. Archive source media/cache/proxy flags are rejected unless
@@ -584,8 +604,10 @@ Key actions:
   `initiator`, `thumbnail_path`, and `drt_export_path` (set when the version
   was retention-collapsed to disk).
 - `diff_versions(timeline_name, from_version, to_version)` — structural diff
-  between two snapshots: `{added, removed, moved}` lists of clips by
-  media_pool_item_id and timeline position.
+  between two snapshots: `{added, removed, moved, trimmed, summary}`. `trimmed`
+  lists clips kept in place but re-trimmed (carries `out_frame_before`); `summary`
+  has per-bucket counts plus `before_clip_count`/`after_clip_count`. Clips are
+  keyed by media_pool_item_id and timeline position.
 - `get_history(timeline_name?, analysis_run_id?, limit?)` — brain-edit rows
   with `edit_type`, `target_metric`, `before_value`, `after_value`, `delta`,
   `rationale`, and `initiator`. Filter by timeline or run; defaults to 50.
@@ -674,6 +696,11 @@ Key actions:
 - `get_track_count(track_type)` — track_type: `"video"`, `"audio"`, `"subtitle"`
 - `add_track(track_type, sub_type?)` / `delete_track(track_type, index)`
 - `get_items(track_type, index)` — items on a track
+- `clip_where(track_type?, track_index?, name_contains?, duration_lt?, duration_gt?)` —
+  (v2.28.0+) return clips on the current timeline matching named filters (AND),
+  instead of walking tracks by hand. Filters may be passed inline or as a
+  `filters` dict; a mistyped filter name is rejected rather than silently
+  matching everything. Returns `{clips, match_count, total_clips}`.
 - `delete_clips(clip_ids, ripple?)` — IDs are unique IDs from `get_items`
 - `duplicate_clips(clip_ids?, selected?, target_track_index?, track_offset?, placement?, record_frame?, record_frame_offset?, copy_properties?, include_linked?)` —
   duplicate existing video timeline items by re-appending the same Media Pool

--- a/install.py
+++ b/install.py
@@ -35,7 +35,7 @@ from src.utils.update_check import (
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.27.2"
+VERSION = "2.28.0"
 # Only hard floor: mcp[cli] requires Python 3.10+. There is no upper bound —
 # Resolve's scripting bridge loads into newer interpreters on recent builds
 # (Python 3.14 verified against Resolve Studio 20.3.2). Older Resolve builds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.27.2",
+  "version": "2.28.0",
   "description": "NPM bootstrapper for the DaVinci Resolve MCP Server.",
   "license": "MIT",
   "author": "Samuel Gursky <samgursky@gmail.com>",

--- a/src/analysis_dashboard.py
+++ b/src/analysis_dashboard.py
@@ -13481,6 +13481,25 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/api/timeline_versions":
             self._json(list_timelines_with_versions(self.state.project_root))
             return
+        if path == "/api/timeline_versions/diff":
+            timeline_name = (query.get("timeline_name") or [""])[0]
+            try:
+                from_version = int((query.get("from_version") or [""])[0])
+                to_version = int((query.get("to_version") or [""])[0])
+            except (ValueError, TypeError):
+                self._json({"success": False, "error": "from_version and to_version (ints) required"},
+                           HTTPStatus.BAD_REQUEST)
+                return
+            if not timeline_name:
+                self._json({"success": False, "error": "timeline_name required"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json({"success": True, **_timeline_versioning.diff_versions(
+                project_root=self.state.project_root,
+                timeline_name=timeline_name,
+                from_version=from_version,
+                to_version=to_version,
+            )})
+            return
         if path.startswith("/api/timeline_versions/"):
             timeline_name = unquote(path[len("/api/timeline_versions/"):])
             if not timeline_name:

--- a/src/batch_cli.py
+++ b/src/batch_cli.py
@@ -318,6 +318,65 @@ def _cmd_cancel(args: argparse.Namespace) -> int:
     return EXIT_OK if payload.get("success") else EXIT_FATAL
 
 
+def _run_spec_action(action: str, params: Dict[str, Any]):
+    """Connect to Resolve (auto-launch) and run a project_manager spec action.
+
+    Imported lazily so the analysis commands stay free of the MCP/Resolve import.
+    """
+    from src.server import get_resolve, _spec_action  # lazy: pulls mcp + resolve
+
+    r = get_resolve()
+    if r is None:
+        return None
+    return _spec_action(r, r.GetProjectManager(), action, params)
+
+
+def _emit_spec_result(result, *, json_mode: bool) -> int:
+    if result is None:
+        _emit("Could not connect to DaVinci Resolve.",
+              json_mode=json_mode,
+              payload={"success": False, "error": "not_connected"})
+        return EXIT_FATAL
+    if json_mode:
+        _emit("", json_mode=True, payload=result)
+    err = result.get("error")
+    if err:
+        _emit(f"Spec error: {err.get('message')}", json_mode=False)
+        return EXIT_FATAL
+    if "actions" in result:  # plan / diff
+        changed = result.get("change_count", 0)
+        _emit(f"Project   : {result.get('project')}", json_mode=False)
+        _emit(f"Changes   : {changed}", json_mode=False)
+        for a in result.get("actions", []):
+            if a.get("op") != "noop":
+                _emit(f"  [{a['op']:>6}] {a['target']}  {a.get('detail', '')}", json_mode=False)
+        return EXIT_OK
+    # apply
+    failures = result.get("failures") or []
+    _emit(f"Applied   : {result.get('applied_count', 0)}", json_mode=False)
+    if failures:
+        for f in failures:
+            _emit(f"  [failed] {f.get('target')}", json_mode=False)
+        return EXIT_PARTIAL
+    _emit("Done: spec applied", json_mode=False)
+    return EXIT_OK
+
+
+def _cmd_plan_spec(args: argparse.Namespace) -> int:
+    result = _run_spec_action("diff_to_spec", {"spec_path": args.spec})
+    return _emit_spec_result(result, json_mode=args.json)
+
+
+def _cmd_apply(args: argparse.Namespace) -> int:
+    result = _run_spec_action("apply_spec", {
+        "spec_path": args.spec,
+        "dry_run": args.dry_run,
+        "run_hooks": args.run_hooks,
+        "continue_on_error": args.continue_on_error,
+    })
+    return _emit_spec_result(result, json_mode=args.json)
+
+
 def _add_run_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("paths", nargs="+", help="Files or directories to analyze")
     parser.add_argument(
@@ -431,6 +490,26 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cancel.add_argument("job_id")
     p_cancel.add_argument("--project-root", required=True)
 
+    p_plan_spec = sub.add_parser(
+        "plan-spec",
+        help="Preview drift between a declarative project spec and live Resolve",
+        parents=[common],
+    )
+    p_plan_spec.add_argument("spec", help="Path to project.dvr.yaml (or .json)")
+
+    p_apply = sub.add_parser(
+        "apply",
+        help="Reconcile the Resolve project toward a declarative spec (idempotent)",
+        parents=[common],
+    )
+    p_apply.add_argument("spec", help="Path to project.dvr.yaml (or .json)")
+    p_apply.add_argument("--dry-run", action="store_true",
+                         help="Compute the plan without mutating")
+    p_apply.add_argument("--run-hooks", action="store_true",
+                         help="Execute the spec's before/after shell hooks (opt-in)")
+    p_apply.add_argument("--continue-on-error", action="store_true",
+                         help="Accumulate failures instead of aborting on the first")
+
     return parser
 
 
@@ -441,6 +520,8 @@ _HANDLERS = {
     "list": _cmd_list,
     "resume": _cmd_resume,
     "cancel": _cmd_cancel,
+    "plan-spec": _cmd_plan_spec,
+    "apply": _cmd_apply,
 }
 
 

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -80,7 +80,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.27.2"
+VERSION = "2.28.0"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 329-tool granular server instead
 """
 
-VERSION = "2.27.2"
+VERSION = "2.28.0"
 
 import base64
 import os
@@ -104,6 +104,9 @@ from src.utils import analysis_runs as _analysis_runs
 from src.utils import brain_edits as _brain_edits
 from src.utils import media_pool_changes as _media_pool_changes
 from src.utils import timeline_versioning as _timeline_versioning
+from src.utils import project_spec as _project_spec
+from src.utils import project_lint as _project_lint
+from src.utils import clip_query as _clip_query
 from src.utils import destructive_hook as _destructive_hook
 from src.utils.destructive_hook import destructive_op as _destructive_op
 
@@ -774,7 +777,7 @@ _RETRYABLE_UNSET = object()
 
 
 def _err(message, *, code=None, category=None, retryable=_RETRYABLE_UNSET,
-         remediation=None, reason=None):
+         remediation=None, reason=None, state=None):
     """Return a structured error envelope.
 
     Callers may pass just a message string for back-compat with the legacy shape;
@@ -787,9 +790,15 @@ def _err(message, *, code=None, category=None, retryable=_RETRYABLE_UNSET,
         - Pass True/False explicitly to override the default (rare; usually the
           default is correct).
 
+    `state`:
+        - Optional dict snapshot of the relevant values at failure time
+          (e.g. {"queue_size": 0, "format": "mov"}). Machine-readable context so
+          the agent doesn't have to parse `reason` prose. Omitted when empty.
+
     Shape:
         {"error": {"message": str, "code": str, "category": str,
-                   "retryable": bool, "reason": str?, "remediation": str?}}
+                   "retryable": bool, "reason": str?, "remediation": str?,
+                   "state": dict?}}
     """
     cat = category if category in ERROR_CATEGORIES else "resolve_api_failed"
     if retryable is _RETRYABLE_UNSET:
@@ -806,6 +815,8 @@ def _err(message, *, code=None, category=None, retryable=_RETRYABLE_UNSET,
         body["reason"] = str(reason)
     if remediation:
         body["remediation"] = str(remediation)
+    if state:
+        body["state"] = state
     return {"error": body}
 
 def _ok(**kw):
@@ -2049,6 +2060,57 @@ def _timeline_item_summary(item, track_info=None):
         "media_pool_item_name": _safe_media_pool_item_name(media_pool_item),
     }
     return summary
+
+
+# Filters the live timeline adapter can populate from a timeline-item summary.
+# Analysis-aware filters in clip_query (analyzed/has_transcription/shot_type/
+# marker_color) require an analysis-DB join not yet wired here; reject them at
+# the boundary rather than return silently-wrong (empty) matches.
+_LIVE_CLIP_WHERE_FILTERS = {
+    "track_type", "track_index", "name_contains", "duration_lt", "duration_gt",
+}
+
+
+def _timeline_clip_where(tl, p: Dict[str, Any]) -> Dict[str, Any]:
+    """clip_where action: return timeline clips matching named filters (AND).
+
+    Filters may be passed as a `filters` dict or as top-level params. Only the
+    structural filters in `_LIVE_CLIP_WHERE_FILTERS` are supported live.
+    """
+    filters = p.get("filters")
+    if not isinstance(filters, dict):
+        # Top-level convenience: treat every param as a filter and validate it,
+        # so a typo'd key is rejected rather than silently matching everything.
+        filters = {k: v for k, v in p.items() if k != "filters"}
+    ok, unknown = _clip_query.validate_filters(filters)
+    if not ok:
+        return _err(
+            f"Unknown clip_where filter(s): {unknown}",
+            code="UNKNOWN_FILTER", category="invalid_input",
+            state={"unknown": unknown, "supported": sorted(_clip_query.SUPPORTED_FILTERS)},
+        )
+    not_live = [k for k in filters if k not in _LIVE_CLIP_WHERE_FILTERS]
+    if not_live:
+        return _err(
+            f"Filter(s) not yet supported on a live timeline: {not_live}",
+            code="FILTER_NOT_LIVE", category="unsupported",
+            remediation="Use structural filters (track_type, track_index, name_contains, duration_lt, duration_gt).",
+            state={"not_live": not_live, "live_supported": sorted(_LIVE_CLIP_WHERE_FILTERS)},
+        )
+    clips: List[Dict[str, Any]] = []
+    for tt in ("video", "audio", "subtitle"):
+        try:
+            count = int(tl.GetTrackCount(tt) or 0)
+        except Exception:
+            continue
+        for ti in range(1, count + 1):
+            for item in (tl.GetItemListInTrack(tt, ti) or []):
+                summary = _timeline_item_summary(item, (tt, ti))
+                if summary:
+                    clips.append(summary)
+    matches = _clip_query.filter_clips(clips, filters)
+    return _ok(filters=filters, match_count=len(matches),
+               total_clips=len(clips), clips=matches)
 
 
 def _serialize_appended_timeline_item(item, index: int, *, allow_empty_timeline_item_id: bool = False):
@@ -11766,6 +11828,252 @@ def _project_boundary_report(resolve_obj, pm, project, p: Dict[str, Any]) -> Dic
     }
 
 
+def _find_project_timeline(project, name: str):
+    """Return the timeline named `name` in `project`, or None."""
+    try:
+        count = int(project.GetTimelineCount() or 0)
+    except Exception:
+        return None
+    for i in range(1, count + 1):
+        tl = project.GetTimelineByIndex(i)
+        try:
+            if tl and tl.GetName() == name:
+                return tl
+        except Exception:
+            continue
+    return None
+
+
+class _SpecLiveExecutor:
+    """Live executor for project_spec.apply_spec — adapts a Resolve project to
+    the duck-typed executor contract. Spec-aware so live_state() only reads the
+    setting keys the spec cares about."""
+
+    def __init__(self, r, pm, spec):
+        self._r = r
+        self._pm = pm
+        self._spec = spec
+        self._proj = pm.GetCurrentProject()
+
+    def live_state(self) -> Dict[str, Any]:
+        proj = self._proj
+        projects = list(self._pm.GetProjectListInCurrentFolder() or [])
+        settings: Dict[str, Any] = {}
+        if proj:
+            for k in _project_spec.effective_settings(self._spec):
+                try:
+                    v = proj.GetSetting(k)
+                except Exception:
+                    v = None
+                if v is not None:
+                    settings[k] = v
+        spec_names = {t.name for t in self._spec.timelines}
+        timelines: List[Dict[str, Any]] = []
+        if proj:
+            count = int(proj.GetTimelineCount() or 0)
+            for i in range(1, count + 1):
+                tl = proj.GetTimelineByIndex(i)
+                if not tl:
+                    continue
+                name = tl.GetName()
+                if name not in spec_names:
+                    timelines.append({"name": name})
+                    continue
+                tspec = next((t for t in self._spec.timelines if t.name == name), None)
+                keys = set((tspec.settings if tspec else {})) | {"timelineFrameRate"}
+                tl_settings: Dict[str, Any] = {}
+                for k in keys:
+                    try:
+                        v = tl.GetSetting(k)
+                    except Exception:
+                        v = None
+                    if v is not None:
+                        tl_settings[k] = v
+                markers: List[Dict[str, Any]] = []
+                try:
+                    for frame, m in (tl.GetMarkers() or {}).items():
+                        entry = {"frame": int(frame)}
+                        if isinstance(m, dict):
+                            entry.update({kk: m.get(kk) for kk in
+                                          ("color", "name", "note", "duration", "customData")})
+                        markers.append(entry)
+                except Exception:
+                    pass
+                timelines.append({"name": name, "settings": tl_settings, "markers": markers})
+        return {
+            "project": proj.GetName() if proj else None,
+            "projects": projects,
+            "settings": settings,
+            "timelines": timelines,
+        }
+
+    def ensure_project(self, name: str) -> bool:
+        if self._proj and self._proj.GetName() == name:
+            return True
+        projects = list(self._pm.GetProjectListInCurrentFolder() or [])
+        proj = self._pm.LoadProject(name) if name in projects else self._pm.CreateProject(name)
+        if proj:
+            self._proj = proj
+            return True
+        return False
+
+    def set_project_setting(self, key: str, value: Any) -> bool:
+        if not self._proj:
+            return False
+        try:
+            return bool(self._proj.SetSetting(key, str(value)))
+        except Exception:
+            return False
+
+    def ensure_timeline(self, name: str, fps: Optional[float]) -> bool:
+        if not self._proj:
+            return False
+        tl = _find_project_timeline(self._proj, name)
+        if tl is None:
+            mp = self._proj.GetMediaPool()
+            if mp is None:
+                return False
+            tl = mp.CreateEmptyTimeline(name)
+            if tl is None:
+                return False
+        if fps is not None:
+            try:
+                tl.SetSetting("timelineFrameRate", str(fps))
+            except Exception:
+                pass
+        return True
+
+    def set_timeline_setting(self, tl_name: str, key: str, value: Any) -> bool:
+        tl = _find_project_timeline(self._proj, tl_name) if self._proj else None
+        if tl is None:
+            return False
+        try:
+            return bool(tl.SetSetting(key, str(value)))
+        except Exception:
+            return False
+
+    def add_marker(self, tl_name: str, marker: Dict[str, Any]) -> bool:
+        tl = _find_project_timeline(self._proj, tl_name) if self._proj else None
+        if tl is None:
+            return False
+        try:
+            return bool(tl.AddMarker(
+                int(marker.get("frame", 0)),
+                marker.get("color", "Blue"),
+                marker.get("name", ""),
+                marker.get("note", ""),
+                int(marker.get("duration", 1)),
+                marker.get("customData", marker.get("custom_data", "")),
+            ))
+        except Exception:
+            return False
+
+
+def _make_spec_hook_runner(timeout: float = 120.0):
+    """Return a callable that runs a Hook's shell command (opt-in only)."""
+    import subprocess
+
+    def _run(hook) -> bool:
+        try:
+            proc = subprocess.run(hook.command, shell=True, timeout=timeout)
+            return proc.returncode == 0
+        except Exception as exc:
+            logger.warning("spec hook '%s' failed: %s", hook.name or hook.command, exc)
+            return False
+
+    return _run
+
+
+def _spec_action(r, pm, action: str, p: Dict[str, Any]) -> Dict[str, Any]:
+    """plan_spec / apply_spec / diff_to_spec — declarative project reconcile."""
+    spec_path = p.get("spec_path") or p.get("path")
+    try:
+        if spec_path:
+            spec = _project_spec.load_spec(str(spec_path))
+        elif isinstance(p.get("spec"), dict):
+            spec = _project_spec.spec_from_dict(p["spec"])
+        else:
+            return _err("Provide spec_path (file) or an inline spec dict.",
+                        code="NO_SPEC", category="invalid_input")
+    except _project_spec.SpecError as exc:
+        return _err(str(exc), code="SPEC_INVALID", category="invalid_input", state=exc.state)
+
+    executor = _SpecLiveExecutor(r, pm, spec)
+    if action == "diff_to_spec":
+        return _ok(project=spec.project, **_project_spec.plan_spec(spec, executor.live_state()))
+    if action == "plan_spec":
+        return _ok(project=spec.project,
+                   **_project_spec.apply_spec(spec, executor, dry_run=True))
+    # apply_spec
+    run_hooks = bool(p.get("run_hooks", False))
+    try:
+        result = _project_spec.apply_spec(
+            spec, executor,
+            dry_run=bool(p.get("dry_run", False)),
+            run_hooks=run_hooks,
+            continue_on_error=bool(p.get("continue_on_error", False)),
+            run_hook=_make_spec_hook_runner() if run_hooks else None,
+        )
+    except _project_spec.SpecError as exc:
+        return _err(str(exc), code="SPEC_APPLY_FAILED",
+                    category="batch_partial", state=exc.state)
+    return _ok(**result) if result.get("success") else {"success": False, **result}
+
+
+def _project_lint_live(r, pm) -> Dict[str, Any]:
+    """Gather live project state and run the lint health-check."""
+    proj = pm.GetCurrentProject()
+    if not proj:
+        return _ok(**_project_lint.lint_report({"project": None}))
+    state: Dict[str, Any] = {"project": proj.GetName()}
+    try:
+        cur = proj.GetCurrentTimeline()
+        state["current_timeline"] = cur.GetName() if cur else None
+    except Exception:
+        state["current_timeline"] = None
+    timelines: List[Dict[str, Any]] = []
+    try:
+        count = int(proj.GetTimelineCount() or 0)
+    except Exception:
+        count = 0
+    for i in range(1, count + 1):
+        tl = proj.GetTimelineByIndex(i)
+        if not tl:
+            continue
+        fps = None
+        try:
+            fps = float(tl.GetSetting("timelineFrameRate"))
+        except Exception:
+            pass
+        item_count = 0
+        try:
+            vc = int(tl.GetTrackCount("video") or 0)
+            for ti in range(1, vc + 1):
+                item_count += len(tl.GetItemListInTrack("video", ti) or [])
+        except Exception:
+            pass
+        timelines.append({"name": tl.GetName(), "fps": fps, "item_count": item_count})
+    state["timelines"] = timelines
+    settings: Dict[str, Any] = {}
+    try:
+        csm = proj.GetSetting("colorScienceMode")
+        if csm is not None:
+            settings["colorScienceMode"] = csm
+    except Exception:
+        pass
+    state["settings"] = settings
+    render: Dict[str, Any] = {}
+    try:
+        rf = proj.GetCurrentRenderFormatAndCodec() or {}
+        if rf.get("format"):
+            render["format"] = rf.get("format")
+        render["codec"] = rf.get("codec")
+    except Exception:
+        pass
+    state["render"] = render
+    return _ok(**_project_lint.lint_report(state))
+
+
 @mcp.tool()
 def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Manage DaVinci Resolve projects.
@@ -11797,6 +12105,16 @@ def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
       safe_set_current_database(db_info, dry_run?, allow_switch?) -> {success}
       preset_lifecycle_probe() -> {project_presets, render_presets, layout_presets, ...}
       project_boundary_report() -> {capabilities, project_manager, settings, database, presets, cloud}
+      lint() -> {ok, counts, issues} — graded project health pre-flight (no project, no
+        current timeline, mixed fps, empty timeline, render/color-science unset, offline media).
+      diff_to_spec(spec_path|spec) -> {actions, diff, change_count} — preview drift vs a
+        declarative spec WITHOUT mutating. Spec is YAML/JSON: {project, color_preset?, settings?,
+        timelines:[{name,fps?,settings?,markers?}], hooks?}.
+      plan_spec(spec_path|spec) -> {dry_run, actions, diff, change_count} — same as apply with dry_run.
+      apply_spec(spec_path|spec, dry_run?, run_hooks?, continue_on_error?) -> {success, applied, failures}
+        Reconcile the project toward the spec (idempotent: re-runs are no-ops). Color/HDR
+        settings are applied in dependency order; markers only added if absent. Hooks run only
+        when run_hooks=true (executes shell from the spec — opt-in).
     """
     p = params or {}
     r = get_resolve()
@@ -11804,6 +12122,10 @@ def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
         return _err("Could not connect to DaVinci Resolve. It was not running and auto-launch failed. Check that Resolve Studio is installed.")
     pm = r.GetProjectManager()
 
+    if action == "lint":
+        return _project_lint_live(r, pm)
+    if action in {"diff_to_spec", "plan_spec", "apply_spec"}:
+        return _spec_action(r, pm, action, p)
     if action == "project_capabilities":
         return _project_capabilities(pm, pm.GetCurrentProject(), r)
     elif action == "probe_project_lifecycle":
@@ -11869,7 +12191,7 @@ def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
             p.get("src_media", True), p.get("render_cache", True), p.get("proxy_media", False)))}
     elif action == "restore":
         return {"success": bool(pm.RestoreProject(p["path"], p.get("name")))}
-    return _unknown(action, ["list","get_current","create","load","save","close","delete","import_project","export_project","archive","restore", *_PROJECT_KERNEL_ACTIONS])
+    return _unknown(action, ["list","get_current","create","load","save","close","delete","import_project","export_project","archive","restore","lint","diff_to_spec","plan_spec","apply_spec", *_PROJECT_KERNEL_ACTIONS])
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -14261,6 +14583,10 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       get_track_name(track_type, index) -> {name}
       set_track_name(track_type, index, name) -> {success}
       get_items(track_type, index) -> {items}
+      clip_where(filters|track_type?, track_index?, name_contains?, duration_lt?, duration_gt?) -> {clips, match_count, total_clips}
+        Find clips on the current timeline matching named filters (AND). Pass filters
+        inline or as a `filters` dict. Live filters: track_type, track_index,
+        name_contains, duration_lt, duration_gt (frames). No clip enumeration needed.
       delete_clips(clip_ids, ripple?) -> {success}  — clip_ids: list of unique IDs
         DESTRUCTIVE. ripple=True is CATASTROPHIC (closes the gap; cannot be selectively undone).
       set_clips_linked(clip_ids, linked) -> {success}
@@ -14402,6 +14728,8 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     if not tl:
         return _err("No current timeline")
 
+    if action == "clip_where":
+        return _timeline_clip_where(tl, p)
     if action == "get_current":
         return {"name": tl.GetName(), "id": tl.GetUniqueId(), "start_frame": tl.GetStartFrame(), "end_frame": tl.GetEndFrame(), "start_timecode": tl.GetStartTimecode()}
     elif action == "get_name":

--- a/src/utils/clip_query.py
+++ b/src/utils/clip_query.py
@@ -1,0 +1,85 @@
+"""Safe declarative clip-query DSL.
+
+The agent-facing way to ask "which clips match X?" without enumerating a whole
+timeline call-by-call. Named filters only — no arbitrary lambdas/code cross the
+tool boundary (the brain gets a closed vocabulary, not `eval`).
+
+Pure: `filter_clips` takes a list of plain clip dicts + a filter dict and returns
+the matching subset. The live MCP adapter gathers clip dicts from the timeline
+and calls this.
+
+Each clip dict is expected to carry (best-effort; missing keys are tolerated):
+    name, track_type, track_index, duration (frames), in_frame, out_frame,
+    clip_id / media_pool_item_id, clip_hash, marker_color, analyzed (bool),
+    has_transcription (bool), shot_type (str).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+# Supported filter keys and a one-line description (also used to validate input
+# and to document the surface in the tool docstring).
+SUPPORTED_FILTERS: Dict[str, str] = {
+    "track_type": "exact match: 'video' | 'audio' | 'subtitle'",
+    "track_index": "exact 1-based track index",
+    "name_contains": "case-insensitive substring of the clip name",
+    "duration_lt": "duration (frames) strictly less than",
+    "duration_gt": "duration (frames) strictly greater than",
+    "marker_color": "exact clip marker/flag color",
+    "shot_type": "exact analyzed shot_type",
+    "analyzed": "bool — clip has an analysis record",
+    "has_transcription": "bool — clip has transcription",
+}
+
+
+def validate_filters(filters: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """Return (ok, unknown_keys). Unknown filter keys are rejected, not ignored,
+    so a typo never silently widens the match set."""
+    unknown = [k for k in filters if k not in SUPPORTED_FILTERS]
+    return (not unknown, unknown)
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _matches(clip: Dict[str, Any], filters: Dict[str, Any]) -> bool:
+    if "track_type" in filters and clip.get("track_type") != filters["track_type"]:
+        return False
+    if "track_index" in filters and clip.get("track_index") != int(filters["track_index"]):
+        return False
+    if "name_contains" in filters:
+        needle = str(filters["name_contains"]).lower()
+        if needle not in str(clip.get("name") or "").lower():
+            return False
+    dur = clip.get("duration")
+    if "duration_lt" in filters:
+        if dur is None or not (dur < float(filters["duration_lt"])):
+            return False
+    if "duration_gt" in filters:
+        if dur is None or not (dur > float(filters["duration_gt"])):
+            return False
+    if "marker_color" in filters and clip.get("marker_color") != filters["marker_color"]:
+        return False
+    if "shot_type" in filters and clip.get("shot_type") != filters["shot_type"]:
+        return False
+    if "analyzed" in filters and bool(clip.get("analyzed")) != _as_bool(filters["analyzed"]):
+        return False
+    if "has_transcription" in filters and bool(clip.get("has_transcription")) != _as_bool(
+        filters["has_transcription"]
+    ):
+        return False
+    return True
+
+
+def filter_clips(clips: List[Dict[str, Any]], filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return the subset of `clips` matching every supplied filter (AND semantics).
+
+    Empty/None filter values are skipped so callers can pass a sparse dict.
+    """
+    active = {k: v for k, v in (filters or {}).items() if v is not None and v != ""}
+    return [c for c in clips if _matches(c, active)]

--- a/src/utils/project_lint.py
+++ b/src/utils/project_lint.py
@@ -1,0 +1,122 @@
+"""Project health lint — a graded pre-flight the brain runs before editing.
+
+Composes a plain *state* dict (gathered live by the MCP adapter from existing
+probes) into a list of graded `Issue`s. Pure and Resolve-free so it unit-tests
+against hand-built state.
+
+The state dict shape (all keys optional; absence is itself a signal):
+    {
+      "project": str | None,
+      "current_timeline": str | None,
+      "timelines": [{"name": str, "fps": float|None, "item_count": int}, ...],
+      "settings": {<key>: <value>},          # project settings
+      "render": {"format": str|None, "codec": str|None},
+      "offline_media_count": int,             # clips referencing missing files
+      "unanalyzed_clip_count": int,           # media-pool clips w/o analysis record
+    }
+
+Inspired by the MIT `mhadifilms/dvr` `lint.py` check set; extended with our
+analysis-aware checks (offline media, unanalyzed clips).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+SEVERITIES = ("error", "warning", "info")
+
+
+@dataclass
+class Issue:
+    severity: str   # error | warning | info
+    code: str
+    message: str
+    target: str = ""
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        out = {"severity": self.severity, "code": self.code, "message": self.message}
+        if self.target:
+            out["target"] = self.target
+        if self.detail:
+            out["detail"] = self.detail
+        return out
+
+
+def _color_science_unset(settings: Dict[str, Any]) -> bool:
+    # Resolve reports "davinciYRGB" (managed off) when color science is the
+    # default; ACES / managed modes set a different colorScienceMode.
+    mode = str(settings.get("colorScienceMode", "")).strip()
+    return mode in ("", "davinciYRGB")
+
+
+def lint_state(state: Dict[str, Any]) -> List[Issue]:
+    """Return graded issues for a project state dict, most-severe first."""
+    issues: List[Issue] = []
+    state = state or {}
+
+    if not state.get("project"):
+        issues.append(Issue("error", "no_project", "No project is open."))
+        return issues  # nothing else is meaningful without a project
+
+    timelines = state.get("timelines") or []
+    if not state.get("current_timeline"):
+        issues.append(Issue("warning", "no_current_timeline", "No timeline is active."))
+
+    # mixed fps across timelines — a common conform foot-gun
+    fps_values = {tl.get("fps") for tl in timelines if tl.get("fps") is not None}
+    if len(fps_values) > 1:
+        issues.append(Issue(
+            "info", "mixed_fps",
+            f"Timelines use {len(fps_values)} different frame rates.",
+            detail=", ".join(str(f) for f in sorted(fps_values)),
+        ))
+
+    for tl in timelines:
+        if (tl.get("item_count") or 0) == 0:
+            issues.append(Issue(
+                "warning", "empty_timeline",
+                f"Timeline '{tl.get('name')}' has no clips.",
+                target=tl.get("name", ""),
+            ))
+
+    render = state.get("render") or {}
+    if not render.get("format"):
+        issues.append(Issue("info", "render_format_unset", "No render format is set."))
+
+    settings = state.get("settings") or {}
+    if _color_science_unset(settings):
+        issues.append(Issue(
+            "info", "color_science_unset",
+            "Color science is unmanaged (DaVinci YRGB).",
+            detail="Set a managed/ACES mode if a color-managed pipeline is expected.",
+        ))
+
+    offline = int(state.get("offline_media_count") or 0)
+    if offline > 0:
+        issues.append(Issue(
+            "error", "offline_media",
+            f"{offline} clip(s) reference offline/missing media.",
+        ))
+
+    unanalyzed = int(state.get("unanalyzed_clip_count") or 0)
+    if unanalyzed > 0:
+        issues.append(Issue(
+            "info", "unanalyzed_clips",
+            f"{unanalyzed} media-pool clip(s) have no analysis record.",
+        ))
+
+    order = {"error": 0, "warning": 1, "info": 2}
+    issues.sort(key=lambda i: order.get(i.severity, 9))
+    return issues
+
+
+def lint_report(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Graded report envelope: counts + ok flag + serialized issues."""
+    issues = lint_state(state)
+    counts = {sev: sum(1 for i in issues if i.severity == sev) for sev in SEVERITIES}
+    return {
+        "ok": counts["error"] == 0,
+        "counts": counts,
+        "issues": [i.to_dict() for i in issues],
+    }

--- a/src/utils/project_spec.py
+++ b/src/utils/project_spec.py
@@ -1,0 +1,428 @@
+"""Declarative project spec — "kubectl apply" for a Resolve project.
+
+A `project.dvr.yaml` (or .json) describes the *desired* project: settings, color
+preset, timelines, markers, and optional before/after hooks. `plan_spec` diffs
+the desired state against live state and emits an ordered `Action` list **without
+mutating**; `apply_spec` executes that plan through an injected executor.
+
+Separation of concerns so it unit-tests without Resolve:
+  - load_spec / validation / plan_spec  → pure (dicts + dataclasses)
+  - apply_spec                          → orchestrator over an injected executor
+                                          (the server provides a live executor;
+                                          tests provide a fake one)
+
+Structure adapted from the MIT-licensed `mhadifilms/dvr` `spec.py`/`apply`:
+SETTINGS_ORDER (color framework before dependent keys), preset-merge (explicit
+settings override the named preset), marker idempotency, and error accumulation.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from src.utils import structural_diff
+
+
+# ── Color presets ────────────────────────────────────────────────────────────
+# Minimal, real starting set. Explicit `settings:` in the spec override these.
+COLOR_PRESETS: Dict[str, Dict[str, str]] = {
+    "rec709_gamma24": {
+        "colorScienceMode": "davinciYRGBColorManagedv2",
+        "colorSpaceTimeline": "Rec.709 (Scene)",
+        "colorSpaceOutput": "Rec.709 Gamma 2.4",
+    },
+    "rec2020_pq_4000": {
+        "colorScienceMode": "davinciYRGBColorManagedv2",
+        "colorSpaceTimeline": "Rec.2020",
+        "colorSpaceOutput": "Rec.2020 ST2084 (4000 nits)",
+        "hdrMasteringLuminanceMax": "4000",
+    },
+    "aces_cct": {
+        "colorScienceMode": "acescct",
+        "colorAcesIDT": "ACES",
+        "colorAcesODT": "Rec.709",
+    },
+}
+
+# Keys applied first (in this relative order) so the color framework is enabled
+# before dependent input/output/HDR keys. Everything not listed is applied after.
+SETTINGS_ORDER: List[str] = [
+    "colorScienceMode",
+    "rcmPresetMode",
+    "colorVersion",
+    "colorAcesIDT",
+    "colorAcesNodeLUTProcessingSpace",
+    "colorAcesODT",
+    "colorSpaceInput",
+    "colorSpaceTimeline",
+    "colorSpaceOutput",
+    "hdrMasteringLuminanceMax",
+]
+
+
+# ── Dataclasses ──────────────────────────────────────────────────────────────
+@dataclass
+class TimelineSpec:
+    name: str
+    fps: Optional[float] = None
+    settings: Dict[str, str] = field(default_factory=dict)
+    markers: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class Hook:
+    when: str          # "before" | "after"
+    command: str
+    name: str = ""
+
+
+@dataclass
+class Spec:
+    project: str
+    color_preset: Optional[str] = None
+    settings: Dict[str, str] = field(default_factory=dict)
+    timelines: List[TimelineSpec] = field(default_factory=list)
+    hooks: List[Hook] = field(default_factory=list)
+
+
+@dataclass
+class Action:
+    op: str            # create | ensure | set | noop
+    target: str        # "project:Show", "timeline:Edit_v2/setting:timelineFrameRate", ...
+    detail: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"op": self.op, "target": self.target, "detail": self.detail, "payload": self.payload}
+
+
+class SpecError(Exception):
+    """Raised on malformed spec or accumulated apply failures.
+
+    Carries `state` so the server can surface it in the structured error envelope.
+    """
+
+    def __init__(self, message: str, *, state: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.message = message
+        self.state = state or {}
+
+
+# ── Loading & validation ─────────────────────────────────────────────────────
+def _parse_hooks(raw: Any) -> List[Hook]:
+    hooks: List[Hook] = []
+    if not raw:
+        return hooks
+    for when in ("before", "after"):
+        for entry in (raw.get(when) or []) if isinstance(raw, dict) else []:
+            if isinstance(entry, str):
+                hooks.append(Hook(when=when, command=entry))
+            elif isinstance(entry, dict) and entry.get("command"):
+                hooks.append(Hook(when=when, command=str(entry["command"]), name=str(entry.get("name", ""))))
+            else:
+                raise SpecError(f"Invalid {when}-hook entry: {entry!r}")
+    return hooks
+
+
+def spec_from_dict(data: Dict[str, Any]) -> Spec:
+    """Validate a plain dict into a `Spec`. Raises `SpecError` on bad shape."""
+    if not isinstance(data, dict):
+        raise SpecError("Spec must be a mapping at the top level.")
+    project = data.get("project")
+    if not project or not isinstance(project, str):
+        raise SpecError("Spec requires a non-empty string `project`.", state={"got": data.get("project")})
+
+    preset = data.get("color_preset")
+    if preset is not None and preset not in COLOR_PRESETS:
+        raise SpecError(
+            f"Unknown color_preset '{preset}'.",
+            state={"known_presets": sorted(COLOR_PRESETS)},
+        )
+
+    settings = data.get("settings") or {}
+    if not isinstance(settings, dict):
+        raise SpecError("`settings` must be a mapping.")
+
+    timelines: List[TimelineSpec] = []
+    for raw_tl in (data.get("timelines") or []):
+        if not isinstance(raw_tl, dict) or not raw_tl.get("name"):
+            raise SpecError(f"Each timeline needs a `name`: {raw_tl!r}")
+        timelines.append(TimelineSpec(
+            name=str(raw_tl["name"]),
+            fps=float(raw_tl["fps"]) if raw_tl.get("fps") is not None else None,
+            settings=dict(raw_tl.get("settings") or {}),
+            markers=list(raw_tl.get("markers") or []),
+        ))
+
+    return Spec(
+        project=str(project),
+        color_preset=preset,
+        settings={str(k): str(v) for k, v in settings.items()},
+        timelines=timelines,
+        hooks=_parse_hooks(data.get("hooks")),
+    )
+
+
+def load_spec(path: str) -> Spec:
+    """Load a spec from a YAML or JSON file. YAML needs PyYAML; JSON always works."""
+    if not os.path.isfile(path):
+        raise SpecError(f"Spec file not found: {path}", state={"path": path})
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    data: Any
+    if path.endswith((".yaml", ".yml")):
+        try:
+            import yaml  # type: ignore
+        except ImportError as exc:  # pragma: no cover - env-dependent
+            raise SpecError(
+                "PyYAML is required to load .yaml specs (pip install pyyaml), "
+                "or provide the spec as .json.",
+                state={"path": path},
+            ) from exc
+        data = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    return spec_from_dict(data)
+
+
+# ── Effective settings (preset merge + ordering) ─────────────────────────────
+def effective_settings(spec: Spec) -> "Dict[str, str]":
+    """Preset settings overlaid by explicit spec.settings (explicit wins)."""
+    merged: Dict[str, str] = {}
+    if spec.color_preset:
+        merged.update(COLOR_PRESETS[spec.color_preset])
+    merged.update(spec.settings)
+    return merged
+
+
+def _ordered_setting_keys(keys: List[str]) -> List[str]:
+    head = [k for k in SETTINGS_ORDER if k in keys]
+    tail = sorted(k for k in keys if k not in SETTINGS_ORDER)
+    return head + tail
+
+
+def _norm_setting_value(value: Any) -> str:
+    """Canonicalize a setting value for comparison. Resolve reports numeric
+    settings with float formatting (e.g. timelineFrameRate -> "24.0") even when
+    the spec says "24"; normalize both so reconcile actually converges (and apply
+    is idempotent). Non-numeric values are returned as plain strings."""
+    s = str(value)
+    try:
+        f = float(s)
+    except (TypeError, ValueError):
+        return s
+    return str(int(f)) if f == int(f) else repr(f)
+
+
+def _settings_equal(a: Any, b: Any) -> bool:
+    return _norm_setting_value(a) == _norm_setting_value(b)
+
+
+# ── Plan ─────────────────────────────────────────────────────────────────────
+def plan_spec(spec: Spec, live: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute the ordered action list + a structural diff. PURE — no mutation.
+
+    `live` is the current state:
+        {"project": str|None, "projects": [names],
+         "settings": {k: v},
+         "timelines": [{"name", "fps", "settings": {...}, "markers": [{frame,...}]}]}
+    """
+    live = live or {}
+    actions: List[Action] = []
+
+    # Project
+    known = set(live.get("projects") or [])
+    if spec.project in known or live.get("project") == spec.project:
+        actions.append(Action("noop", f"project:{spec.project}", "exists"))
+    else:
+        actions.append(Action("create", f"project:{spec.project}", "create project"))
+
+    # Project settings (preset-merged, dependency-ordered)
+    live_settings = live.get("settings") or {}
+    desired = effective_settings(spec)
+    for key in _ordered_setting_keys(list(desired)):
+        want = desired[key]
+        if _settings_equal(live_settings.get(key, ""), want):
+            actions.append(Action("noop", f"project:{spec.project}/setting:{key}", "matches"))
+        else:
+            actions.append(Action(
+                "set", f"project:{spec.project}/setting:{key}",
+                f"{live_settings.get(key)!r} -> {want!r}", {"key": key, "value": want},
+            ))
+
+    # Timelines + their settings + markers. NOTE: `fps` is a *creation-time*
+    # property handled by ensure_timeline — Resolve refuses SetSetting on
+    # timelineFrameRate after a timeline exists — so it is never emitted as a
+    # per-timeline `set` action.
+    live_tls = {tl.get("name"): tl for tl in (live.get("timelines") or [])}
+    for tl in spec.timelines:
+        live_tl = live_tls.get(tl.name)
+        if live_tl is None:
+            actions.append(Action("ensure", f"timeline:{tl.name}", "create timeline",
+                                   {"fps": tl.fps}))
+        else:
+            actions.append(Action("noop", f"timeline:{tl.name}", "exists"))
+
+        live_tl_settings = (live_tl or {}).get("settings") or {}
+        for key in _ordered_setting_keys(list(tl.settings)):
+            want = tl.settings[key]
+            if _settings_equal(live_tl_settings.get(key, ""), want):
+                actions.append(Action("noop", f"timeline:{tl.name}/setting:{key}", "matches"))
+            else:
+                actions.append(Action("set", f"timeline:{tl.name}/setting:{key}",
+                                       f"{live_tl_settings.get(key)!r} -> {want!r}",
+                                       {"key": key, "value": want}))
+
+        live_frames = {m.get("frame") for m in ((live_tl or {}).get("markers") or [])}
+        for marker in tl.markers:
+            frame = marker.get("frame")
+            if frame in live_frames:
+                actions.append(Action("noop", f"timeline:{tl.name}/marker:{frame}", "exists"))
+            else:
+                actions.append(Action("set", f"timeline:{tl.name}/marker:{frame}",
+                                       "add marker", {"marker": marker}))
+
+    diff = structural_diff.compare(
+        _spec_normalized_state(live, spec),
+        _spec_desired_state(spec),
+        left_label="live", right_label="spec",
+    )
+    return {
+        "actions": [a.to_dict() for a in actions],
+        "diff": diff.to_dict(),
+        "change_count": sum(1 for a in actions if a.op != "noop"),
+    }
+
+
+def _spec_desired_state(spec: Spec) -> Dict[str, Any]:
+    return {
+        "project": spec.project,
+        "settings": {k: _norm_setting_value(v) for k, v in effective_settings(spec).items()},
+        "timelines": [
+            {
+                "name": tl.name,
+                "settings": {k: _norm_setting_value(v) for k, v in tl.settings.items()},
+                "markers": [{"frame": m.get("frame"), **{k: v for k, v in m.items() if k != "frame"}}
+                            for m in tl.markers],
+            }
+            for tl in spec.timelines
+        ],
+    }
+
+
+def _spec_normalized_state(live: Dict[str, Any], spec: Spec) -> Dict[str, Any]:
+    """Project live state onto only the keys the spec cares about, so the diff
+    reports drift toward the spec rather than every unrelated live setting.
+    Values are normalized so numeric formatting (24 vs 24.0) is not a phantom
+    diff."""
+    desired = effective_settings(spec)
+    live_settings = live.get("settings") or {}
+    spec_tl_names = {tl.name for tl in spec.timelines}
+    live_tls = {tl.get("name"): tl for tl in (live.get("timelines") or [])}
+    return {
+        "project": live.get("project"),
+        "settings": {k: _norm_setting_value(live_settings.get(k)) for k in desired if k in live_settings},
+        "timelines": [
+            {
+                "name": name,
+                "settings": {k: _norm_setting_value((live_tls[name].get("settings") or {}).get(k))
+                             for k in (next((t.settings for t in spec.timelines if t.name == name), {}))
+                             if k in (live_tls[name].get("settings") or {})},
+                "markers": live_tls[name].get("markers") or [],
+            }
+            for name in spec_tl_names if name in live_tls
+        ],
+    }
+
+
+# ── Apply (orchestrator over an injected executor) ───────────────────────────
+def apply_spec(
+    spec: Spec,
+    executor: Any,
+    *,
+    dry_run: bool = False,
+    run_hooks: bool = False,
+    continue_on_error: bool = False,
+    run_hook: Optional[Callable[[Hook], Any]] = None,
+) -> Dict[str, Any]:
+    """Reconcile live state toward `spec` through `executor`.
+
+    `executor` is duck-typed; it must provide:
+        live_state() -> dict
+        ensure_project(name) -> bool
+        set_project_setting(key, value) -> bool
+        ensure_timeline(name, fps) -> bool
+        set_timeline_setting(timeline_name, key, value) -> bool
+        add_marker(timeline_name, marker: dict) -> bool
+
+    Hooks execute only when `run_hooks=True` AND a `run_hook` callable is given —
+    arbitrary shell from a spec stays opt-in. Failures accumulate when
+    `continue_on_error`; otherwise the first failure raises `SpecError`.
+    """
+    live = executor.live_state()
+    plan = plan_spec(spec, live)
+    if dry_run:
+        return {"success": True, "dry_run": True, **plan}
+
+    failures: List[Dict[str, Any]] = []
+    applied: List[Dict[str, Any]] = []
+
+    def _record(ok: bool, target: str, detail: str = "") -> None:
+        entry = {"target": target, "detail": detail}
+        if ok:
+            applied.append(entry)
+        else:
+            failures.append(entry)
+            if not continue_on_error:
+                raise SpecError(
+                    f"apply failed at {target}",
+                    state={"project": spec.project, "failures": failures, "applied": applied},
+                )
+
+    befores = [h for h in spec.hooks if h.when == "before"]
+    afters = [h for h in spec.hooks if h.when == "after"]
+
+    if run_hooks and run_hook:
+        for h in befores:
+            _record(bool(run_hook(h)), f"hook:before:{h.name or h.command}")
+
+    # Project + settings
+    _record(bool(executor.ensure_project(spec.project)), f"project:{spec.project}")
+    desired = effective_settings(spec)
+    for key in _ordered_setting_keys(list(desired)):
+        if _settings_equal((live.get("settings") or {}).get(key, ""), desired[key]):
+            continue
+        _record(bool(executor.set_project_setting(key, desired[key])),
+                f"project:{spec.project}/setting:{key}", str(desired[key]))
+
+    # Timelines. `fps` is creation-time only (ensure_timeline); never set as a
+    # post-creation timelineFrameRate setting — Resolve refuses that.
+    live_tls = {tl.get("name"): tl for tl in (live.get("timelines") or [])}
+    for tl in spec.timelines:
+        _record(bool(executor.ensure_timeline(tl.name, tl.fps)), f"timeline:{tl.name}")
+        live_tl_settings = (live_tls.get(tl.name) or {}).get("settings") or {}
+        for key in _ordered_setting_keys(list(tl.settings)):
+            if _settings_equal(live_tl_settings.get(key, ""), tl.settings[key]):
+                continue
+            _record(bool(executor.set_timeline_setting(tl.name, key, tl.settings[key])),
+                    f"timeline:{tl.name}/setting:{key}", str(tl.settings[key]))
+        live_frames = {m.get("frame") for m in ((live_tls.get(tl.name) or {}).get("markers") or [])}
+        for marker in tl.markers:
+            if marker.get("frame") in live_frames:
+                continue
+            _record(bool(executor.add_marker(tl.name, marker)),
+                    f"timeline:{tl.name}/marker:{marker.get('frame')}")
+
+    if run_hooks and run_hook:
+        for h in afters:
+            _record(bool(run_hook(h)), f"hook:after:{h.name or h.command}")
+
+    return {
+        "success": not failures,
+        "applied_count": len(applied),
+        "applied": applied,
+        "failures": failures,
+        "project": spec.project,
+    }

--- a/src/utils/structural_diff.py
+++ b/src/utils/structural_diff.py
@@ -1,0 +1,175 @@
+"""Structural diff over plain JSON-able state (snapshots, specs).
+
+A general recursive diff that classifies every leaf change as added / removed /
+changed, and — crucially — aligns *lists* by a stable identity key before
+comparing, so a reordered or trimmed element reads as a move/change instead of a
+wholesale delete+add. This is the substrate the timeline-version diff and the
+declarative-spec `plan` both build on.
+
+Pure and Resolve-free: every function takes plain dicts/lists and returns plain
+data, so it unit-tests without a live Resolve instance.
+
+Design ported (with adaptation) from the MIT-licensed `mhadifilms/dvr` `diff.py`
+`_walk` smart-alignment idea; the identity-key precedence here is tuned for our
+snapshots (stable media id / shot id first, then frame/index, then name).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# Identity keys tried in order when aligning two lists of dicts. The first key
+# present in an element wins; alignment then matches elements sharing that key's
+# value. Falls back to positional (index) alignment when no key is shared.
+DEFAULT_LIST_KEYS: Tuple[str, ...] = (
+    "clip_hash",            # our rename-stable canonical hash (issue #51)
+    "media_pool_item_id",   # Resolve GetUniqueId — stable across renames
+    "shot_id",
+    "id",
+    "uid",
+    "frame",                # markers
+    "name",
+)
+
+
+@dataclass
+class Change:
+    """One leaf-level difference. `op` ∈ {added, removed, changed}.
+
+    `path` is a dotted/bracketed location, e.g. ``tracks.video[1].name`` or
+    ``markers[frame=0].color``. `before`/`after` are the scalar values (None on
+    the side where the element/leaf is absent).
+    """
+
+    op: str
+    path: str
+    before: Any = None
+    after: Any = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"op": self.op, "path": self.path, "before": self.before, "after": self.after}
+
+
+@dataclass
+class Diff:
+    changes: List[Change] = field(default_factory=list)
+    left_label: str = "before"
+    right_label: str = "after"
+
+    def added(self) -> List[Change]:
+        return [c for c in self.changes if c.op == "added"]
+
+    def removed(self) -> List[Change]:
+        return [c for c in self.changes if c.op == "removed"]
+
+    def changed(self) -> List[Change]:
+        return [c for c in self.changes if c.op == "changed"]
+
+    def is_empty(self) -> bool:
+        return not self.changes
+
+    def summary(self) -> Dict[str, int]:
+        return {
+            "added": len(self.added()),
+            "removed": len(self.removed()),
+            "changed": len(self.changed()),
+            "total": len(self.changes),
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "left_label": self.left_label,
+            "right_label": self.right_label,
+            "summary": self.summary(),
+            "changes": [c.to_dict() for c in self.changes],
+        }
+
+
+def _identity_key(item: Any, list_keys: Tuple[str, ...]) -> Optional[Tuple[str, Any]]:
+    """Return (key_name, value) for the first identity key present on a dict item."""
+    if not isinstance(item, dict):
+        return None
+    for key in list_keys:
+        if key in item and item[key] is not None:
+            return (key, item[key])
+    return None
+
+
+def _align_lists(
+    left: List[Any], right: List[Any], list_keys: Tuple[str, ...]
+) -> List[Tuple[Optional[Any], Optional[Any], str]]:
+    """Pair up elements of two lists.
+
+    Returns a list of (left_item, right_item, label) triples. When a shared
+    identity key exists, elements are matched by it (so reorders don't read as
+    delete+add); otherwise alignment is positional. `label` is the path segment
+    used for the pair (``[key=value]`` for keyed, ``[i]`` for positional).
+    """
+    # Try keyed alignment first: only viable if *both* sides expose the same key.
+    left_keyed = [(_identity_key(x, list_keys), x) for x in left]
+    right_keyed = [(_identity_key(x, list_keys), x) for x in right]
+    if all(k is not None for k, _ in left_keyed) and all(k is not None for k, _ in right_keyed):
+        pairs: List[Tuple[Optional[Any], Optional[Any], str]] = []
+        right_by_key: Dict[Tuple[str, Any], Any] = {k: v for k, v in right_keyed}  # type: ignore[misc]
+        consumed: set = set()
+        for k, lv in left_keyed:
+            label = f"[{k[0]}={k[1]}]"  # type: ignore[index]
+            if k in right_by_key:
+                pairs.append((lv, right_by_key[k], label))
+                consumed.add(k)
+            else:
+                pairs.append((lv, None, label))
+        for k, rv in right_keyed:
+            if k not in consumed:
+                pairs.append((None, rv, f"[{k[0]}={k[1]}]"))  # type: ignore[index]
+        return pairs
+
+    # Positional fallback.
+    pairs = []
+    for i in range(max(len(left), len(right))):
+        lv = left[i] if i < len(left) else None
+        rv = right[i] if i < len(right) else None
+        pairs.append((lv, rv, f"[{i}]"))
+    return pairs
+
+
+def _walk(left: Any, right: Any, path: str, out: List[Change], list_keys: Tuple[str, ...]) -> None:
+    # Type mismatch or one side missing → record as a changed/added/removed leaf.
+    if isinstance(left, dict) and isinstance(right, dict):
+        for key in sorted(set(left) | set(right)):
+            child_path = f"{path}.{key}" if path else key
+            if key not in left:
+                out.append(Change("added", child_path, None, right[key]))
+            elif key not in right:
+                out.append(Change("removed", child_path, left[key], None))
+            else:
+                _walk(left[key], right[key], child_path, out, list_keys)
+        return
+
+    if isinstance(left, list) and isinstance(right, list):
+        for lv, rv, seg in _align_lists(left, right, list_keys):
+            child_path = f"{path}{seg}"
+            if lv is None:
+                out.append(Change("added", child_path, None, rv))
+            elif rv is None:
+                out.append(Change("removed", child_path, lv, None))
+            else:
+                _walk(lv, rv, child_path, out, list_keys)
+        return
+
+    if left != right:
+        out.append(Change("changed", path or "", left, right))
+
+
+def compare(
+    left: Any,
+    right: Any,
+    *,
+    left_label: str = "before",
+    right_label: str = "after",
+    list_keys: Tuple[str, ...] = DEFAULT_LIST_KEYS,
+) -> Diff:
+    """Diff two JSON-able structures into a `Diff` of leaf-level changes."""
+    out: List[Change] = []
+    _walk(left, right, "", out, list_keys)
+    return Diff(changes=out, left_label=left_label, right_label=right_label)

--- a/src/utils/timeline_versioning.py
+++ b/src/utils/timeline_versioning.py
@@ -347,32 +347,54 @@ def diff_versions(
 
     before = _snapshot(from_version)
     after = _snapshot(to_version)
-    # Key on (media_pool_item_id, track_type, track_index, in_frame) — a clip
-    # moved to a different track or trimmed differently counts as a change.
+    # Position key: (media id, track type, track index, in_frame). Same key in
+    # both versions = same placement; a differing out_frame on that same key is
+    # a *trim*. A differing track/in_frame for the same media id is a *move*.
     def _key(row: Dict[str, Any]) -> Tuple[str, str, int, int]:
         return (row["media_pool_item_id"], row["track_type"], row["track_index"], row["in_frame"])
 
-    before_keys = {_key(r) for r in before}
-    after_keys = {_key(r) for r in after}
+    before_by_key = {_key(r): r for r in before}
+    after_by_key = {_key(r): r for r in after}
+    before_keys = set(before_by_key)
+    after_keys = set(after_by_key)
+
     added = [r for r in after if _key(r) not in before_keys]
     removed = [r for r in before if _key(r) not in after_keys]
-    # "moved" approximation: same media id, different (track or in_frame).
+
+    # Trimmed: same placement key in both, but the out_frame differs.
+    trimmed: List[Dict[str, Any]] = []
+    for key in before_keys & after_keys:
+        if before_by_key[key]["out_frame"] != after_by_key[key]["out_frame"]:
+            row = dict(after_by_key[key])
+            row["out_frame_before"] = before_by_key[key]["out_frame"]
+            trimmed.append(row)
+
+    # Moved: same media id present on both sides but at a different placement
+    # (so it shows up in both `added` and `removed` above). Report it once.
     before_by_id: Dict[str, List[Dict[str, Any]]] = {}
     for r in before:
         before_by_id.setdefault(r["media_pool_item_id"], []).append(r)
     moved: List[Dict[str, Any]] = []
-    for r in after:
+    for r in added:
         prevs = before_by_id.get(r["media_pool_item_id"])
-        if not prevs:
-            continue
-        if any(_key(p) != _key(r) for p in prevs):
+        if prevs and any(_key(p) != _key(r) for p in prevs):
             moved.append(r)
+
     return {
         "from_version": from_version,
         "to_version": to_version,
         "added": added,
         "removed": removed,
         "moved": moved,
+        "trimmed": trimmed,
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "moved": len(moved),
+            "trimmed": len(trimmed),
+            "before_clip_count": len(before),
+            "after_clip_count": len(after),
+        },
     }
 
 

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -188,5 +188,63 @@ class BatchCliRunIntegrationTests(unittest.TestCase):
             self.assertEqual(events[-1].get("status"), "completed")
 
 
+class BatchCliSpecCommandTests(unittest.TestCase):
+    """plan-spec / apply argparse plumbing + exit-code mapping. The spec action
+    itself (project_spec) is covered by tests/test_project_spec.py; here we mock
+    _run_spec_action so no Resolve connection is needed."""
+
+    def test_help_lists_spec_subcommands(self):
+        parser = batch_cli._build_parser()
+        with self.assertRaises(SystemExit):
+            with redirect_stdout(io.StringIO()) as buf:
+                parser.parse_args(["--help"])
+        text = buf.getvalue()
+        self.assertIn("plan-spec", text)
+        self.assertIn("apply", text)
+
+    def test_apply_requires_spec(self):
+        parser = batch_cli._build_parser()
+        with self.assertRaises(SystemExit):
+            with redirect_stdout(io.StringIO()), patch("sys.stderr", io.StringIO()):
+                parser.parse_args(["apply"])
+
+    def test_plan_spec_emits_plan_and_exits_ok(self):
+        plan = {"project": "Show", "change_count": 1,
+                "actions": [{"op": "create", "target": "project:Show", "detail": ""}],
+                "diff": {}}
+        with patch.object(batch_cli, "_run_spec_action", return_value=plan):
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["plan-spec", "/tmp/spec.json"])
+        self.assertEqual(rc, batch_cli.EXIT_OK)
+
+    def test_apply_success_exit_ok(self):
+        result = {"success": True, "applied_count": 3, "applied": [], "failures": []}
+        with patch.object(batch_cli, "_run_spec_action", return_value=result):
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["apply", "/tmp/spec.json"])
+        self.assertEqual(rc, batch_cli.EXIT_OK)
+
+    def test_apply_partial_exit_2(self):
+        result = {"success": False, "applied_count": 1, "applied": [],
+                  "failures": [{"target": "timeline:A"}]}
+        with patch.object(batch_cli, "_run_spec_action", return_value=result):
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["apply", "/tmp/spec.json"])
+        self.assertEqual(rc, batch_cli.EXIT_PARTIAL)
+
+    def test_not_connected_exit_fatal(self):
+        with patch.object(batch_cli, "_run_spec_action", return_value=None):
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["apply", "/tmp/spec.json"])
+        self.assertEqual(rc, batch_cli.EXIT_FATAL)
+
+    def test_spec_error_envelope_exit_fatal(self):
+        result = {"error": {"message": "bad spec", "category": "invalid_input"}}
+        with patch.object(batch_cli, "_run_spec_action", return_value=result):
+            with redirect_stdout(io.StringIO()):
+                rc = batch_cli.main(["plan-spec", "/tmp/spec.json"])
+        self.assertEqual(rc, batch_cli.EXIT_FATAL)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_clip_query.py
+++ b/tests/test_clip_query.py
@@ -1,0 +1,57 @@
+"""Unit tests for the clip-query DSL (Phase C2)."""
+import unittest
+
+from src.utils import clip_query as cq
+
+
+CLIPS = [
+    {"name": "INSERT_hand", "track_type": "video", "track_index": 1,
+     "duration": 8, "analyzed": True, "has_transcription": False, "shot_type": "insert"},
+    {"name": "wide_master", "track_type": "video", "track_index": 1,
+     "duration": 240, "analyzed": True, "has_transcription": True, "shot_type": "wide"},
+    {"name": "room_tone", "track_type": "audio", "track_index": 2,
+     "duration": 500, "analyzed": False, "has_transcription": False},
+]
+
+
+class ClipQueryTest(unittest.TestCase):
+    def test_duration_lt(self):
+        out = cq.filter_clips(CLIPS, {"duration_lt": 12})
+        self.assertEqual([c["name"] for c in out], ["INSERT_hand"])
+
+    def test_track_type(self):
+        out = cq.filter_clips(CLIPS, {"track_type": "audio"})
+        self.assertEqual([c["name"] for c in out], ["room_tone"])
+
+    def test_name_contains_case_insensitive(self):
+        out = cq.filter_clips(CLIPS, {"name_contains": "insert"})
+        self.assertEqual([c["name"] for c in out], ["INSERT_hand"])
+
+    def test_analyzed_false(self):
+        out = cq.filter_clips(CLIPS, {"analyzed": False})
+        self.assertEqual([c["name"] for c in out], ["room_tone"])
+
+    def test_and_semantics(self):
+        out = cq.filter_clips(CLIPS, {"track_type": "video", "duration_gt": 100})
+        self.assertEqual([c["name"] for c in out], ["wide_master"])
+
+    def test_empty_filters_returns_all(self):
+        self.assertEqual(len(cq.filter_clips(CLIPS, {})), 3)
+
+    def test_sparse_filters_skip_none_and_blank(self):
+        out = cq.filter_clips(CLIPS, {"track_type": "video", "name_contains": "", "shot_type": None})
+        self.assertEqual(len(out), 2)
+
+    def test_validate_rejects_unknown_keys(self):
+        ok, unknown = cq.validate_filters({"duration_lt": 5, "bogus": 1})
+        self.assertFalse(ok)
+        self.assertEqual(unknown, ["bogus"])
+
+    def test_validate_accepts_known(self):
+        ok, unknown = cq.validate_filters({"track_type": "video", "shot_type": "wide"})
+        self.assertTrue(ok)
+        self.assertEqual(unknown, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_error_envelope.py
+++ b/tests/test_error_envelope.py
@@ -110,6 +110,17 @@ class ErrorEnvelopeContractTest(unittest.TestCase):
         out = _err("x")
         self.assertNotIsInstance(out["error"], str)
 
+    def test_state_field_carried_when_provided(self):
+        """state= surfaces a machine-readable snapshot at failure time."""
+        out = _err("no render job", category="resolve_api_failed",
+                   state={"queue_size": 0, "format": "mov"})
+        self.assertEqual(out["error"]["state"], {"queue_size": 0, "format": "mov"})
+
+    def test_state_omitted_when_empty(self):
+        """Empty/None state must not bloat the envelope."""
+        self.assertNotIn("state", _err("x")["error"])
+        self.assertNotIn("state", _err("x", state={})["error"])
+
     def test_check_emits_structured_not_connected_when_resolve_absent(self):
         """Integration smoke: _check returns a NOT_CONNECTED error when Resolve is unreachable."""
         import src.server as compound

--- a/tests/test_project_lint.py
+++ b/tests/test_project_lint.py
@@ -1,0 +1,73 @@
+"""Unit tests for the project lint health-check (Phase C1)."""
+import unittest
+
+from src.utils import project_lint as pl
+
+
+def _codes(state):
+    return {i.code for i in pl.lint_state(state)}
+
+
+class ProjectLintTest(unittest.TestCase):
+    def test_no_project_short_circuits(self):
+        issues = pl.lint_state({"project": None})
+        self.assertEqual([i.code for i in issues], ["no_project"])
+        self.assertEqual(issues[0].severity, "error")
+
+    def test_clean_project_has_no_errors(self):
+        state = {
+            "project": "Show",
+            "current_timeline": "Edit",
+            "timelines": [{"name": "Edit", "fps": 24, "item_count": 10}],
+            "settings": {"colorScienceMode": "acescct"},
+            "render": {"format": "mov"},
+        }
+        report = pl.lint_report(state)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["counts"]["error"], 0)
+
+    def test_no_current_timeline_warning(self):
+        self.assertIn("no_current_timeline", _codes({"project": "S", "timelines": []}))
+
+    def test_mixed_fps_info(self):
+        state = {
+            "project": "S", "current_timeline": "A",
+            "timelines": [{"name": "A", "fps": 24, "item_count": 1},
+                          {"name": "B", "fps": 30, "item_count": 1}],
+        }
+        self.assertIn("mixed_fps", _codes(state))
+
+    def test_empty_timeline_warning(self):
+        state = {"project": "S", "current_timeline": "A",
+                 "timelines": [{"name": "A", "fps": 24, "item_count": 0}]}
+        self.assertIn("empty_timeline", _codes(state))
+
+    def test_color_science_unset_info(self):
+        state = {"project": "S", "current_timeline": "A",
+                 "timelines": [{"name": "A", "fps": 24, "item_count": 1}],
+                 "settings": {"colorScienceMode": "davinciYRGB"}}
+        self.assertIn("color_science_unset", _codes(state))
+
+    def test_offline_media_is_error(self):
+        state = {"project": "S", "current_timeline": "A",
+                 "timelines": [{"name": "A", "fps": 24, "item_count": 1}],
+                 "offline_media_count": 3}
+        report = pl.lint_report(state)
+        self.assertFalse(report["ok"])
+        self.assertIn("offline_media", _codes(state))
+
+    def test_unanalyzed_clips_info(self):
+        state = {"project": "S", "current_timeline": "A",
+                 "timelines": [{"name": "A", "fps": 24, "item_count": 1}],
+                 "unanalyzed_clip_count": 5}
+        self.assertIn("unanalyzed_clips", _codes(state))
+
+    def test_issues_sorted_error_first(self):
+        state = {"project": "S", "timelines": [{"name": "A", "fps": 24, "item_count": 0}],
+                 "offline_media_count": 1}
+        issues = pl.lint_state(state)
+        self.assertEqual(issues[0].severity, "error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_spec.py
+++ b/tests/test_project_spec.py
@@ -1,0 +1,220 @@
+"""Unit tests for the declarative project spec: load, plan, apply (Phase B)."""
+import json
+import os
+import tempfile
+import unittest
+
+from src.utils import project_spec as ps
+
+
+class FakeExecutor:
+    """In-memory executor recording calls; mimics the live one's contract."""
+
+    def __init__(self, live):
+        self._live = live
+        self.calls = []
+        self.fail_on = set()  # targets to fail
+
+    def live_state(self):
+        return self._live
+
+    def _ok(self, tag, target):
+        self.calls.append((tag, target))
+        return target not in self.fail_on
+
+    def ensure_project(self, name):
+        return self._ok("ensure_project", f"project:{name}")
+
+    def set_project_setting(self, key, value):
+        return self._ok("set_project_setting", f"setting:{key}")
+
+    def ensure_timeline(self, name, fps):
+        return self._ok("ensure_timeline", f"timeline:{name}")
+
+    def set_timeline_setting(self, tl, key, value):
+        return self._ok("set_timeline_setting", f"timeline:{tl}/setting:{key}")
+
+    def add_marker(self, tl, marker):
+        return self._ok("add_marker", f"timeline:{tl}/marker:{marker.get('frame')}")
+
+
+SPEC_DICT = {
+    "project": "MyShow",
+    "color_preset": "rec709_gamma24",
+    "settings": {"timelineFrameRate": "24"},
+    "timelines": [
+        {"name": "Edit_v2", "fps": 24,
+         "markers": [{"frame": 0, "color": "Blue", "name": "HEAD"}]},
+    ],
+    "hooks": {"before": [{"command": "echo hi", "name": "setup"}], "after": ["echo bye"]},
+}
+
+
+class SpecLoadTest(unittest.TestCase):
+    def test_from_dict_ok(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        self.assertEqual(spec.project, "MyShow")
+        self.assertEqual(spec.color_preset, "rec709_gamma24")
+        self.assertEqual(len(spec.timelines), 1)
+        self.assertEqual(spec.timelines[0].fps, 24)
+        self.assertEqual(len(spec.hooks), 2)
+
+    def test_missing_project_raises(self):
+        with self.assertRaises(ps.SpecError):
+            ps.spec_from_dict({"timelines": []})
+
+    def test_unknown_preset_raises(self):
+        with self.assertRaises(ps.SpecError) as cm:
+            ps.spec_from_dict({"project": "X", "color_preset": "nope"})
+        self.assertIn("known_presets", cm.exception.state)
+
+    def test_timeline_requires_name(self):
+        with self.assertRaises(ps.SpecError):
+            ps.spec_from_dict({"project": "X", "timelines": [{"fps": 24}]})
+
+    def test_load_json_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "spec.json")
+            with open(path, "w") as fh:
+                json.dump(SPEC_DICT, fh)
+            spec = ps.load_spec(path)
+            self.assertEqual(spec.project, "MyShow")
+
+    def test_load_missing_file_raises(self):
+        with self.assertRaises(ps.SpecError):
+            ps.load_spec("/no/such/spec.json")
+
+
+class EffectiveSettingsTest(unittest.TestCase):
+    def test_explicit_overrides_preset(self):
+        spec = ps.spec_from_dict({
+            "project": "X", "color_preset": "rec709_gamma24",
+            "settings": {"colorSpaceOutput": "Custom"},
+        })
+        eff = ps.effective_settings(spec)
+        self.assertEqual(eff["colorSpaceOutput"], "Custom")  # explicit wins
+        self.assertIn("colorScienceMode", eff)               # preset still present
+
+    def test_settings_order_puts_color_science_first(self):
+        keys = ps._ordered_setting_keys(["timelineFrameRate", "colorSpaceOutput", "colorScienceMode"])
+        self.assertLess(keys.index("colorScienceMode"), keys.index("colorSpaceOutput"))
+
+
+class NumericSettingNormalizationTest(unittest.TestCase):
+    """Regression for the live finding: Resolve reports fps as '24.0' but specs
+    say '24' — comparison must be numeric so reconcile converges."""
+
+    def test_norm_value(self):
+        self.assertEqual(ps._norm_setting_value("24.0"), "24")
+        self.assertEqual(ps._norm_setting_value("24"), "24")
+        self.assertEqual(ps._norm_setting_value(24.0), "24")
+        self.assertEqual(ps._norm_setting_value("Rec.709"), "Rec.709")
+
+    def test_settings_equal_numeric(self):
+        self.assertTrue(ps._settings_equal("24.0", "24"))
+        self.assertTrue(ps._settings_equal("23.976", "23.976"))
+        self.assertFalse(ps._settings_equal("24", "25"))
+
+    def test_project_setting_2400_matches_24_is_noop(self):
+        spec = ps.spec_from_dict({"project": "S", "settings": {"timelineFrameRate": "24"}})
+        plan = ps.plan_spec(spec, {"project": "S", "projects": ["S"],
+                                   "settings": {"timelineFrameRate": "24.0"}, "timelines": []})
+        self.assertEqual(plan["change_count"], 0)
+
+    def test_fps_not_emitted_as_timeline_setting(self):
+        # fps is creation-time only — no per-timeline timelineFrameRate set action.
+        spec = ps.spec_from_dict({"project": "S",
+                                  "timelines": [{"name": "A", "fps": 24}]})
+        plan = ps.plan_spec(spec, {"project": "S", "projects": ["S"], "settings": {},
+                                   "timelines": [{"name": "A", "settings": {"timelineFrameRate": "24.0"}}]})
+        setting_actions = [a for a in plan["actions"] if "/setting:timelineFrameRate" in a["target"]
+                           and a["target"].startswith("timeline:")]
+        self.assertEqual(setting_actions, [])
+
+
+class PlanTest(unittest.TestCase):
+    def test_fresh_project_plans_create(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        plan = ps.plan_spec(spec, {"projects": [], "settings": {}, "timelines": []})
+        ops = {a["op"] for a in plan["actions"]}
+        self.assertIn("create", ops)
+        self.assertIn("ensure", ops)  # timeline
+        self.assertGreater(plan["change_count"], 0)
+
+    def test_matching_state_is_all_noop(self):
+        spec = ps.spec_from_dict({"project": "S", "settings": {"timelineFrameRate": "24"}})
+        plan = ps.plan_spec(spec, {"project": "S", "projects": ["S"],
+                                   "settings": {"timelineFrameRate": "24"}, "timelines": []})
+        self.assertEqual(plan["change_count"], 0)
+        self.assertTrue(all(a["op"] == "noop" for a in plan["actions"]))
+
+    def test_marker_idempotent_in_plan(self):
+        spec = ps.spec_from_dict({
+            "project": "S",
+            "timelines": [{"name": "A", "markers": [{"frame": 0}]}],
+        })
+        live = {"project": "S", "projects": ["S"], "settings": {},
+                "timelines": [{"name": "A", "settings": {}, "markers": [{"frame": 0}]}]}
+        plan = ps.plan_spec(spec, live)
+        marker_actions = [a for a in plan["actions"] if "marker" in a["target"]]
+        self.assertTrue(all(a["op"] == "noop" for a in marker_actions))
+
+
+class ApplyTest(unittest.TestCase):
+    def test_dry_run_does_not_execute(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        ex = FakeExecutor({"projects": [], "settings": {}, "timelines": []})
+        out = ps.apply_spec(spec, ex, dry_run=True)
+        self.assertTrue(out["dry_run"])
+        self.assertEqual(ex.calls, [])
+
+    def test_apply_executes_and_reports(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        ex = FakeExecutor({"projects": [], "settings": {}, "timelines": []})
+        out = ps.apply_spec(spec, ex)
+        self.assertTrue(out["success"])
+        tags = {t for t, _ in ex.calls}
+        self.assertIn("ensure_project", tags)
+        self.assertIn("ensure_timeline", tags)
+        self.assertIn("add_marker", tags)
+
+    def test_apply_skips_matching_settings(self):
+        spec = ps.spec_from_dict({"project": "S", "settings": {"timelineFrameRate": "24"}})
+        ex = FakeExecutor({"project": "S", "projects": ["S"],
+                           "settings": {"timelineFrameRate": "24"}, "timelines": []})
+        ps.apply_spec(spec, ex)
+        self.assertNotIn("set_project_setting", {t for t, _ in ex.calls})
+
+    def test_first_failure_raises_without_continue(self):
+        spec = ps.spec_from_dict({"project": "S"})
+        ex = FakeExecutor({"projects": [], "settings": {}, "timelines": []})
+        ex.fail_on.add("project:S")
+        with self.assertRaises(ps.SpecError) as cm:
+            ps.apply_spec(spec, ex)
+        self.assertIn("failures", cm.exception.state)
+
+    def test_continue_on_error_accumulates(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        ex = FakeExecutor({"projects": [], "settings": {}, "timelines": []})
+        ex.fail_on.add("timeline:Edit_v2/marker:0")
+        out = ps.apply_spec(spec, ex, continue_on_error=True)
+        self.assertFalse(out["success"])
+        self.assertEqual(len(out["failures"]), 1)
+
+    def test_hooks_opt_in(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        ex = FakeExecutor({"projects": [], "settings": {}, "timelines": []})
+        ran = []
+        ps.apply_spec(spec, ex, run_hooks=True, run_hook=lambda h: ran.append(h.command) or True)
+        self.assertEqual(ran, ["echo hi", "echo bye"])
+
+    def test_hooks_skipped_by_default(self):
+        spec = ps.spec_from_dict(SPEC_DICT)
+        ex = FakeExecutor({"projects": [], "settings": {}, "timelines": []})
+        ran = []
+        ps.apply_spec(spec, ex, run_hook=lambda h: ran.append(h.command) or True)
+        self.assertEqual(ran, [])  # run_hooks defaulted False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spec_lint_wiring.py
+++ b/tests/test_spec_lint_wiring.py
@@ -1,0 +1,270 @@
+"""Wiring tests for the live server adapters: clip_where, lint, and the
+declarative spec executor. Uses an in-memory fake Resolve so no live app is
+needed. The pure cores are covered separately (test_project_spec / _lint /
+_clip_query / _structural_diff); these exercise the server.py glue."""
+import unittest
+
+from src import server
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+class FakeMPI:
+    def __init__(self, uid):
+        self._uid = uid
+
+    def GetUniqueId(self):
+        return self._uid
+
+    def GetName(self):
+        return f"media_{self._uid}"
+
+
+class FakeItem:
+    def __init__(self, start, end, name, mpi):
+        self._start, self._end, self._name = start, end, name
+        self._mpi = FakeMPI(mpi)
+
+    def GetStart(self):
+        return self._start
+
+    def GetEnd(self):
+        return self._end
+
+    def GetDuration(self):
+        return self._end - self._start
+
+    def GetName(self):
+        return self._name
+
+    def GetUniqueId(self):
+        return f"item_{self._name}"
+
+    def GetMediaPoolItem(self):
+        return self._mpi
+
+
+class FakeTimeline:
+    def __init__(self, name, tracks=None, settings=None, markers=None):
+        self.name = name
+        self._tracks = tracks or {}          # {("video",1): [FakeItem,...]}
+        self._settings = settings or {}
+        self._markers = markers or {}        # {frame: {color,...}}
+
+    def GetName(self):
+        return self.name
+
+    def GetTrackCount(self, tt):
+        return max([idx for (t, idx) in self._tracks if t == tt] + [0])
+
+    def GetItemListInTrack(self, tt, idx):
+        return self._tracks.get((tt, idx), [])
+
+    def GetSetting(self, key):
+        return self._settings.get(key)
+
+    def SetSetting(self, key, value):
+        self._settings[key] = value
+        return True
+
+    def GetMarkers(self):
+        return dict(self._markers)
+
+    def AddMarker(self, frame, color, name, note, duration, custom):
+        self._markers[frame] = {"color": color, "name": name, "note": note,
+                                "duration": duration, "customData": custom}
+        return True
+
+    def GetStartFrame(self):
+        return 0
+
+    def GetEndFrame(self):
+        return 100
+
+    def GetUniqueId(self):
+        return f"tl_{self.name}"
+
+    def GetStartTimecode(self):
+        return "01:00:00:00"
+
+
+class FakeMediaPool:
+    def __init__(self, project):
+        self._project = project
+
+    def CreateEmptyTimeline(self, name):
+        tl = FakeTimeline(name)
+        self._project._timelines.append(tl)
+        return tl
+
+
+class FakeProject:
+    def __init__(self, name, timelines=None, settings=None):
+        self.name = name
+        self._timelines = timelines or []
+        self._settings = settings or {}
+        self._current = self._timelines[0] if self._timelines else None
+        self._mp = FakeMediaPool(self)
+
+    def GetName(self):
+        return self.name
+
+    def GetCurrentTimeline(self):
+        return self._current
+
+    def GetTimelineCount(self):
+        return len(self._timelines)
+
+    def GetTimelineByIndex(self, i):
+        return self._timelines[i - 1] if 1 <= i <= len(self._timelines) else None
+
+    def GetSetting(self, key):
+        return self._settings.get(key)
+
+    def SetSetting(self, key, value):
+        self._settings[key] = value
+        return True
+
+    def GetMediaPool(self):
+        return self._mp
+
+    def GetCurrentRenderFormatAndCodec(self):
+        return {"format": "mov", "codec": "ProRes422"}
+
+
+class FakePM:
+    def __init__(self, project, projects=None):
+        self._project = project
+        self._projects = projects or ([project.GetName()] if project else [])
+
+    def GetCurrentProject(self):
+        return self._project
+
+    def GetProjectListInCurrentFolder(self):
+        return list(self._projects)
+
+    def CreateProject(self, name):
+        self._project = FakeProject(name)
+        self._projects.append(name)
+        return self._project
+
+    def LoadProject(self, name):
+        return self._project
+
+
+class FakeResolve:
+    def __init__(self, pm):
+        self._pm = pm
+
+    def GetProjectManager(self):
+        return self._pm
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+class ClipWhereWiringTest(unittest.TestCase):
+    def _timeline(self):
+        return FakeTimeline("Edit", tracks={
+            ("video", 1): [
+                FakeItem(0, 8, "INSERT_a", "mA"),
+                FakeItem(8, 248, "wide_master", "mB"),
+            ],
+            ("audio", 1): [FakeItem(0, 500, "room_tone", "mC")],
+        })
+
+    def test_duration_filter(self):
+        out = server._timeline_clip_where(self._timeline(), {"duration_lt": 12})
+        self.assertTrue(out["success"])
+        self.assertEqual(out["match_count"], 1)
+        self.assertEqual(out["clips"][0]["name"], "INSERT_a")
+        self.assertEqual(out["total_clips"], 3)
+
+    def test_track_type_filter(self):
+        out = server._timeline_clip_where(self._timeline(), {"track_type": "audio"})
+        self.assertEqual([c["name"] for c in out["clips"]], ["room_tone"])
+
+    def test_unknown_filter_rejected(self):
+        out = server._timeline_clip_where(self._timeline(), {"bogus": 1})
+        self.assertIn("error", out)
+        self.assertEqual(out["error"]["category"], "invalid_input")
+
+    def test_analysis_filter_not_live(self):
+        out = server._timeline_clip_where(self._timeline(), {"analyzed": True})
+        self.assertIn("error", out)
+        self.assertEqual(out["error"]["category"], "unsupported")
+
+
+class LintWiringTest(unittest.TestCase):
+    def test_lint_clean_project(self):
+        tl = FakeTimeline("Edit", tracks={("video", 1): [FakeItem(0, 10, "a", "m1")]},
+                          settings={"timelineFrameRate": "24"})
+        proj = FakeProject("Show", timelines=[tl], settings={"colorScienceMode": "acescct"})
+        out = server._project_lint_live(FakeResolve(FakePM(proj)), FakePM(proj))
+        self.assertTrue(out["success"])
+        self.assertEqual(out["counts"]["error"], 0)
+
+    def test_lint_no_project(self):
+        pm = FakePM(None, projects=[])
+        out = server._project_lint_live(FakeResolve(pm), pm)
+        codes = {i["code"] for i in out["issues"]}
+        self.assertIn("no_project", codes)
+
+    def test_lint_empty_timeline_warns(self):
+        tl = FakeTimeline("Edit", tracks={}, settings={"timelineFrameRate": "24"})
+        proj = FakeProject("Show", timelines=[tl])
+        pm = FakePM(proj)
+        out = server._project_lint_live(FakeResolve(pm), pm)
+        self.assertIn("empty_timeline", {i["code"] for i in out["issues"]})
+
+
+class SpecActionWiringTest(unittest.TestCase):
+    def test_diff_to_spec_inline(self):
+        proj = FakeProject("Show", timelines=[], settings={})
+        pm = FakePM(proj)
+        out = server._spec_action(FakeResolve(pm), pm, "diff_to_spec", {
+            "spec": {"project": "Show", "settings": {"timelineFrameRate": "24"}},
+        })
+        self.assertTrue(out["success"])
+        self.assertIn("actions", out)
+        self.assertGreaterEqual(out["change_count"], 1)  # fps setting differs
+
+    def test_apply_spec_creates_timeline_and_marker(self):
+        proj = FakeProject("Show", timelines=[], settings={})
+        pm = FakePM(proj)
+        out = server._spec_action(FakeResolve(pm), pm, "apply_spec", {
+            "spec": {
+                "project": "Show",
+                "timelines": [{"name": "Edit_v2", "fps": 24,
+                               "markers": [{"frame": 0, "color": "Blue", "name": "HEAD"}]}],
+            },
+        })
+        self.assertTrue(out["success"], out)
+        names = [tl.GetName() for tl in proj._timelines]
+        self.assertIn("Edit_v2", names)
+        new_tl = next(tl for tl in proj._timelines if tl.GetName() == "Edit_v2")
+        self.assertIn(0, new_tl.GetMarkers())
+
+    def test_apply_spec_idempotent_second_run(self):
+        proj = FakeProject("Show", timelines=[], settings={})
+        pm = FakePM(proj)
+        spec = {"project": "Show",
+                "timelines": [{"name": "E", "fps": 24, "markers": [{"frame": 0}]}]}
+        server._spec_action(FakeResolve(pm), pm, "apply_spec", {"spec": spec})
+        # Second run: plan should be all-noop.
+        plan = server._spec_action(FakeResolve(pm), pm, "diff_to_spec", {"spec": spec})
+        self.assertEqual(plan["change_count"], 0, plan["actions"])
+
+    def test_bad_spec_returns_invalid_input(self):
+        proj = FakeProject("Show")
+        pm = FakePM(proj)
+        out = server._spec_action(FakeResolve(pm), pm, "apply_spec", {"spec": {"no_project": 1}})
+        self.assertIn("error", out)
+        self.assertEqual(out["error"]["category"], "invalid_input")
+
+    def test_missing_spec_arg(self):
+        proj = FakeProject("Show")
+        pm = FakePM(proj)
+        out = server._spec_action(FakeResolve(pm), pm, "apply_spec", {})
+        self.assertEqual(out["error"]["code"], "NO_SPEC")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_structural_diff.py
+++ b/tests/test_structural_diff.py
@@ -1,0 +1,67 @@
+"""Unit tests for the reusable structural diff engine (Phase A)."""
+import unittest
+
+from src.utils import structural_diff as sd
+
+
+class StructuralDiffTest(unittest.TestCase):
+    def test_identical_is_empty(self):
+        a = {"x": 1, "list": [{"id": 1, "v": "a"}]}
+        diff = sd.compare(a, dict(a, list=[{"id": 1, "v": "a"}]))
+        self.assertTrue(diff.is_empty())
+        self.assertEqual(diff.summary()["total"], 0)
+
+    def test_scalar_change(self):
+        diff = sd.compare({"fps": 24}, {"fps": 25})
+        self.assertEqual(diff.summary(), {"added": 0, "removed": 0, "changed": 1, "total": 1})
+        self.assertEqual(diff.changed()[0].before, 24)
+        self.assertEqual(diff.changed()[0].after, 25)
+        self.assertEqual(diff.changed()[0].path, "fps")
+
+    def test_added_and_removed_keys(self):
+        diff = sd.compare({"a": 1}, {"b": 2})
+        ops = {c.op for c in diff.changes}
+        self.assertEqual(ops, {"added", "removed"})
+
+    def test_list_keyed_alignment_detects_reorder_as_no_change(self):
+        # Same elements, different order, keyed by media_pool_item_id → no change.
+        left = [{"media_pool_item_id": "A", "v": 1}, {"media_pool_item_id": "B", "v": 2}]
+        right = [{"media_pool_item_id": "B", "v": 2}, {"media_pool_item_id": "A", "v": 1}]
+        diff = sd.compare({"clips": left}, {"clips": right})
+        self.assertTrue(diff.is_empty(), diff.to_dict())
+
+    def test_list_keyed_alignment_detects_field_change(self):
+        left = [{"id": "A", "grade": "x"}]
+        right = [{"id": "A", "grade": "y"}]
+        diff = sd.compare({"clips": left}, {"clips": right})
+        self.assertEqual(diff.summary()["changed"], 1)
+        self.assertIn("[id=A]", diff.changed()[0].path)
+
+    def test_list_keyed_add_remove(self):
+        left = [{"id": "A"}]
+        right = [{"id": "A"}, {"id": "B"}]
+        diff = sd.compare(left, right)
+        self.assertEqual(diff.summary()["added"], 1)
+        self.assertEqual(diff.added()[0].after, {"id": "B"})
+
+    def test_positional_fallback_when_no_shared_key(self):
+        diff = sd.compare([1, 2, 3], [1, 9, 3])
+        self.assertEqual(diff.summary()["changed"], 1)
+        self.assertEqual(diff.changed()[0].path, "[1]")
+
+    def test_clip_hash_takes_precedence_over_name(self):
+        # Renamed clip (same hash) is a change, not delete+add.
+        left = [{"clip_hash": "h1", "name": "old"}]
+        right = [{"clip_hash": "h1", "name": "new"}]
+        diff = sd.compare(left, right)
+        self.assertEqual(diff.summary()["changed"], 1)
+        self.assertIn("[clip_hash=h1]", diff.changed()[0].path)
+
+    def test_to_dict_shape(self):
+        d = sd.compare({"a": 1}, {"a": 2}).to_dict()
+        self.assertEqual(set(d), {"left_label", "right_label", "summary", "changes"})
+        self.assertEqual(d["changes"][0]["op"], "changed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timeline_versioning.py
+++ b/tests/test_timeline_versioning.py
@@ -295,6 +295,41 @@ class TimelineVersioning(unittest.TestCase):
         # mpi_c was unchanged — should appear in none.
         self.assertNotIn("mpi_c", added_ids | removed_ids | moved_ids)
 
+    def test_diff_versions_summary_and_trimmed(self) -> None:
+        # v1: a (0-100), b (100-200)
+        self.timeline.set_tracks({
+            ("video", 1): [
+                _MockTimelineItem(0, 100, "mpi_a"),
+                _MockTimelineItem(100, 200, "mpi_b"),
+            ],
+        })
+        timeline_versioning.archive_current_timeline(
+            resolve=None, project=self.project, project_root=self.project_root,
+            analysis_run_id="run_1",
+        )
+        # v2: a trimmed (0-80, same in_frame), b unchanged
+        self.timeline.set_tracks({
+            ("video", 1): [
+                _MockTimelineItem(0, 80, "mpi_a"),     # trimmed (out 100 -> 80)
+                _MockTimelineItem(100, 200, "mpi_b"),  # unchanged
+            ],
+        })
+        timeline_versioning.archive_current_timeline(
+            resolve=None, project=self.project, project_root=self.project_root,
+            analysis_run_id="run_2",
+        )
+        diff = timeline_versioning.diff_versions(
+            project_root=self.project_root, timeline_name="Edit",
+            from_version=1, to_version=2,
+        )
+        self.assertEqual([r["media_pool_item_id"] for r in diff["trimmed"]], ["mpi_a"])
+        self.assertEqual(diff["trimmed"][0]["out_frame_before"], 100)
+        self.assertEqual(diff["trimmed"][0]["out_frame"], 80)
+        self.assertIn("summary", diff)
+        self.assertEqual(diff["summary"]["trimmed"], 1)
+        self.assertEqual(diff["summary"]["before_clip_count"], 2)
+        self.assertEqual(diff["summary"]["after_clip_count"], 2)
+
     def test_prune_collapses_old_versions_to_drt(self) -> None:
         for rid in [f"run_{i}" for i in range(5)]:
             timeline_versioning.archive_current_timeline(


### PR DESCRIPTION
## Summary

New capabilities, all backward compatible (no tools/actions/params renamed or removed):

- **Timeline version diff** — `diff_versions` now reports `added/removed/moved/trimmed` with summary counts and before/after totals. New reusable `structural_diff` engine aligns clips by rename-stable identity. Exposed via `GET /api/timeline_versions/diff`.
- **Declarative project spec + apply** (`project.dvr.yaml` / `.json`) — describe desired settings, color preset, timelines, and markers, then reconcile the live project toward them. Idempotent, dry-run preview, dependency-ordered settings, markers added only when absent, explicit settings override a named preset, opt-in shell hooks. MCP: `project_manager` actions `diff_to_spec` / `plan_spec` / `apply_spec`. CLI: `batch plan-spec` / `batch apply`.
- **Project health lint** — `project_manager(action="lint")` returns graded issues (no project, no current timeline, mixed fps, empty timeline, render/color-science unset, offline media, unanalyzed clips).
- **Clip query DSL** — `timeline(action="clip_where", ...)` returns clips matching named filters; unknown filter names are rejected rather than silently matching all.
- **Error envelopes** can carry an optional machine-readable `state` snapshot.

## Testing

- 4 new pure-engine modules with full unit coverage, a fake-Resolve wiring suite, plus CLI/error/diff additions. 819 tests pass (pre-existing media_analysis + live-API failures are environment-only).
- `lint`, `diff_to_spec`, and the mutating `apply_spec` path validated live against DaVinci Resolve. Live testing caught two real bugs (float-formatted setting comparison for idempotency; `fps` as creation-time only) — both fixed with regression tests.

## Release

Version bumped to 2.28.0 across all surfaces; CHANGELOG + SKILL.md updated. Tag `v2.28.0` (pushed after merge) triggers the npm publish workflow.