### PR TITLE
Normalize render formats and add proxy UI fallback

### DIFF
--- a/.claude/skills/davinci-resolve-mcp.md
+++ b/.claude/skills/davinci-resolve-mcp.md
@@ -1,0 +1,21 @@
+---
+name: davinci-resolve-mcp
+description: Work with DaVinci Resolve projects through the local davinci-resolve MCP server, including project inspection, timeline editing, media pool management, Output Blanking UI fallback, offline media diagnosis, and Resolve MCP troubleshooting.
+---
+
+# DaVinci Resolve MCP — Claude Skill Wrapper
+
+This is a Claude-compatible wrapper for the canonical repo skill.
+
+Read and follow:
+
+`skills/davinci-resolve-mcp/SKILL.md`
+
+Use the helper scripts from:
+
+`skills/davinci-resolve-mcp/scripts/`
+
+Do not duplicate local machine paths into this wrapper. The canonical skill uses
+environment variables and repo-relative paths so it can be installed into Codex,
+Claude, OpenCode, OpenClaude, or another MCP client without user-specific path
+leaks.

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -738,9 +738,18 @@ structure, interchange, comparison, missing-media, and relink-planning helpers:
 - `import_timeline_checked(path, options?, timeline_name?, import_source_clips?, require_temp_path?, dry_run?)`
 - `compare_timelines(right_timeline_id?|right_timeline_index?|left_snapshot?, right_snapshot?)`
 - `probe_interchange_roundtrip(format?, output_dir?, cleanup_imported?)`
-- `detect_missing_media`
-- `build_relink_plan(search_roots)`
+- `detect_missing_media(sanitized?|sanitize_paths?, omit_raw_paths?)`
+- `build_relink_plan(search_roots, max_depth?, max_seconds?, max_files_scanned?, skip_search_when_volume_missing?, sanitized?)`
 - `conform_boundary_report`
+
+For offline media, prefer the sanitized readback first:
+`timeline(action="detect_missing_media", params={"sanitized": true})`. The
+response includes a `diagnosis` block with deduplicated Media Pool items,
+missing volume roots, sample basenames, and a recommended next step. If a source
+volume such as a camera card is not mounted, `build_relink_plan` skips broad
+search by default and reports `skip_reason="missing_source_volume_not_mounted"`;
+mount the volume or pass `skip_search_when_volume_missing=false` only when a
+bounded scan of approved roots is intentional.
 
 Audio / Fairlight kernel actions (v2.14.0+) add live-tested audio state,
 mapping, voice-isolation, sync, transcription, subtitle, and Fairlight boundary

--- a/docs/kernels/timeline-conform-interchange-kernel.md
+++ b/docs/kernels/timeline-conform-interchange-kernel.md
@@ -35,8 +35,8 @@ All actions are exposed through `timeline`.
 | `import_timeline_checked` | Guard timeline imports from temp locations and normalize import options. |
 | `compare_timelines` | Compare current timeline to another timeline or two supplied snapshots. |
 | `probe_interchange_roundtrip` | Export, import, compare, and optionally delete the imported timeline. |
-| `detect_missing_media` | Detect missing/offline media using Resolve status fields and file-path existence. |
-| `build_relink_plan` | Read-only search-root scan for relink candidates by missing file basename. |
+| `detect_missing_media` | Detect missing/offline media using Resolve status fields and file-path existence, with a sanitized diagnosis block for mounted-volume/folder/file failure modes. |
+| `build_relink_plan` | Read-only, bounded search-root scan for relink candidates by missing file basename. Skips broad scans by default when the source volume is not mounted. |
 | `conform_boundary_report` | Return capabilities, timeline structure, gaps/overlaps, source ranges, and missing-media summary. |
 
 ## Interchange Matrix
@@ -64,8 +64,9 @@ Supported aliases include `aaf`, `drt`, `edl`, `edl_cdl`, `edl_sdl`,
 - FCPXML directory-style exports are normalized with a `primary_file` path.
 - DRT export/import/compare round-trip succeeded and cleaned up the imported
   timeline.
-- Synthetic-only unlink, missing-media detection, relink candidate planning,
-  and safe relink all worked through generated media.
+- Synthetic-only unlink, missing-media detection, sanitized missing-volume
+  diagnosis, relink candidate planning, and safe relink all worked through
+  generated media.
 
 ## Boundaries
 
@@ -74,8 +75,11 @@ Supported aliases include `aaf`, `drt`, `edl`, `edl_cdl`, `edl_sdl`,
   relationships.
 - The public API exposes timeline items, source ranges, markers, and some media
   references, but not full transition/effect/retime semantics for every format.
-- `build_relink_plan` is intentionally read-only. Execute relinks through
-  `media_pool.safe_relink` only with synthetic or explicitly approved paths.
+- `build_relink_plan` is intentionally read-only. It deduplicates missing
+  basenames, supports `max_depth`, `max_seconds`, and `max_files_scanned`, and
+  skips broad scans by default when a source volume such as a camera card is not
+  mounted. Execute relinks through `media_pool.safe_relink` only with synthetic
+  or explicitly approved paths.
 - Missing-media status fields vary by Resolve build. The kernel combines status
   text with local file existence when a file path is available.
 - Export and import helpers require temp paths by default because they write

--- a/skills/davinci-resolve-mcp/SKILL.md
+++ b/skills/davinci-resolve-mcp/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: davinci-resolve-mcp
+description: Use when working with DaVinci Resolve projects through the local davinci-resolve MCP server, including project inspection, timeline editing, media pool management, markers, color/Fusion/Fairlight/Deliver operations, Resolve script plugins, DCTLs, Fuses, UI automation fallbacks, or troubleshooting Resolve MCP connectivity.
+---
+
+# DaVinci Resolve MCP
+
+Use the local `davinci-resolve` MCP server to work with DaVinci Resolve Studio
+projects. Treat Resolve project state and source media as production assets:
+verify before writing, and never modify source media unless the user asks for
+that exact operation.
+
+This skill is portable. Do not hard-code user-specific paths. Prefer:
+
+- `DAVINCI_MCP_REPO` for the local checkout path
+- `DAVINCI_MCP_PYTHON` for the Python interpreter
+- `CODEX_HOME` for Codex configuration
+- repo-relative helper paths when this skill is used from the checkout
+
+## Local Setup
+
+- MCP checkout: `$DAVINCI_MCP_REPO` or the repository containing this skill
+- Server entrypoint: `$DAVINCI_MCP_REPO/src/server.py`
+- Python: `$DAVINCI_MCP_PYTHON` or `$DAVINCI_MCP_REPO/.venv/bin/python`
+- Codex config: `$CODEX_HOME/config.toml`
+- Claude Desktop config:
+  `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Detailed upstream skill reference: `$DAVINCI_MCP_REPO/docs/SKILL.md`
+- Install/reference docs: `$DAVINCI_MCP_REPO/docs/install.md`
+- Control panel docs: `$DAVINCI_MCP_REPO/docs/guides/control-panel.md`
+- Read-only doctor:
+  `$DAVINCI_MCP_REPO/skills/davinci-resolve-mcp/scripts/doctor.py`
+
+If DaVinci MCP tools are not present in the active tool list, tell the user to
+restart the MCP client so the server config is reloaded. Do not pretend to have
+live Resolve tool access when the tools are not available.
+
+Run the doctor when setup or connection state is unclear:
+
+```bash
+python skills/davinci-resolve-mcp/scripts/doctor.py
+```
+
+## Before Acting
+
+1. Confirm the user's Resolve intent: inspect, organize, edit, grade, render,
+   automate, or troubleshoot.
+2. Use MCP tools directly when available. Start with
+   `resolve_control(action="launch")`, then `get_version` and `get_page`.
+3. If Resolve does not connect, check that DaVinci Resolve Studio is running and
+   Preferences > General > External scripting using is set to `Local`. If the
+   Python module imports but `scriptapp("Resolve")` returns false, this is the
+   exact user-facing next action:
+
+```text
+App: DaVinci Resolve Studio
+Exact screen: DaVinci Resolve > Settings/Preferences > General
+Click path: External scripting using
+Value: Local
+Expected result: restart Resolve, then resolve_control(get_version) returns product/version
+```
+
+4. Before destructive actions such as delete project, delete clips, quit app, or
+   overwrite exports, ask for explicit confirmation.
+5. Re-fetch project, timeline, clip, and item IDs after destructive edits because
+   Resolve API object references can become stale.
+
+## UI Automation Fallback
+
+Prefer Resolve's scripting API and MCP actions first. When Resolve has a UI
+feature that is not exposed by `GetSetting/SetSetting` or any documented API
+method, use macOS UI automation as the second layer instead of inventing visual
+overlays or non-native workarounds. This is local, macOS-only, and requires
+Accessibility permission, but it keeps the operation native inside Resolve.
+
+Use the generic helper for menu-only features:
+
+```bash
+python skills/davinci-resolve-mcp/scripts/resolve_menu_click.py \
+  Timeline "Output Blanking" 2.39
+```
+
+Use `--dry-run` before a new path, and `--list-menu-bar` when menu labels are
+unclear. If the command reports `-1719`, `Hilfszugriff`, or assistive access,
+tell the user the exact fix: `System Settings > Privacy & Security >
+Accessibility`, then allow the app/process running the MCP client or
+`osascript`/Terminal. UI automation must be verified with a read-back where
+possible: Resolve settings snapshot, current page/timeline, rendered frame,
+still, thumbnail, or visible menu state.
+
+## Output Blanking
+
+For native timeline output blanking, do not build overlay mattes unless the user
+explicitly asks for that workaround. Resolve does not expose Timeline > Output
+Blanking through the normal `GetSetting/SetSetting` API on tested builds, so use
+the local macOS UI automation path:
+
+- Preferred MCP action:
+  `timeline(action="set_output_blanking_ui", params={"aspect": "2.39"})`
+- Capabilities/readiness:
+  `timeline(action="output_blanking_ui_capabilities")`
+- Direct helper fallback:
+
+```bash
+python skills/davinci-resolve-mcp/scripts/resolve_output_blanking_ui.py 2.39
+```
+
+Common presets/aliases: `1.33`/`4:3`, `1.66`, `1.77`/`16:9`, `1.85`, `2.0`,
+`2.35`, `2.39`, `2.40`, and `off`.
+
+## Offline Media / Relink
+
+For offline media, lead with a sanitized readback:
+
+```text
+timeline(action="detect_missing_media", params={"sanitized": true})
+```
+
+The response includes a `diagnosis` block with deduplicated Media Pool items,
+missing volume roots, sample basenames, and a recommended next step. If a source
+volume such as a camera card is not mounted, `build_relink_plan` skips broad
+search by default and reports `skip_reason="missing_source_volume_not_mounted"`.
+Mount the volume or pass `skip_search_when_volume_missing=false` only when a
+bounded scan of approved roots is intentional.
+
+Relinking is a Resolve project database change. Use `media_pool.safe_relink`
+with explicit, user-approved paths after reviewing the plan.
+
+## Page Context
+
+Switch pages before page-sensitive work:
+
+- Edit/Cut: timeline edits, tracks, generators, titles
+- Media: media import and storage browsing
+- Color: node graphs, CDL, Gallery stills
+- Fusion: active Fusion composition work
+- Fairlight: audio-specific work
+- Deliver: render queue, render settings, export jobs
+
+Use `resolve_control(action="open_page", params={"page": "<page>"})` when the
+current page is wrong.
+
+## Common Workflow
+
+For a new Resolve task:
+
+1. Launch/connect and get version/page.
+2. Get current project via `project_manager(action="get_current")`.
+3. Get current timeline via `timeline(action="get_current")`.
+4. Fetch media pool clips or timeline items before editing.
+5. Make the smallest safe MCP change.
+6. Verify with a read-back tool call such as timeline/project/item get/list.
+
+For visual inspection, prefer:
+
+- `timeline_markers(action="get_thumbnail_image")` for an MCP image when the
+  client can display images.
+- `timeline_markers(action="get_thumbnail")` only when raw Resolve thumbnail
+  data is needed by tooling.
+- `gallery_stills(action="grab_and_export")` on the Color page when a standard
+  image export is needed.
+
+For the local control panel, prefer the MCP actions in current builds:
+
+- `resolve_control(action="open_control_panel")`
+- `resolve_control(action="control_panel_status")`
+- `resolve_control(action="close_control_panel")`
+
+If those actions are unavailable, run:
+
+```bash
+python -m src.control_panel --no-open
+```
+
+## Tool Families
+
+The compound server exposes action-based tools. Key families:
+
+- `resolve_control`, `layout_presets`, `render_presets`
+- `project_manager`, `project_manager_folders`, `project_manager_database`,
+  `project_manager_cloud`, `project_settings`
+- `media_storage`, `media_pool`, `folder`, `media_pool_item`
+- `timeline`, `timeline_markers`, `timeline_ai`
+- `timeline_item`, `timeline_item_markers`, `timeline_item_fusion`,
+  `timeline_item_color`, `timeline_item_takes`
+- `timeline_versioning`, `gallery`, `gallery_stills`, `graph`, `color_group`,
+  `fusion_comp`, `render`
+- `fuse_plugin`, `dctl`, `script_plugin`
+- `media_analysis`, `setup`
+
+## Media Analysis Defaults
+
+Source-safe does not mean underpowered. For Resolve-target media analysis, keep
+visual analysis, transcription, persisted artifacts, metadata writeback, and
+Media Pool marker writeback enabled unless the user explicitly opts out. If
+`host_chat_paths` returns frame paths and a `vision_token`, read the frames as
+images and finish the run with
+`media_analysis(action="commit_vision", params={...})`; pending vision is not a
+successful completed analysis.
+
+Use these docs when needed:
+
+- Media analysis: `docs/guides/media-analysis-guide.md`
+- Editorial decisions: `docs/guides/editorial-decision-guide.md`
+- Color decisions: `docs/guides/color-decision-guide.md`
+- Kernel map: `docs/kernels/README.md`
+
+When a failure involves Fuses, DCTLs, scripts, LUTs, OpenFX, Fusion templates,
+workflow integrations, or codec plugins, read the relevant note from the repo's
+`docs/authoring/`, `docs/notes/`, or `docs/integrations/` directory instead of
+guessing.

--- a/skills/davinci-resolve-mcp/SKILL.md
+++ b/skills/davinci-resolve-mcp/SKILL.md
@@ -17,6 +17,10 @@ This skill is portable. Do not hard-code user-specific paths. Prefer:
 - `CODEX_HOME` for Codex configuration
 - repo-relative helper paths when this skill is used from the checkout
 
+Current upstream baseline: `v2.28.0`. This adds project lint, declarative
+project specs, timeline-version structural diff, clip query filters, and
+machine-readable error `state` fields.
+
 ## Local Setup
 
 - MCP checkout: `$DAVINCI_MCP_REPO` or the repository containing this skill
@@ -171,6 +175,49 @@ If those actions are unavailable, run:
 ```bash
 python -m src.control_panel --no-open
 ```
+
+## Project Lint And Specs
+
+Use v2.28.0 project-management actions when a user asks for project setup,
+health checks, repeatable project templates, or "make this project match this
+spec":
+
+- `project_manager(action="lint")`: read-only project health pre-flight.
+  Reports errors/warnings/info for missing project/timeline, mixed frame rates,
+  empty timelines, unset render format, unmanaged color science, offline media,
+  and unanalyzed clips.
+- `project_manager(action="diff_to_spec", params={"spec_path": "..."} )` or
+  `params={"spec": {...}}`: preview drift without mutating.
+- `project_manager(action="plan_spec", params={...})`: ordered dry-run action
+  list.
+- `project_manager(action="apply_spec", params={"spec_path": "...",
+  "dry_run": true})`: reconcile only after reviewing the dry run. Shell hooks
+  run only with `run_hooks=true`.
+
+Specs are YAML or JSON and may include `project`, `color_preset`, `settings`,
+`timelines`, `markers`, and opt-in `hooks`. Treat `apply_spec` as a Resolve
+project mutation. Run dry-run first and ask for explicit approval before a
+non-dry-run apply.
+
+If a tool error includes a `state` object, read that structured state instead
+of parsing prose; it is intended for agent recovery.
+
+## Timeline Diff And Clip Query
+
+Use v2.28.0 timeline tools to avoid manual track walking:
+
+- `timeline_versioning(action="diff_versions", params={"timeline_name": "...",
+  "from_version": 1, "to_version": 2})`: structural diff between archived
+  timeline snapshots. Returns added, removed, moved, trimmed, and summary
+  counts.
+- `timeline(action="clip_where", params={"filters": {...}})`: find current
+  timeline clips with AND filters such as `track_type`, `track_index`,
+  `name_contains`, `duration_lt`, and `duration_gt`. Unknown filters are
+  rejected instead of silently matching everything.
+
+Use `diff_versions` after major automated edits to explain exactly what changed.
+Use `clip_where` before edits when the target clips can be described by name,
+track, or duration.
 
 ## Tool Families
 

--- a/skills/davinci-resolve-mcp/agents/openai.yaml
+++ b/skills/davinci-resolve-mcp/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "DaVinci Resolve MCP"
+  short_description: "Work with Resolve projects through MCP."
+  default_prompt: "Use $davinci-resolve-mcp to inspect and modify my open DaVinci Resolve project."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "davinci-resolve"
+      description: "Local DaVinci Resolve MCP server configured in the active MCP client."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/davinci-resolve-mcp/agents/openai.yaml
+++ b/skills/davinci-resolve-mcp/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "DaVinci Resolve MCP"
-  short_description: "Work with Resolve projects through MCP."
+  short_description: "Work with Resolve projects through MCP, including project lint/spec workflows, timeline diffing, clip queries, media analysis, and safe edit/delivery operations."
   default_prompt: "Use $davinci-resolve-mcp to inspect and modify my open DaVinci Resolve project."
 
 dependencies:
@@ -11,3 +11,15 @@ dependencies:
 
 policy:
   allow_implicit_invocation: true
+  source_media_safety: "Never modify source media unless explicitly requested."
+  preferred_first_calls:
+    - "resolve_control(action='launch')"
+    - "resolve_control(action='get_version')"
+    - "project_manager(action='lint')"
+  v2_28_highlights:
+    - "project_manager.lint"
+    - "project_manager.diff_to_spec"
+    - "project_manager.plan_spec"
+    - "project_manager.apply_spec"
+    - "timeline_versioning.diff_versions"
+    - "timeline.clip_where"

--- a/skills/davinci-resolve-mcp/scripts/doctor.py
+++ b/skills/davinci-resolve-mcp/scripts/doctor.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Read-only diagnostics for a local DaVinci Resolve MCP setup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def find_repo_root() -> Path:
+    env_repo = os.environ.get("DAVINCI_MCP_REPO")
+    if env_repo:
+        return Path(env_repo).expanduser().resolve()
+    current = Path(__file__).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / "src" / "server.py").exists():
+            return candidate
+    return current.parents[3]
+
+
+REPO = find_repo_root()
+PYTHON = Path(os.environ.get("DAVINCI_MCP_PYTHON", REPO / ".venv" / "bin" / "python")).expanduser()
+if not PYTHON.exists():
+    PYTHON = Path(sys.executable)
+SERVER = REPO / "src" / "server.py"
+CODEX_HOME = Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+CODEX_CONFIG = CODEX_HOME / "config.toml"
+CLAUDE_CONFIG = Path(
+    os.environ.get(
+        "CLAUDE_DESKTOP_CONFIG",
+        "~/Library/Application Support/Claude/claude_desktop_config.json",
+    )
+).expanduser()
+RESOLVE_APP = Path(os.environ.get("RESOLVE_APP", "/Applications/DaVinci Resolve/DaVinci Resolve.app"))
+RESOLVE_API = Path(
+    os.environ.get(
+        "RESOLVE_SCRIPT_API",
+        "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting",
+    )
+)
+RESOLVE_MODULES = Path(os.environ.get("RESOLVE_SCRIPT_MODULES", RESOLVE_API / "Modules"))
+RESOLVE_LIB = Path(
+    os.environ.get(
+        "RESOLVE_SCRIPT_LIB",
+        "/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion/fusionscript.so",
+    )
+)
+
+
+def run(cmd: list[str], timeout: int = 12) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except Exception as exc:
+        return {"ok": False, "returncode": None, "stdout": "", "stderr": str(exc)}
+
+
+def run_in_repo(cmd: list[str], timeout: int = 12) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True, timeout=timeout)
+        return {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except Exception as exc:
+        return {"ok": False, "returncode": None, "stdout": "", "stderr": str(exc)}
+
+
+def check(results: list[dict[str, str]], status: str, name: str, detail: str) -> None:
+    results.append({"status": status, "name": name, "detail": detail})
+
+
+def file_contains(path: Path, needles: list[str]) -> tuple[bool, str]:
+    if not path.exists():
+        return False, "missing"
+    text = path.read_text(errors="replace")
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        return False, "missing: " + ", ".join(missing)
+    return True, "contains davinci-resolve MCP entry"
+
+
+def version_from_server() -> str:
+    if not SERVER.exists():
+        return "unknown"
+    match = re.search(r'^VERSION\s*=\s*"([^"]+)"', SERVER.read_text(errors="replace"), re.M)
+    return match.group(1) if match else "unknown"
+
+
+def git_summary() -> str:
+    if not (REPO / ".git").exists():
+        return "not a git checkout"
+    status = run_in_repo(["git", "status", "--short", "--branch"], timeout=8)
+    return status["stdout"] or status["stderr"] or "git status produced no output"
+
+
+def git_head() -> str:
+    if not (REPO / ".git").exists():
+        return "not a git checkout"
+    head = run_in_repo(["git", "describe", "--tags", "--always", "--dirty"], timeout=8)
+    return head["stdout"] or head["stderr"] or "git describe produced no output"
+
+
+def resolve_probe() -> dict[str, Any]:
+    if not PYTHON.exists():
+        return {"import_ok": False, "error": f"{PYTHON} is missing"}
+
+    code = f"""
+import json
+import sys
+sys.path.insert(0, {str(RESOLVE_MODULES)!r})
+try:
+    import DaVinciResolveScript as dvr
+    resolve = dvr.scriptapp("Resolve")
+    payload = {{
+        "import_ok": True,
+        "module": getattr(dvr, "__file__", None),
+        "resolve_connected": bool(resolve),
+        "product": resolve.GetProductName() if resolve else None,
+        "version": resolve.GetVersionString() if resolve else None,
+    }}
+except Exception as exc:
+    payload = {{"import_ok": False, "error": repr(exc)}}
+print(json.dumps(payload))
+"""
+    env = {
+        **os.environ,
+        "RESOLVE_SCRIPT_API": str(RESOLVE_API),
+        "RESOLVE_SCRIPT_LIB": str(RESOLVE_LIB),
+        "PYTHONPATH": str(RESOLVE_MODULES),
+    }
+    proc = subprocess.run([str(PYTHON), "-c", code], capture_output=True, text=True, timeout=12, env=env)
+    output = (proc.stdout or proc.stderr).strip()
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError:
+        payload = {"import_ok": False, "error": output or f"probe exited {proc.returncode}"}
+    payload["returncode"] = proc.returncode
+    return payload
+
+
+def collect() -> list[dict[str, str]]:
+    results: list[dict[str, str]] = []
+
+    check(results, "OK" if REPO.exists() else "FAIL", "MCP checkout", str(REPO))
+    check(results, "OK" if SERVER.exists() else "FAIL", "Server entrypoint", str(SERVER))
+    check(results, "OK" if PYTHON.exists() else "FAIL", "Python", str(PYTHON))
+    check(results, "OK" if RESOLVE_APP.exists() else "FAIL", "Resolve app", str(RESOLVE_APP))
+    check(results, "OK" if RESOLVE_API.exists() else "FAIL", "Resolve scripting API", str(RESOLVE_API))
+    check(results, "OK" if RESOLVE_MODULES.exists() else "FAIL", "Resolve scripting modules", str(RESOLVE_MODULES))
+    check(results, "OK" if RESOLVE_LIB.exists() else "FAIL", "Resolve scripting library", str(RESOLVE_LIB))
+
+    needles = [str(SERVER), str(RESOLVE_API), str(RESOLVE_LIB), str(RESOLVE_MODULES)]
+    ok, detail = file_contains(CODEX_CONFIG, needles)
+    check(results, "OK" if ok else "WARN", "Codex MCP config", f"{CODEX_CONFIG}: {detail}")
+    ok, detail = file_contains(CLAUDE_CONFIG, needles)
+    check(results, "OK" if ok else "WARN", "Claude Desktop MCP config", f"{CLAUDE_CONFIG}: {detail}")
+
+    pyver = run([str(PYTHON), "--version"]) if PYTHON.exists() else {"ok": False, "stdout": "", "stderr": "missing"}
+    check(results, "OK" if pyver["ok"] else "FAIL", "Python version", pyver["stdout"] or pyver["stderr"])
+
+    probe = resolve_probe()
+    if probe.get("import_ok"):
+        check(results, "OK", "DaVinciResolveScript import", str(probe.get("module")))
+        if probe.get("resolve_connected"):
+            detail = f"{probe.get('product')} {probe.get('version')}"
+            check(results, "OK", "Resolve scripting connection", detail)
+        else:
+            check(
+                results,
+                "WARN",
+                "Resolve scripting connection",
+                'Module import worked, but scriptapp("Resolve") returned no object. Open DaVinci Resolve Studio, set Preferences > General > External scripting using = Local, and restart Resolve.',
+            )
+    else:
+        check(results, "FAIL", "DaVinciResolveScript import", str(probe.get("error")))
+
+    check(results, "OK", "MCP server version", version_from_server())
+    check(results, "OK", "MCP git head", git_head())
+    check(results, "OK", "Git status", git_summary())
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    args = parser.parse_args()
+
+    results = collect()
+    if args.json:
+        print(json.dumps({"checks": results}, indent=2))
+    else:
+        for item in results:
+            print(f"[{item['status']}] {item['name']}: {item['detail']}")
+
+    return 1 if any(item["status"] == "FAIL" for item in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/davinci-resolve-mcp/scripts/resolve_menu_click.py
+++ b/skills/davinci-resolve-mcp/scripts/resolve_menu_click.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Click an arbitrary DaVinci Resolve menu path on macOS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def applescript_list(values: list[str]) -> str:
+    return "{" + ", ".join(json.dumps(value) for value in values) + "}"
+
+
+def build_click_script(menu_path: list[str], delay: float) -> str:
+    return f"""
+tell application "DaVinci Resolve" to activate
+delay {delay}
+tell application "System Events"
+  tell process "DaVinci Resolve"
+    set frontmost to true
+    set pathLabels to {applescript_list(menu_path)}
+    set pathCount to count of pathLabels
+    if pathCount < 2 then error "Menu path must include at least a menu and a menu item"
+
+    set currentMenu to menu 1 of menu bar item (item 1 of pathLabels) of menu bar 1
+    if pathCount > 2 then
+      repeat with i from 2 to (pathCount - 1)
+        set currentMenu to menu 1 of menu item (item i of pathLabels) of currentMenu
+      end repeat
+    end if
+    set clickedLabel to item pathCount of pathLabels
+    click menu item clickedLabel of currentMenu
+    return clickedLabel
+  end tell
+end tell
+"""
+
+
+def build_list_menubar_script(delay: float) -> str:
+    return f"""
+tell application "DaVinci Resolve" to activate
+delay {delay}
+tell application "System Events"
+  tell process "DaVinci Resolve"
+    set frontmost to true
+    return name of menu bar items of menu bar 1
+  end tell
+end tell
+"""
+
+
+def run_osascript(script: str, timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def error_payload(proc: subprocess.CompletedProcess[str], menu_path: list[str]) -> dict[str, object]:
+    stderr = (proc.stderr or "").strip()
+    stdout = (proc.stdout or "").strip()
+    note = None
+    if "-1719" in stderr or "Hilfszugriff" in stderr or "assistive" in stderr.lower():
+        note = (
+            "Grant Accessibility permission in System Settings > Privacy & Security > "
+            "Accessibility for the app/process running this helper or for osascript/Terminal."
+        )
+    return {
+        "success": False,
+        "error": stderr or stdout or f"osascript exited {proc.returncode}",
+        "returncode": proc.returncode,
+        "menu_path": menu_path,
+        "accessibility_note": note,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("menu_path", nargs="*", help='Menu path, e.g. Timeline "Output Blanking" 2.39')
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned click without executing")
+    parser.add_argument("--list-menu-bar", action="store_true", help="List Resolve menu bar labels")
+    parser.add_argument("--delay", type=float, default=0.4, help="Activation delay before reading menus")
+    parser.add_argument("--timeout", type=int, default=8)
+    args = parser.parse_args()
+
+    if sys.platform != "darwin":
+        print(json.dumps({"success": False, "error": "macOS only"}, indent=2), file=sys.stderr)
+        return 2
+
+    if args.list_menu_bar:
+        proc = run_osascript(build_list_menubar_script(args.delay), args.timeout)
+        if proc.returncode != 0:
+            print(json.dumps(error_payload(proc, []), indent=2), file=sys.stderr)
+            return proc.returncode
+        print(json.dumps({
+            "success": True,
+            "menu_bar_items": [item.strip() for item in (proc.stdout or "").strip().split(",") if item.strip()],
+        }, indent=2))
+        return 0
+
+    if len(args.menu_path) < 2:
+        parser.error("Provide at least two path parts: menu and menu item")
+
+    if args.dry_run:
+        print(json.dumps({
+            "success": True,
+            "dry_run": True,
+            "menu_path": args.menu_path,
+        }, indent=2))
+        return 0
+
+    proc = run_osascript(build_click_script(args.menu_path, args.delay), args.timeout)
+    if proc.returncode != 0:
+        print(json.dumps(error_payload(proc, args.menu_path), indent=2), file=sys.stderr)
+        return proc.returncode
+
+    print(json.dumps({
+        "success": True,
+        "clicked_label": (proc.stdout or "").strip(),
+        "menu_path": args.menu_path,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/davinci-resolve-mcp/scripts/resolve_output_blanking_ui.py
+++ b/skills/davinci-resolve-mcp/scripts/resolve_output_blanking_ui.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Click DaVinci Resolve's native Timeline > Output Blanking menu on macOS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+ALIASES = {
+    "1.33": ["1.33", "1.33:1", "4:3"],
+    "4:3": ["1.33", "1.33:1", "4:3"],
+    "1.66": ["1.66", "1.66:1"],
+    "1.77": ["1.77", "1.77:1", "1.78", "1.78:1", "16:9"],
+    "16:9": ["1.77", "1.77:1", "1.78", "1.78:1", "16:9"],
+    "1.85": ["1.85", "1.85:1"],
+    "2.0": ["2.0", "2.00", "2.0:1", "2.00:1", "2:1"],
+    "2.35": ["2.35", "2.35:1"],
+    "2.39": ["2.39", "2.39:1"],
+    "2.40": ["2.40", "2.4", "2.40:1", "2.4:1"],
+    "none": ["None", "No Blanking", "Reset", "Off"],
+    "off": ["None", "No Blanking", "Reset", "Off"],
+    "reset": ["None", "No Blanking", "Reset", "Off"],
+}
+
+
+def candidate_labels(aspect: Any) -> list[str]:
+    raw = str(aspect or "").strip()
+    if not raw:
+        return []
+    key = raw.lower().replace(" ", "")
+    if key in ALIASES:
+        return ALIASES[key]
+    if raw.endswith(":1"):
+        return [raw[:-2], raw]
+    return [raw, f"{raw}:1"]
+
+
+def applescript_list(values: list[str]) -> str:
+    return "{" + ", ".join(json.dumps(value) for value in values) + "}"
+
+
+def build_script(candidates: list[str], delay: float) -> str:
+    return f"""
+tell application "DaVinci Resolve" to activate
+delay {delay}
+tell application "System Events"
+  tell process "DaVinci Resolve"
+    set frontmost to true
+    set timelineMenuLabels to {applescript_list(["Timeline", "Zeitleiste"])}
+    set outputMenuLabels to {applescript_list(["Output Blanking", "Ausgabe-Austastung"])}
+    set targetLabels to {applescript_list(candidates)}
+    set clickedLabel to ""
+    set timelineMenuLabel to ""
+    set outputMenuLabel to ""
+
+    repeat with timelineCandidate in timelineMenuLabels
+      try
+        set timelineMenuLabel to timelineCandidate as text
+        set timelineMenu to menu 1 of menu bar item timelineMenuLabel of menu bar 1
+        exit repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+        set timelineMenuLabel to ""
+      end try
+    end repeat
+    if timelineMenuLabel is "" then error "Timeline menu not found"
+
+    repeat with outputCandidate in outputMenuLabels
+      try
+        set outputMenuLabel to outputCandidate as text
+        set outputMenu to menu 1 of menu item outputMenuLabel of timelineMenu
+        exit repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+        set outputMenuLabel to ""
+      end try
+    end repeat
+    if outputMenuLabel is "" then error "Output Blanking submenu not found"
+
+    repeat with targetCandidate in targetLabels
+      try
+        set clickedLabel to targetCandidate as text
+        click menu item clickedLabel of outputMenu
+        exit repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+        set clickedLabel to ""
+      end try
+    end repeat
+    if clickedLabel is "" then
+      set availableLabels to name of menu items of outputMenu
+      error "Output Blanking preset not found. Available: " & (availableLabels as text)
+    end if
+    return clickedLabel
+  end tell
+end tell
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("aspect", nargs="?", help="Preset such as 2.39, 2.35, 1.85, 4:3, 16:9, or off")
+    parser.add_argument("--dry-run", action="store_true", help="Print candidates without clicking")
+    parser.add_argument("--list-presets", action="store_true", help="Print supported aliases")
+    parser.add_argument("--delay", type=float, default=0.4, help="Activation delay before reading menus")
+    parser.add_argument("--timeout", type=int, default=8)
+    args = parser.parse_args()
+
+    if args.list_presets:
+        print(json.dumps(ALIASES, indent=2, sort_keys=True))
+        return 0
+
+    candidates = candidate_labels(args.aspect)
+    if not candidates:
+        parser.error("aspect is required unless --list-presets is used")
+
+    if args.dry_run:
+        print(json.dumps({
+            "success": True,
+            "dry_run": True,
+            "aspect": args.aspect,
+            "candidate_labels": candidates,
+            "menu_path": "Timeline > Output Blanking",
+        }, indent=2))
+        return 0
+
+    if sys.platform != "darwin":
+        print(json.dumps({"success": False, "error": "macOS only"}, indent=2), file=sys.stderr)
+        return 2
+
+    proc = subprocess.run(
+        ["osascript", "-e", build_script(candidates, args.delay)],
+        capture_output=True,
+        text=True,
+        timeout=args.timeout,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        note = None
+        if "-1719" in stderr or "Hilfszugriff" in stderr or "assistive" in stderr.lower():
+            note = (
+                "Grant Accessibility permission in System Settings > Privacy & Security > "
+                "Accessibility for the app/process running this helper or for osascript/Terminal."
+            )
+        print(json.dumps({
+            "success": False,
+            "error": stderr or (proc.stdout or "").strip(),
+            "returncode": proc.returncode,
+            "candidate_labels": candidates,
+            "accessibility_note": note,
+        }, indent=2), file=sys.stderr)
+        return proc.returncode
+
+    print(json.dumps({
+        "success": True,
+        "clicked_label": (proc.stdout or "").strip(),
+        "candidate_labels": candidates,
+        "menu_path": "Timeline > Output Blanking",
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/server.py
+++ b/src/server.py
@@ -5767,6 +5767,8 @@ _MEDIA_POOL_KERNEL_ACTIONS = [
     "safe_unlink",
     "link_proxy_checked",
     "link_full_resolution_checked",
+    "generate_proxy_media_ui_capabilities",
+    "generate_proxy_media_ui",
     "set_clip_marks",
     "clear_clip_marks",
     "copy_clip_annotations",
@@ -9085,6 +9087,7 @@ def _media_pool_ingest_capabilities():
                 "media_pool.safe_relink and safe_unlink with path/clip validation",
                 "proxy link/unlink through MediaPoolItem APIs",
                 "media_pool.link_proxy_checked with file validation",
+                "media_pool.generate_proxy_media_ui for Resolve's native proxy generator via guarded macOS UI automation",
                 "full-resolution media link where Resolve 20 exposes it",
                 "media_pool.link_full_resolution_checked with version/path validation",
             ],
@@ -9107,6 +9110,7 @@ def _media_pool_ingest_capabilities():
         "partially_supported": {
             "clip_properties": "Resolve accepts only some GetClipProperty/SetClipProperty keys by media type and build.",
             "proxy_and_full_resolution_links": "Resolve may accept paths without deep compatibility validation; probes must use synthetic media.",
+            "native_proxy_generation": "Resolve exposes no documented Generate Proxy Media scripting API; media_pool.generate_proxy_media_ui uses macOS UI automation with dry_run and allow_generate guards.",
             "audio_transcription": "Transcription availability depends on Resolve Studio features, installed components, media type, and page/build state.",
             "image_sequences": "Sequence import behavior depends on FilePath pattern, frame range, and Resolve's still/sequence interpretation.",
             "audio_mapping": "Readback is available on supported media, but mapping shape varies by clip type.",
@@ -9596,6 +9600,277 @@ def _link_full_resolution_checked(root, p: Dict[str, Any]):
     if p.get("dry_run"):
         return _ok(clip=_media_pool_item_summary(clip), path=path)
     return {"success": bool(clip.LinkFullResolutionMedia(path))}
+
+
+_GENERATE_PROXY_MEDIA_UI_LABELS = [
+    "Generate Proxy Media",
+    "Proxy Media generieren",
+    "Proxy-Medien generieren",
+    "Proxy-Medien erzeugen",
+]
+
+
+def _proxy_media_readback(clip):
+    summary = _media_pool_item_summary(clip)
+    out = {
+        "clip": summary,
+        "proxy": None,
+        "proxy_media_path": None,
+        "properties_available": False,
+    }
+    properties, prop_err = _safe_clip_call(clip, "GetClipProperty", "")
+    if not isinstance(properties, dict):
+        if prop_err:
+            out["error"] = prop_err
+        return out
+    out["properties_available"] = True
+    out["proxy"] = properties.get("Proxy") or properties.get("Proxy Media")
+    out["proxy_media_path"] = (
+        properties.get("Proxy Media Path")
+        or properties.get("Proxy Media File Path")
+        or properties.get("Proxy Path")
+        or ""
+    )
+    return out
+
+
+def _generate_proxy_media_ui_capabilities():
+    return {
+        "available": sys.platform == "darwin",
+        "platform": sys.platform,
+        "mode": "macos_system_events_ui_automation",
+        "official_resolve_api": {
+            "generate_proxy_media": False,
+            "link_proxy_media": True,
+        },
+        "actions": ["generate_proxy_media_ui"],
+        "ui_path": "Media page > selected Media Pool clip(s) > context menu > Generate Proxy Media",
+        "guards": {
+            "dry_run_supported": True,
+            "allow_generate_required": True,
+            "selected_clips_supported": True,
+            "explicit_clip_id_supported": True,
+            "explicit_multi_clip_selection": "preselect clips in Resolve and call selected=True",
+            "proxy_path_readback": "best-effort via GetClipProperty('') keys such as Proxy Media Path",
+        },
+        "notes": [
+            "DaVinci Resolve's public scripting API exposes LinkProxyMedia but not a documented Generate Proxy Media call.",
+            "This fallback clicks Resolve's native UI command and therefore requires macOS Accessibility permission.",
+            "Resolve may generate proxies asynchronously; proxy path readback can remain empty until the background job finishes.",
+        ],
+    }
+
+
+def _generate_proxy_media_ui_script(labels: List[str], delay_seconds: float) -> str:
+    delay_seconds = max(0.0, min(float(delay_seconds), 5.0))
+    app_menu_labels = [
+        "Clip",
+        "Clips",
+        "Media Pool",
+        "Media",
+        "Medienpool",
+        "Medien",
+    ]
+    return f"""
+on tryMenuBarClick(menuLabels, targetLabels)
+  tell application "System Events"
+    tell process "DaVinci Resolve"
+      repeat with menuCandidate in menuLabels
+        try
+          set menuCandidateText to menuCandidate as text
+          set candidateMenu to menu 1 of menu bar item menuCandidateText of menu bar 1
+          repeat with targetCandidate in targetLabels
+            try
+              set targetText to targetCandidate as text
+              click menu item targetText of candidateMenu
+              return targetText
+            on error errMsg number errNum
+              if errNum is -1719 then error errMsg number errNum
+            end try
+          end repeat
+        on error errMsg number errNum
+          if errNum is -1719 then error errMsg number errNum
+        end try
+      end repeat
+    end tell
+  end tell
+  return ""
+end tryMenuBarClick
+
+on tryFocusedContextMenuClick(targetLabels)
+  tell application "System Events"
+    tell process "DaVinci Resolve"
+      try
+        set focusedElement to value of attribute "AXFocusedUIElement"
+        perform action "AXShowMenu" of focusedElement
+        delay {delay_seconds}
+        repeat with targetCandidate in targetLabels
+          try
+            set targetText to targetCandidate as text
+            click menu item targetText of menu 1 of focusedElement
+            return targetText
+          on error errMsg number errNum
+            if errNum is -1719 then error errMsg number errNum
+          end try
+        end repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+      end try
+    end tell
+  end tell
+  return ""
+end tryFocusedContextMenuClick
+
+tell application "DaVinci Resolve" to activate
+delay 0.4
+tell application "System Events"
+  tell process "DaVinci Resolve"
+    set frontmost to true
+  end tell
+end tell
+
+set targetLabels to {_applescript_list(labels)}
+set menuLabels to {_applescript_list(app_menu_labels)}
+set clickedLabel to tryMenuBarClick(menuLabels, targetLabels)
+if clickedLabel is "" then set clickedLabel to tryFocusedContextMenuClick(targetLabels)
+if clickedLabel is "" then
+  error "Generate Proxy Media menu item not found. Open the Media page, select clip(s) in the Media Pool, focus the Media Pool, then retry."
+end if
+return clickedLabel
+"""
+
+
+def _generate_proxy_media_ui(resolve_obj, mp, root, p: Dict[str, Any]):
+    resolved, err = _clips_from_params(root, mp, p)
+    if err:
+        return err
+    clips, missing = resolved
+    ids = p.get("clip_ids") or p.get("ids")
+    selected = bool(p.get("selected", False))
+    explicit_ids = list(ids) if isinstance(ids, list) else []
+    labels = p.get("candidate_labels") or p.get("labels") or _GENERATE_PROXY_MEDIA_UI_LABELS
+    if not isinstance(labels, list) or not labels or not all(isinstance(label, str) and label for label in labels):
+        return _err("candidate_labels must be a non-empty list of strings")
+    before = [_proxy_media_readback(clip) for clip in clips]
+
+    if sys.platform != "darwin":
+        if p.get("dry_run"):
+            return _ok(
+                available=False,
+                dry_run=True,
+                would_generate=True,
+                clips=_clip_summaries(clips),
+                missing=missing,
+                before=before,
+                candidate_labels=labels,
+                accessibility_required=True,
+                note="generate_proxy_media_ui is macOS-only because it uses System Events UI automation.",
+            )
+        return _err("generate_proxy_media_ui is macOS-only because it uses System Events UI automation")
+
+    if explicit_ids and len(explicit_ids) > 1 and not selected:
+        return _err(
+            "For multiple clips, preselect them in Resolve's Media Pool and call generate_proxy_media_ui with selected=True. "
+            "The Resolve API exposes SetSelectedClip for one clip, not a documented multi-select API."
+        )
+
+    if p.get("dry_run"):
+        return _ok(
+            dry_run=True,
+            would_generate=True,
+            clips=_clip_summaries(clips),
+            missing=missing,
+            before=before,
+            candidate_labels=labels,
+            ui_path="Media page > selected Media Pool clip(s) > context menu > Generate Proxy Media",
+            accessibility_required=True,
+            allow_generate_required=True,
+        )
+
+    if not p.get("allow_generate", False):
+        result = _err(
+            "Set allow_generate=True to click Resolve's native Generate Proxy Media command. "
+            "Use dry_run=True first to verify the target clip selection."
+        )
+        result.update(
+            {
+                "allow_generate_required": True,
+                "would_generate": True,
+                "clips": _clip_summaries(clips),
+                "missing": missing,
+                "before": before,
+                "candidate_labels": labels,
+            }
+        )
+        return result
+
+    if resolve_obj and _has_method(resolve_obj, "OpenPage"):
+        try:
+            if not resolve_obj.OpenPage("media"):
+                return _err("Failed to switch Resolve to the Media page before UI automation")
+        except Exception as exc:
+            return _err(f"Failed to switch Resolve to the Media page before UI automation: {exc}")
+
+    if explicit_ids and len(explicit_ids) == 1 and not selected:
+        if not _has_method(mp, "SetSelectedClip"):
+            return _err("SetSelectedClip unavailable; preselect the clip in Resolve and call selected=True")
+        try:
+            if not mp.SetSelectedClip(clips[0]):
+                return _err(f"Failed to select clip before proxy generation: {explicit_ids[0]}")
+        except Exception as exc:
+            return _err(f"Failed to select clip before proxy generation: {exc}")
+
+    timeout = int(p.get("timeout", 20))
+    delay_seconds = float(p.get("ui_delay_seconds", p.get("uiDelaySeconds", 0.35)))
+    script = _generate_proxy_media_ui_script(labels, delay_seconds)
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return _err(f"Timed out while clicking Generate Proxy Media after {timeout}s")
+    except Exception as exc:
+        return _err(f"Failed to run osascript: {exc}")
+
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        accessibility_note = None
+        if "-1719" in stderr or "Hilfszugriff" in stderr or "assistive" in stderr.lower():
+            accessibility_note = (
+                "Grant Accessibility permission in System Settings > Privacy & Security > Accessibility "
+                "for the app/process running the MCP client or for osascript/Terminal, then retry."
+            )
+        return {
+            "success": False,
+            "error": stderr or stdout or f"osascript exited {proc.returncode}",
+            "returncode": proc.returncode,
+            "clips": _clip_summaries(clips),
+            "missing": missing,
+            "before": before,
+            "candidate_labels": labels,
+            "ui_path": "Media page > selected Media Pool clip(s) > context menu > Generate Proxy Media",
+            "accessibility_note": accessibility_note,
+        }
+
+    wait_seconds = max(0.0, min(float(p.get("readback_wait_seconds", p.get("readbackWaitSeconds", 1.0))), 10.0))
+    if wait_seconds:
+        time.sleep(wait_seconds)
+    after = [_proxy_media_readback(clip) for clip in clips]
+    return _ok(
+        clicked_label=stdout,
+        clips=_clip_summaries(clips),
+        missing=missing,
+        before=before,
+        after=after,
+        candidate_labels=labels,
+        ui_path="Media page > selected Media Pool clip(s) > context menu > Generate Proxy Media",
+        note="Clicked Resolve's native Generate Proxy Media command via macOS UI automation.",
+        readback_note="Proxy generation can be asynchronous; Proxy Media Path may remain empty until Resolve finishes the background job.",
+    )
 
 
 def _set_clip_marks(root, mp, p: Dict[str, Any]):
@@ -13287,13 +13562,21 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
       safe_unlink(clip_ids|selected, dry_run?) -> {success}
       link_proxy_checked(clip_id, proxy_path|path, dry_run?) -> {success}
       link_full_resolution_checked(clip_id, path|full_res_media_path, dry_run?) -> {success}
+      generate_proxy_media_ui_capabilities() -> {available, official_resolve_api, guards}
+      generate_proxy_media_ui(clip_ids|selected, dry_run?, allow_generate?) -> {success}
+        — macOS UI automation fallback for Resolve's native Generate Proxy Media
+          command. Public Resolve scripting has LinkProxyMedia, but no documented
+          Generate Proxy Media call. Use dry_run=True first; actual clicks require
+          allow_generate=True. For multiple clips, preselect them in Resolve and
+          call selected=True because Resolve exposes SetSelectedClip but no
+          documented multi-select API.
       set_clip_marks(clip_ids|selected, mark_in, mark_out, type?, dry_run?) -> {success, results}
       clear_clip_marks(clip_ids|selected, type?, dry_run?) -> {success, results}
       copy_clip_annotations(source_clip_id, target_clip_ids, include_markers?, include_flags?, include_clip_color?, dry_run?) -> {success, results}
       media_pool_boundary_report(depth?, clip_ids?, selected?) -> {capabilities, media_pool, items?}
     """
     p = params or {}
-    _, proj, mp, err = _get_mp()
+    resolve_obj, proj, mp, err = _get_mp()
     if err:
         return err
     root = mp.GetRootFolder()
@@ -13551,6 +13834,10 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
         return _link_proxy_checked(root, p)
     elif action == "link_full_resolution_checked":
         return _link_full_resolution_checked(root, p)
+    elif action == "generate_proxy_media_ui_capabilities":
+        return _generate_proxy_media_ui_capabilities()
+    elif action == "generate_proxy_media_ui":
+        return _generate_proxy_media_ui(resolve_obj, mp, root, p)
     elif action == "set_clip_marks":
         return _set_clip_marks(root, mp, p)
     elif action == "clear_clip_marks":

--- a/src/server.py
+++ b/src/server.py
@@ -12696,9 +12696,47 @@ def _render_formats(proj):
     return _ser(formats)
 
 
-def _render_codecs(proj, fmt: str):
+def _render_format_id_from_formats(formats: Any, fmt: str) -> str:
+    if not isinstance(fmt, str) or not fmt or not isinstance(formats, dict):
+        return fmt
+    if fmt in formats:
+        return formats.get(fmt) or fmt
+    if fmt in formats.values():
+        return fmt
+    needle = fmt.lower()
+    for label, format_id in formats.items():
+        label_text = str(label)
+        id_text = str(format_id)
+        if label_text.lower() == needle:
+            return id_text or fmt
+        if id_text.lower() == needle:
+            return id_text
+    return fmt
+
+
+def _render_format_id(proj, fmt: str, formats: Optional[Dict[str, Any]] = None) -> str:
+    if formats is None:
+        formats = _render_formats(proj)
+    return _render_format_id_from_formats(formats, fmt)
+
+
+def _render_format_requested(requested: Optional[List[Any]], label: str, extension: Any, format_id: str, formats: Dict[str, Any]) -> bool:
+    if not requested:
+        return True
+    extension_text = str(extension)
+    for item in requested:
+        if item == label or item == extension or item == format_id:
+            return True
+        if isinstance(item, str) and _render_format_id_from_formats(formats, item) == format_id:
+            return True
+        if isinstance(item, str) and item.lower() in {label.lower(), extension_text.lower(), format_id.lower()}:
+            return True
+    return False
+
+
+def _render_codecs(proj, fmt: str, formats: Optional[Dict[str, Any]] = None):
     try:
-        return _ser(proj.GetRenderCodecs(fmt) or {})
+        return _ser(proj.GetRenderCodecs(_render_format_id(proj, fmt, formats)) or {})
     except Exception as exc:
         return {"error": str(exc)}
 
@@ -12743,10 +12781,11 @@ def _probe_render_matrix(proj, p: Dict[str, Any]):
     pair_count = 0
     errors = []
     for fmt, extension in formats.items():
-        if requested and fmt not in requested:
+        format_id = _render_format_id_from_formats(formats, fmt)
+        if not _render_format_requested(requested, fmt, extension, format_id, formats):
             continue
-        codecs = _render_codecs(proj, fmt)
-        format_row = {"format": fmt, "extension": extension, "codecs": [], "codec_count": 0}
+        codecs = _render_codecs(proj, format_id, formats)
+        format_row = {"format": fmt, "extension": extension, "format_id": format_id, "codecs": [], "codec_count": 0}
         if isinstance(codecs, dict) and codecs.get("error"):
             format_row["error"] = codecs["error"]
             errors.append({"format": fmt, "error": codecs["error"]})
@@ -12759,11 +12798,11 @@ def _probe_render_matrix(proj, p: Dict[str, Any]):
                     break
                 row = {"label": label, "codec": codec}
                 try:
-                    row["resolutions"] = _ser(proj.GetRenderResolutions(fmt, codec) or [])
+                    row["resolutions"] = _ser(proj.GetRenderResolutions(format_id, codec) or [])
                     row["resolution_count"] = len(row["resolutions"])
                 except Exception as exc:
                     row["error"] = str(exc)
-                    errors.append({"format": fmt, "codec": codec, "error": str(exc)})
+                    errors.append({"format": fmt, "format_id": format_id, "codec": codec, "error": str(exc)})
                 format_row["codecs"].append(row)
                 pair_count += 1
         matrix.append(format_row)
@@ -12891,7 +12930,7 @@ def _prepare_render_job(proj, p: Dict[str, Any]):
     before = _render_settings_snapshot(proj)
     format_success = None
     if p.get("format") and p.get("codec"):
-        format_success = bool(proj.SetCurrentRenderFormatAndCodec(p["format"], p["codec"]))
+        format_success = bool(proj.SetCurrentRenderFormatAndCodec(_render_format_id(proj, p["format"]), p["codec"]))
     settings_success = bool(proj.SetRenderSettings(settings))
     job_id = proj.AddRenderJob() if settings_success else None
     return {
@@ -13042,17 +13081,17 @@ def render(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, An
     elif action == "get_formats":
         return {"formats": _ser(proj.GetRenderFormats())}
     elif action == "get_codecs":
-        return {"codecs": _ser(proj.GetRenderCodecs(p["format"]))}
+        return {"codecs": _render_codecs(proj, p["format"])}
     elif action == "get_format_and_codec":
         return _ser(proj.GetCurrentRenderFormatAndCodec())
     elif action == "set_format_and_codec":
-        return {"success": bool(proj.SetCurrentRenderFormatAndCodec(p["format"], p["codec"]))}
+        return {"success": bool(proj.SetCurrentRenderFormatAndCodec(_render_format_id(proj, p["format"]), p["codec"]))}
     elif action == "get_mode":
         return {"mode": proj.GetCurrentRenderMode()}
     elif action == "set_mode":
         return {"success": bool(proj.SetCurrentRenderMode(p["mode"]))}
     elif action == "get_resolutions":
-        return {"resolutions": _ser(proj.GetRenderResolutions(p["format"], p["codec"]))}
+        return {"resolutions": _ser(proj.GetRenderResolutions(_render_format_id(proj, p["format"]), p["codec"]))}
     elif action == "get_settings":
         missing = _requires_method(proj, "GetRenderSettings", "unknown")
         if missing:

--- a/src/server.py
+++ b/src/server.py
@@ -4941,6 +4941,123 @@ def _probe_interchange_roundtrip(proj, mp, tl, p: Dict[str, Any]):
     }
 
 
+def _sanitize_media_path(path: Any, *, keep_filename: bool = True) -> Optional[str]:
+    if not path:
+        return None
+    text = str(path)
+    filename = os.path.basename(text.rstrip(os.sep))
+    parts = [part for part in text.split(os.sep) if part]
+    if text.startswith("/Volumes/") and len(parts) >= 2:
+        root = f"/Volumes/{parts[1]}"
+        return f"{root}/.../{filename}" if keep_filename and filename else f"{root}/..."
+    if text.startswith(os.sep):
+        return f"/.../{filename}" if keep_filename and filename else "/..."
+    return f".../{filename}" if keep_filename and filename else "..."
+
+
+def _media_path_volume_root(path: Any) -> Optional[str]:
+    if not path:
+        return None
+    text = str(path)
+    parts = [part for part in text.split(os.sep) if part]
+    if text.startswith("/Volumes/") and len(parts) >= 2:
+        return f"/Volumes/{parts[1]}"
+    if text.startswith(os.sep) and parts:
+        return os.sep + parts[0]
+    return None
+
+
+def _missing_media_diagnosis(missing_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    by_media_pool_item: Dict[str, Dict[str, Any]] = {}
+    missing_volumes: Dict[str, Dict[str, Any]] = {}
+    missing_folders: Dict[str, Dict[str, Any]] = {}
+
+    for row in missing_rows:
+        file_path = row.get("file_path")
+        media_pool_item_id = row.get("media_pool_item_id") or file_path or row.get("name")
+        basename = os.path.basename(str(file_path or row.get("media_pool_item_name") or row.get("name") or ""))
+        item = by_media_pool_item.setdefault(
+            str(media_pool_item_id),
+            {
+                "media_pool_item_id": row.get("media_pool_item_id"),
+                "media_pool_item_name": row.get("media_pool_item_name") or row.get("name"),
+                "wanted_basename": basename,
+                "file_path_sanitized": _sanitize_media_path(file_path),
+                "volume_root_sanitized": _sanitize_media_path(_media_path_volume_root(file_path), keep_filename=False),
+                "timeline_occurrence_count": 0,
+                "track_refs": [],
+            },
+        )
+        item["timeline_occurrence_count"] += 1
+        item["track_refs"].append(
+            {
+                "track_type": row.get("track_type"),
+                "track_index": row.get("track_index"),
+                "timeline_item_id": row.get("timeline_item_id"),
+            }
+        )
+
+        volume_root = _media_path_volume_root(file_path)
+        if volume_root:
+            volume_row = missing_volumes.setdefault(
+                volume_root,
+                {
+                    "volume_root_sanitized": _sanitize_media_path(volume_root, keep_filename=False),
+                    "mounted": os.path.isdir(volume_root),
+                    "clip_count": 0,
+                    "sample_basenames": [],
+                },
+            )
+            volume_row["clip_count"] += 1
+            if basename and basename not in volume_row["sample_basenames"] and len(volume_row["sample_basenames"]) < 8:
+                volume_row["sample_basenames"].append(basename)
+
+        folder = os.path.dirname(str(file_path)) if file_path else ""
+        if folder:
+            folder_row = missing_folders.setdefault(
+                folder,
+                {
+                    "folder_sanitized": _sanitize_media_path(folder, keep_filename=False),
+                    "exists": os.path.isdir(folder),
+                    "clip_count": 0,
+                    "sample_basenames": [],
+                },
+            )
+            folder_row["clip_count"] += 1
+            if basename and basename not in folder_row["sample_basenames"] and len(folder_row["sample_basenames"]) < 8:
+                folder_row["sample_basenames"].append(basename)
+
+    unique_items = list(by_media_pool_item.values())
+    missing_volume_rows = list(missing_volumes.values())
+    missing_folder_rows = list(missing_folders.values())
+    absent_volumes = [row for row in missing_volume_rows if not row.get("mounted")]
+    absent_folders = [row for row in missing_folder_rows if not row.get("exists")]
+    primary_cause = "none"
+    recommended_next_step = "No offline media detected."
+    if absent_volumes:
+        primary_cause = "volume_not_mounted"
+        labels = ", ".join(row["volume_root_sanitized"] for row in absent_volumes[:3])
+        recommended_next_step = f"Mount the missing volume(s): {labels}."
+    elif absent_folders:
+        primary_cause = "folder_not_found"
+        labels = ", ".join(row["folder_sanitized"] for row in absent_folders[:3])
+        recommended_next_step = f"Attach or locate the missing media folder(s): {labels}."
+    elif unique_items:
+        primary_cause = "files_missing_or_renamed"
+        recommended_next_step = "Search approved media roots for the wanted basenames, then relink with media_pool.safe_relink."
+
+    return {
+        "unique_media_pool_item_count": len(unique_items),
+        "timeline_occurrence_count": len(missing_rows),
+        "primary_cause": primary_cause,
+        "recommended_next_step": recommended_next_step,
+        "missing_volumes": missing_volume_rows,
+        "missing_folders": missing_folder_rows,
+        "unique_media_pool_items": unique_items,
+        "sanitized": True,
+    }
+
+
 def _detect_missing_media_from_snapshot(snapshot: Dict[str, Any]):
     missing = []
     present = []
@@ -4966,12 +5083,80 @@ def _detect_missing_media_from_snapshot(snapshot: Dict[str, Any]):
                     missing.append(row)
                 else:
                     present.append(row)
-    return {"missing": missing, "present_count": len(present), "missing_count": len(missing)}
+    diagnosis = _missing_media_diagnosis(missing)
+    return {
+        "missing": missing,
+        "present_count": len(present),
+        "missing_count": len(missing),
+        "diagnosis": diagnosis,
+    }
 
 
 def _detect_missing_media(tl, p: Dict[str, Any]):
     snapshot = _timeline_conform_snapshot(tl, {**p, "include_clip_properties": True})
-    return _detect_missing_media_from_snapshot(snapshot)
+    report = _detect_missing_media_from_snapshot(snapshot)
+    if p.get("sanitize_paths") or p.get("sanitized"):
+        report = dict(report)
+        report["missing"] = [
+            {
+                **row,
+                "file_path_sanitized": _sanitize_media_path(row.get("file_path")),
+                "file_path": None if p.get("omit_raw_paths", True) else row.get("file_path"),
+            }
+            for row in report.get("missing", [])
+        ]
+    return report
+
+
+def _bounded_basename_matches(
+    wanted: str,
+    search_roots: List[str],
+    p: Dict[str, Any],
+) -> Tuple[List[str], Dict[str, Any]]:
+    started = time.monotonic()
+    max_seconds = float(p.get("max_seconds", p.get("timeout_seconds", 20)) or 20)
+    max_files = int(p.get("max_files_scanned", p.get("maxFilesScanned", 50000)) or 50000)
+    max_depth_raw = p.get("max_depth", p.get("maxDepth"))
+    max_depth = int(max_depth_raw) if max_depth_raw is not None else None
+    all_matches = bool(p.get("all_matches", False))
+    matches: List[str] = []
+    files_scanned = 0
+    dirs_scanned = 0
+    stopped_reason = None
+
+    for root in search_roots:
+        root_depth = len(os.path.abspath(root).rstrip(os.sep).split(os.sep))
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirs_scanned += 1
+            if max_depth is not None:
+                current_depth = len(os.path.abspath(dirpath).rstrip(os.sep).split(os.sep)) - root_depth
+                if current_depth >= max_depth:
+                    dirnames[:] = []
+            files_scanned += len(filenames)
+            if wanted in filenames:
+                matches.append(os.path.join(dirpath, wanted))
+                if not all_matches:
+                    return matches, {
+                        "files_scanned": files_scanned,
+                        "dirs_scanned": dirs_scanned,
+                        "stopped_reason": "first_match",
+                    }
+            if files_scanned >= max_files:
+                stopped_reason = "max_files_scanned"
+                break
+            if time.monotonic() - started >= max_seconds:
+                stopped_reason = "max_seconds"
+                break
+        if matches and not all_matches:
+            break
+        if stopped_reason:
+            break
+
+    return matches, {
+        "files_scanned": files_scanned,
+        "dirs_scanned": dirs_scanned,
+        "stopped_reason": stopped_reason,
+    }
 
 
 def _build_relink_plan(tl, p: Dict[str, Any]):
@@ -4982,26 +5167,55 @@ def _build_relink_plan(tl, p: Dict[str, Any]):
     if invalid:
         return _err(f"search_roots must be existing directories: {invalid}")
     missing_report = _detect_missing_media(tl, p)
+    diagnosis = missing_report.get("diagnosis") or _missing_media_diagnosis(missing_report.get("missing", []))
+    if p.get("skip_search_when_volume_missing", True) and any(
+        not row.get("mounted") for row in diagnosis.get("missing_volumes", [])
+    ):
+        return {
+            "success": True,
+            "dry_run": True,
+            "search_skipped": True,
+            "skip_reason": "missing_source_volume_not_mounted",
+            "search_roots": [_sanitize_media_path(root, keep_filename=False) for root in search_roots],
+            "candidate_count": 0,
+            "missing_count": missing_report.get("missing_count", 0),
+            "diagnosis": diagnosis,
+            "candidates": [],
+            "execution_note": "Mount the missing source volume or pass skip_search_when_volume_missing=false to scan approved roots.",
+        }
     candidates = []
+    rows_by_basename: Dict[str, List[Dict[str, Any]]] = {}
     for row in missing_report.get("missing", []):
         wanted = os.path.basename(str(row.get("file_path") or row.get("media_pool_item_name") or row.get("name") or ""))
-        matches = []
         if wanted:
-            for root in search_roots:
-                for dirpath, _, filenames in os.walk(root):
-                    if wanted in filenames:
-                        matches.append(os.path.join(dirpath, wanted))
-                        if not p.get("all_matches", False):
-                            break
-                if matches and not p.get("all_matches", False):
-                    break
-        candidates.append({**row, "wanted_basename": wanted, "candidate_paths": matches, "candidate_count": len(matches)})
+            rows_by_basename.setdefault(wanted, []).append(row)
+    for wanted, rows in rows_by_basename.items():
+        row = rows[0]
+        matches = []
+        scan = {"files_scanned": 0, "dirs_scanned": 0, "stopped_reason": None}
+        if wanted:
+            matches, scan = _bounded_basename_matches(wanted, search_roots, p)
+        sanitized_matches = [_sanitize_media_path(path) for path in matches]
+        candidates.append(
+            {
+                **row,
+                "wanted_basename": wanted,
+                "timeline_occurrence_count": len(rows),
+                "candidate_paths": [] if p.get("sanitize_paths") or p.get("sanitized") else matches,
+                "candidate_paths_sanitized": sanitized_matches,
+                "candidate_count": len(matches),
+                "scan": scan,
+            }
+        )
     return {
         "success": True,
         "dry_run": True,
-        "search_roots": search_roots,
+        "search_roots": [] if p.get("sanitize_paths") or p.get("sanitized") else search_roots,
+        "search_roots_sanitized": [_sanitize_media_path(root, keep_filename=False) for root in search_roots],
         "candidate_count": sum(1 for row in candidates if row["candidate_count"]),
         "missing_count": missing_report.get("missing_count", 0),
+        "unique_missing_basename_count": len(candidates),
+        "diagnosis": diagnosis,
         "candidates": candidates,
         "execution_note": "Review this plan, then use media_pool.safe_relink with explicit synthetic or approved paths if desired.",
     }
@@ -8017,6 +8231,13 @@ def _media_analysis_transcription_options(enabled: bool) -> Dict[str, Any]:
     return options
 
 
+def _media_analysis_vision_options(enabled: bool) -> Dict[str, Any]:
+    options = {"enabled": bool(enabled)}
+    if enabled:
+        options["provider"] = HOST_CHAT_PATHS_PROVIDER
+    return options
+
+
 def _media_analysis_metadata_writeback_enabled(p: Dict[str, Any]) -> bool:
     raw = _first_param(
         p,
@@ -8233,20 +8454,21 @@ def _media_analysis_apply_setup_defaults(action: str, p: Dict[str, Any]) -> Dict
 
     if action in {"plan", "analyze_file", "analyze_clip", "analyze_bin", "analyze_project", "analyze_timeline", "analyze_sequence", "start_batch_job", "review_timeline_markers", "publish_clip_metadata"}:
         include_visuals = _first_param(out, "include_visuals", "includeVisuals")
-        if not _has_any_param(out, "vision"):
+        if isinstance(out.get("vision"), bool):
+            out["vision"] = _media_analysis_vision_options(out["vision"])
+            applied["vision_shorthand"] = out["vision"]["enabled"]
+        elif not _has_any_param(out, "vision"):
             if include_visuals is not None:
                 visuals_enabled = _media_analysis_bool(include_visuals, True)
-                out["vision"] = {"enabled": visuals_enabled}
-                if visuals_enabled:
-                    out["vision"]["provider"] = HOST_CHAT_PATHS_PROVIDER
+                out["vision"] = _media_analysis_vision_options(visuals_enabled)
                 applied["include_visuals"] = visuals_enabled
             else:
                 vision_default = prefs.get("vision_default")
                 if vision_default == "on":
-                    out["vision"] = {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER}
+                    out["vision"] = _media_analysis_vision_options(True)
                     applied["vision_default"] = vision_default
                 elif vision_default in {"off", "technical_only"}:
-                    out["vision"] = {"enabled": False}
+                    out["vision"] = _media_analysis_vision_options(False)
                     applied["vision_default"] = vision_default
         include_transcription = _first_param(out, "include_transcription", "includeTranscription")
         if not _has_any_param(out, "transcription"):
@@ -13358,6 +13580,153 @@ def media_pool_item_markers(action: str, params: Optional[Dict[str, Any]] = None
     return _unknown(action, ["add","get_all","get_by_custom_data","update_custom_data","get_custom_data","delete_by_color","delete_at_frame","delete_by_custom_data","add_flag","get_flags","clear_flags","set_name","link_full_resolution_media","monitor_growing_file","replace_clip_preserve_sub_clip"])
 
 
+_OUTPUT_BLANKING_ALIASES = {
+    "1.33": ["1.33", "1.33:1", "4:3"],
+    "4:3": ["1.33", "1.33:1", "4:3"],
+    "1.66": ["1.66", "1.66:1"],
+    "1.77": ["1.77", "1.77:1", "1.78", "1.78:1", "16:9"],
+    "16:9": ["1.77", "1.77:1", "1.78", "1.78:1", "16:9"],
+    "1.85": ["1.85", "1.85:1"],
+    "2.0": ["2.0", "2.00", "2.0:1", "2.00:1", "2:1"],
+    "2.35": ["2.35", "2.35:1"],
+    "2.39": ["2.39", "2.39:1"],
+    "2.40": ["2.40", "2.4", "2.40:1", "2.4:1"],
+    "none": ["None", "No Blanking", "Reset", "Off"],
+    "off": ["None", "No Blanking", "Reset", "Off"],
+    "reset": ["None", "No Blanking", "Reset", "Off"],
+}
+
+
+def _output_blanking_candidate_labels(aspect: Any) -> List[str]:
+    raw = str(aspect or "").strip()
+    if not raw:
+        return []
+    key = raw.lower().replace(" ", "")
+    aliases = _OUTPUT_BLANKING_ALIASES.get(key)
+    if aliases:
+        return aliases
+    if raw.endswith(":1"):
+        return [raw[:-2], raw]
+    return [raw, f"{raw}:1"]
+
+
+def _applescript_list(values: List[str]) -> str:
+    return "{" + ", ".join(json.dumps(value) for value in values) + "}"
+
+
+def _set_output_blanking_ui(p: Dict[str, Any]) -> Dict[str, Any]:
+    aspect = p.get("aspect", p.get("ratio", p.get("preset")))
+    candidates = _output_blanking_candidate_labels(aspect)
+    if not candidates:
+        return _err("set_output_blanking_ui requires aspect, ratio, or preset")
+    if sys.platform != "darwin":
+        return _err("set_output_blanking_ui is macOS-only because it uses System Events UI automation")
+
+    if p.get("dry_run"):
+        return _ok(
+            dry_run=True,
+            aspect=aspect,
+            candidate_labels=candidates,
+            menu_path="Timeline > Output Blanking",
+            accessibility_required=True,
+        )
+
+    timeout = int(p.get("timeout", 8))
+    script = f"""
+tell application "DaVinci Resolve" to activate
+delay 0.4
+tell application "System Events"
+  tell process "DaVinci Resolve"
+    set frontmost to true
+    set timelineMenuLabels to {_applescript_list(["Timeline", "Zeitleiste"])}
+    set outputMenuLabels to {_applescript_list(["Output Blanking", "Ausgabe-Austastung"])}
+    set targetLabels to {_applescript_list(candidates)}
+    set clickedLabel to ""
+    set timelineMenuLabel to ""
+    set outputMenuLabel to ""
+
+    repeat with timelineCandidate in timelineMenuLabels
+      try
+        set timelineMenuLabel to timelineCandidate as text
+        set timelineMenu to menu 1 of menu bar item timelineMenuLabel of menu bar 1
+        exit repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+        set timelineMenuLabel to ""
+      end try
+    end repeat
+    if timelineMenuLabel is "" then error "Timeline menu not found"
+
+    repeat with outputCandidate in outputMenuLabels
+      try
+        set outputMenuLabel to outputCandidate as text
+        set outputMenu to menu 1 of menu item outputMenuLabel of timelineMenu
+        exit repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+        set outputMenuLabel to ""
+      end try
+    end repeat
+    if outputMenuLabel is "" then error "Output Blanking submenu not found"
+
+    repeat with targetCandidate in targetLabels
+      try
+        set clickedLabel to targetCandidate as text
+        click menu item clickedLabel of outputMenu
+        exit repeat
+      on error errMsg number errNum
+        if errNum is -1719 then error errMsg number errNum
+        set clickedLabel to ""
+      end try
+    end repeat
+    if clickedLabel is "" then
+      set availableLabels to name of menu items of outputMenu
+      error "Output Blanking preset not found. Available: " & (availableLabels as text)
+    end if
+    return clickedLabel
+  end tell
+end tell
+"""
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return _err(f"Timed out while clicking Timeline > Output Blanking after {timeout}s")
+    except Exception as exc:
+        return _err(f"Failed to run osascript: {exc}")
+
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        accessibility_note = None
+        if "-1719" in stderr or "Hilfszugriff" in stderr or "assistive" in stderr.lower():
+            accessibility_note = (
+                "Grant Accessibility permission in System Settings > Privacy & Security > Accessibility "
+                "for the app/process running the MCP client or for osascript/Terminal, then retry."
+            )
+        return {
+            "success": False,
+            "error": stderr or stdout or f"osascript exited {proc.returncode}",
+            "returncode": proc.returncode,
+            "aspect": aspect,
+            "candidate_labels": candidates,
+            "menu_path": "Timeline > Output Blanking",
+            "accessibility_note": accessibility_note,
+        }
+
+    return _ok(
+        aspect=aspect,
+        clicked_label=stdout,
+        candidate_labels=candidates,
+        menu_path="Timeline > Output Blanking",
+        note="Clicked Resolve's native Output Blanking menu via macOS UI automation.",
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # TOOL 15: media_analysis
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -14306,6 +14675,9 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         UNSAFE. No path sandboxing. Prefer export_timeline_checked.
       get_setting(name?) -> {settings}
       set_setting(name, value) -> {success}
+      output_blanking_ui_capabilities() -> {presets, aliases, menu_path}
+      set_output_blanking_ui(aspect, dry_run?, timeout?) -> {success}
+        macOS-only UI automation for Resolve's native Timeline > Output Blanking menu.
       insert_generator(name) -> {success}
       insert_fusion_generator(name) -> {success}
       insert_fusion_composition() -> {success}
@@ -14335,8 +14707,8 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       import_timeline_checked(path, options?, timeline_name?, import_source_clips?, require_temp_path?, dry_run?) -> {success, name, id}
       compare_timelines(right_timeline_id?|right_timeline_index?|left_snapshot?, right_snapshot?) -> {match, differences}
       probe_interchange_roundtrip(format?, output_dir?, cleanup_imported?) -> {success, export, import, comparison}
-      detect_missing_media() -> {missing, missing_count}
-      build_relink_plan(search_roots) -> {candidates}
+      detect_missing_media(sanitized?|sanitize_paths?, omit_raw_paths?) -> {missing, missing_count, diagnosis}
+      build_relink_plan(search_roots, max_depth?, max_seconds?, max_files_scanned?, skip_search_when_volume_missing?, sanitized?) -> {candidates, diagnosis}
       conform_boundary_report(...) -> {capabilities, timeline, gaps_overlaps, source_ranges, missing_media}
       audio_capabilities() -> {supported, partially_supported, unsupported}
       probe_audio_item(track_type?, track_index?, item_index?) -> {summary, audio_properties, source_audio_mapping}
@@ -14572,6 +14944,20 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         return {"settings": _ser(tl.GetSetting(p.get("name", "")))}
     elif action == "set_setting":
         return {"success": bool(tl.SetSetting(p["name"], p["value"]))}
+    elif action == "output_blanking_ui_capabilities":
+        return _ok(
+            platform=sys.platform,
+            supported=sys.platform == "darwin",
+            menu_path="Timeline > Output Blanking",
+            aliases=_OUTPUT_BLANKING_ALIASES,
+            accessibility_required=True,
+            note=(
+                "Uses macOS System Events to click Resolve's native menu. "
+                "Grant Accessibility permission to the MCP host or osascript first."
+            ),
+        )
+    elif action == "set_output_blanking_ui":
+        return _set_output_blanking_ui(p)
     elif action == "insert_generator":
         r = tl.InsertGeneratorIntoTimeline(p["name"])
         return _ok() if r else _err("Failed to insert generator")
@@ -14799,7 +15185,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         if mp_err:
             return mp_err
         return _fairlight_boundary_report(proj, mp, tl, p)
-    return _unknown(action, ["list","get_current","set_current","get_name","set_name","get_start_frame","get_end_frame","get_start_timecode","set_start_timecode","get_track_count","add_track","delete_track","get_track_sub_type","set_track_enable","get_track_enabled","set_track_lock","get_track_locked","get_track_name","set_track_name","get_items","delete_clips","set_clips_linked","duplicate","duplicate_clips","copy_clips","move_clips","copy_range","duplicate_range","overwrite_range","lift_range","story_spine_report","create_variant_from_ranges","bulk_set_item_properties","apply_look_to_items","thumbnail_contact_sheet","marker_thumbnail_review","edit_kernel_capabilities","probe_edit_kernel_item","title_property_scan","set_title_text","bulk_set_title_text","create_compound_clip","create_fusion_clip","import_into_timeline","export","get_setting","set_setting","insert_generator","insert_fusion_generator","insert_fusion_composition","insert_ofx_generator","insert_title","insert_fusion_title","get_unique_id","get_node_graph","get_media_pool_item","get_mark_in_out","set_mark_in_out","clear_mark_in_out","convert_to_stereo","get_items_in_track","get_voice_isolation_state","set_voice_isolation_state","extract_source_frame_ranges","audio_mix_capability_report",*_TIMELINE_CONFORM_KERNEL_ACTIONS,*_TIMELINE_AUDIO_KERNEL_ACTIONS])
+    return _unknown(action, ["list","get_current","set_current","get_name","set_name","get_start_frame","get_end_frame","get_start_timecode","set_start_timecode","get_track_count","add_track","delete_track","get_track_sub_type","set_track_enable","get_track_enabled","set_track_lock","get_track_locked","get_track_name","set_track_name","get_items","delete_clips","set_clips_linked","duplicate","duplicate_clips","copy_clips","move_clips","copy_range","duplicate_range","overwrite_range","lift_range","story_spine_report","create_variant_from_ranges","bulk_set_item_properties","apply_look_to_items","thumbnail_contact_sheet","marker_thumbnail_review","edit_kernel_capabilities","probe_edit_kernel_item","title_property_scan","set_title_text","bulk_set_title_text","create_compound_clip","create_fusion_clip","import_into_timeline","export","get_setting","set_setting","output_blanking_ui_capabilities","set_output_blanking_ui","insert_generator","insert_fusion_generator","insert_fusion_composition","insert_ofx_generator","insert_title","insert_fusion_title","get_unique_id","get_node_graph","get_media_pool_item","get_mark_in_out","set_mark_in_out","clear_mark_in_out","convert_to_stereo","get_items_in_track","get_voice_isolation_state","set_voice_isolation_state","extract_source_frame_ranges","audio_mix_capability_report",*_TIMELINE_CONFORM_KERNEL_ACTIONS,*_TIMELINE_AUDIO_KERNEL_ACTIONS])
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -14877,7 +15263,14 @@ def timeline_markers(action: str, params: Optional[Dict[str, Any]] = None) -> An
         it = tl.GetCurrentVideoItem()
         return {"name": it.GetName(), "id": it.GetUniqueId()} if it else {"name": None, "id": None}
     elif action == "get_thumbnail":
-        return _ser(tl.GetCurrentClipThumbnailImage())
+        thumbnail = tl.GetCurrentClipThumbnailImage()
+        if thumbnail is None:
+            return {
+                "success": False,
+                "thumbnail": None,
+                "error": "Resolve did not return a thumbnail for the current playhead. Open the Color page and ensure a video item is under the playhead.",
+            }
+        return _ser(thumbnail)
     elif action == "get_thumbnail_image":
         thumbnail = tl.GetCurrentClipThumbnailImage()
         if not thumbnail:

--- a/src/server.py
+++ b/src/server.py
@@ -893,7 +893,7 @@ def _confirm_token_gc():
 def _confirm_token_required() -> bool:
     """Honor setup default destructive.require_confirm_token (default True)."""
     try:
-        prefs = _media_analysis_preferences_read() if "_media_analysis_preferences_read" in globals() else {}
+        prefs = _read_media_analysis_preferences() if "_read_media_analysis_preferences" in globals() else {}
     except Exception:
         prefs = {}
     destructive = prefs.get("destructive") if isinstance(prefs.get("destructive"), dict) else {}

--- a/tests/test_confirm_token_preferences.py
+++ b/tests/test_confirm_token_preferences.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch
+
+import src.server as compound
+
+
+class ConfirmTokenPreferenceTests(unittest.TestCase):
+    def test_confirm_token_gate_honors_destructive_preference_false(self):
+        with patch.object(
+            compound,
+            "_read_media_analysis_preferences",
+            return_value={"destructive": {"require_confirm_token": False}},
+        ):
+            self.assertFalse(compound._confirm_token_required())
+
+    def test_confirm_token_gate_defaults_to_required(self):
+        with patch.object(compound, "_read_media_analysis_preferences", return_value={}):
+            self.assertTrue(compound._confirm_token_required())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marker_params.py
+++ b/tests/test_marker_params.py
@@ -1,6 +1,8 @@
 import unittest
+from unittest.mock import Mock, patch
 
 import src.server as compound
+from src.utils import destructive_hook
 from tests._error_envelope_helpers import err_message
 
 
@@ -37,6 +39,9 @@ class TimelineStub:
         self.deleted_frames.append(frame)
         return True
 
+    def GetCurrentClipThumbnailImage(self):
+        return None
+
 
 class FiveArgMarkerStub:
     def __init__(self):
@@ -52,11 +57,14 @@ class FiveArgMarkerStub:
 class TimelineMarkerParamTest(unittest.TestCase):
     def setUp(self):
         self.original_get_tl = compound._get_tl
+        self.original_versioning_provider = destructive_hook._PROVIDER
         self.timeline = TimelineStub()
         compound._get_tl = lambda: (None, self.timeline, None)
+        destructive_hook._PROVIDER = None
 
     def tearDown(self):
         compound._get_tl = self.original_get_tl
+        destructive_hook._PROVIDER = self.original_versioning_provider
 
     def test_add_accepts_frame_id_alias_and_defaults_name_duration(self):
         out = compound.timeline_markers(
@@ -109,6 +117,13 @@ class TimelineMarkerParamTest(unittest.TestCase):
 
         self.assertEqual(err_message(out), "timecode must use HH:MM:SS:FF format")
 
+    def test_get_thumbnail_returns_error_dict_when_resolve_returns_nil(self):
+        out = compound.timeline_markers("get_thumbnail")
+
+        self.assertEqual(out["success"], False)
+        self.assertIsNone(out["thumbnail"])
+        self.assertIn("did not return a thumbnail", out["error"])
+
     def test_add_marker_falls_back_to_five_arg_overload_when_custom_data_empty(self):
         target = FiveArgMarkerStub()
 
@@ -126,6 +141,37 @@ class TimelineMarkerParamTest(unittest.TestCase):
 
         self.assertEqual(out, {"success": True, "frame": 12})
         self.assertEqual(target.add_calls, [(12, "Blue", "Fallback", "", 1)])
+
+
+class OutputBlankingUiTest(unittest.TestCase):
+    def test_output_blanking_aliases_include_common_ratios(self):
+        self.assertEqual(
+            compound._output_blanking_candidate_labels("4:3"),
+            ["1.33", "1.33:1", "4:3"],
+        )
+        self.assertEqual(
+            compound._output_blanking_candidate_labels("2.39"),
+            ["2.39", "2.39:1"],
+        )
+
+    def test_output_blanking_dry_run_does_not_call_osascript(self):
+        with patch.object(compound.sys, "platform", "darwin"), patch.object(compound.subprocess, "run") as run:
+            out = compound._set_output_blanking_ui({"aspect": "2.39", "dry_run": True})
+
+        self.assertTrue(out["success"])
+        self.assertTrue(out["dry_run"])
+        self.assertEqual(out["menu_path"], "Timeline > Output Blanking")
+        self.assertEqual(out["candidate_labels"], ["2.39", "2.39:1"])
+        run.assert_not_called()
+
+    def test_output_blanking_reports_accessibility_error(self):
+        proc = Mock(returncode=1, stdout="", stderr="System Events got an error: osascript has no assistive access (-1719)")
+        with patch.object(compound.sys, "platform", "darwin"), patch.object(compound.subprocess, "run", return_value=proc):
+            out = compound._set_output_blanking_ui({"aspect": "2.39"})
+
+        self.assertFalse(out["success"])
+        self.assertEqual(out["returncode"], 1)
+        self.assertIn("Accessibility permission", out["accessibility_note"])
 
 
 if __name__ == "__main__":

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -6,6 +6,7 @@ import sqlite3
 import subprocess
 import tempfile
 import unittest
+from typing import Any, Dict, Optional
 
 from src import server as _server_module
 from src.server import (
@@ -1935,6 +1936,14 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                 self.assertEqual(visuals_on["vision"], {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER})
                 self.assertTrue(visuals_on["_setup_defaults_applied"]["include_visuals"])
 
+                vision_bool = _media_analysis_apply_setup_defaults("analyze_clip", {"vision": True})
+                self.assertEqual(vision_bool["vision"], {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER})
+                self.assertTrue(vision_bool["_setup_defaults_applied"]["vision_shorthand"])
+
+                vision_false = _media_analysis_apply_setup_defaults("analyze_clip", {"vision": False})
+                self.assertEqual(vision_false["vision"], {"enabled": False})
+                self.assertFalse(vision_false["_setup_defaults_applied"]["vision_shorthand"])
+
                 transcription_on = _media_analysis_apply_setup_defaults("analyze_clip", {"include_transcription": True})
                 self.assertEqual(transcription_on["transcription"], {"enabled": True, "allow_model_download": True})
                 self.assertTrue(transcription_on["_setup_defaults_applied"]["include_transcription"])
@@ -3226,6 +3235,7 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                 "cleanup_frames": False,
                 "max_analysis_frames": 1,
                 "vision": {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER},
+                "transcription": {"enabled": False},
             }
             caps = detect_capabilities(env={})
             plan = build_plan(
@@ -3280,6 +3290,7 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                 "cleanup_frames": True,
                 "max_analysis_frames": 3,
                 "vision": {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER},
+                "transcription": {"enabled": False},
             }
             caps = detect_capabilities(env={})
             plan = build_plan(

--- a/tests/test_media_pool_ingest_probe.py
+++ b/tests/test_media_pool_ingest_probe.py
@@ -1,10 +1,14 @@
 import unittest
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock, patch
 
+import src.server as compound
 from src.server import (
     _copy_clip_annotations,
     _copy_metadata,
+    _generate_proxy_media_ui,
+    _generate_proxy_media_ui_capabilities,
     _media_pool_ingest_capabilities,
     _media_pool_item_probe,
     _media_pool_probe,
@@ -38,6 +42,8 @@ class MediaPoolItemStub:
             "Camera #": "A",
             "Audio Notes": "",
             "Track 1": "",
+            "Proxy": "None",
+            "Proxy Media Path": "",
         }
         self.markers = {12: {"color": "Blue", "name": "Review", "note": "Check", "duration": 1}}
         self.flags = ["Blue"]
@@ -145,6 +151,7 @@ class MediaPoolStub:
     def __init__(self):
         self.clip = MediaPoolItemStub()
         self.root = FolderStub(clips=[self.clip], subfolders=[FolderStub(name="Ingest")])
+        self.selected_clip = self.clip
 
     def GetUniqueId(self):
         return "media-pool-1"
@@ -156,7 +163,11 @@ class MediaPoolStub:
         return self.root
 
     def GetSelectedClips(self):
-        return [self.clip]
+        return [self.selected_clip] if self.selected_clip else []
+
+    def SetSelectedClip(self, clip):
+        self.selected_clip = clip
+        return True
 
     def ImportMedia(self, paths):
         return []
@@ -323,6 +334,86 @@ class MediaPoolIngestProbeTest(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["results"][0]["markers"], 1)
         self.assertEqual(result["results"][0]["flags"], 1)
+
+    def test_generate_proxy_media_ui_capabilities_document_api_gap(self):
+        capabilities = _generate_proxy_media_ui_capabilities()
+
+        self.assertIn("generate_proxy_media_ui", capabilities["actions"])
+        self.assertFalse(capabilities["official_resolve_api"]["generate_proxy_media"])
+        self.assertTrue(capabilities["official_resolve_api"]["link_proxy_media"])
+
+    def test_generate_proxy_media_ui_dry_run_does_not_call_osascript(self):
+        mp = MediaPoolStub()
+        with patch.object(compound.sys, "platform", "darwin"), patch.object(compound.subprocess, "run") as run:
+            result = _generate_proxy_media_ui(None, mp, mp.root, {"selected": True, "dry_run": True})
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["dry_run"])
+        self.assertTrue(result["would_generate"])
+        self.assertEqual(result["before"][0]["proxy"], "None")
+        run.assert_not_called()
+
+    def test_generate_proxy_media_ui_requires_allow_generate_for_actual_click(self):
+        mp = MediaPoolStub()
+        with patch.object(compound.sys, "platform", "darwin"), patch.object(compound.subprocess, "run") as run:
+            result = _generate_proxy_media_ui(None, mp, mp.root, {"selected": True})
+
+        self.assertIn("error", result)
+        self.assertTrue(result["allow_generate_required"])
+        self.assertTrue(result["would_generate"])
+        run.assert_not_called()
+
+    def test_generate_proxy_media_ui_reports_accessibility_error(self):
+        mp = MediaPoolStub()
+        proc = Mock(returncode=1, stdout="", stderr="System Events got an error: assistive access is not allowed. (-1719)")
+        with patch.object(compound.sys, "platform", "darwin"), patch.object(compound.subprocess, "run", return_value=proc):
+            result = _generate_proxy_media_ui(
+                None,
+                mp,
+                mp.root,
+                {"selected": True, "allow_generate": True, "readback_wait_seconds": 0},
+            )
+
+        self.assertFalse(result["success"])
+        self.assertIn("accessibility_note", result)
+        self.assertIn("Accessibility", result["accessibility_note"])
+
+    def test_generate_proxy_media_ui_selects_explicit_single_clip_before_click(self):
+        mp = MediaPoolStub()
+        other = MediaPoolItemStub(unique_id="clip-2", name="other.mov")
+        mp.root.clips.append(other)
+        mp.selected_clip = other
+        resolve_obj = Mock()
+        resolve_obj.OpenPage.return_value = True
+        proc = Mock(returncode=0, stdout="Generate Proxy Media\n", stderr="")
+
+        with patch.object(compound.sys, "platform", "darwin"), patch.object(compound.subprocess, "run", return_value=proc):
+            result = _generate_proxy_media_ui(
+                resolve_obj,
+                mp,
+                mp.root,
+                {"clip_ids": ["clip-1"], "allow_generate": True, "readback_wait_seconds": 0},
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(mp.selected_clip.GetUniqueId(), "clip-1")
+        resolve_obj.OpenPage.assert_called_once_with("media")
+        self.assertEqual(result["clicked_label"], "Generate Proxy Media")
+
+    def test_generate_proxy_media_ui_rejects_multiple_explicit_clip_ids(self):
+        mp = MediaPoolStub()
+        mp.root.clips.append(MediaPoolItemStub(unique_id="clip-2", name="other.mov"))
+
+        with patch.object(compound.sys, "platform", "darwin"):
+            result = _generate_proxy_media_ui(
+                None,
+                mp,
+                mp.root,
+                {"clip_ids": ["clip-1", "clip-2"], "allow_generate": True},
+            )
+
+        self.assertIn("error", result)
+        self.assertIn("selected=True", result["error"]["message"])
 
 
 if __name__ == "__main__":

--- a/tests/test_render_deliver_probe.py
+++ b/tests/test_render_deliver_probe.py
@@ -26,6 +26,8 @@ class RenderProjectStub:
         self.jobs = {}
         self.deleted = []
         self.quick_export_calls = []
+        self.codec_queries = []
+        self.resolution_queries = []
 
     def AddRenderJob(self):
         job_id = f"job-{len(self.jobs) + 1}"
@@ -59,11 +61,18 @@ class RenderProjectStub:
         return {"mp4": "mp4", "QuickTime": "mov"}
 
     def GetRenderCodecs(self, render_format):
+        self.codec_queries.append(render_format)
         if render_format == "mp4":
             return {"H.264": "H.264", "H.265": "H.265"}
-        return {"ProRes 422 HQ": "ProRes422HQ"}
+        if render_format == "mov":
+            return {
+                "Apple ProRes 422 LT": "ProRes422LT",
+                "Apple ProRes 422 HQ": "ProRes422HQ",
+            }
+        return {}
 
     def GetRenderResolutions(self, render_format, codec):
+        self.resolution_queries.append((render_format, codec))
         return [{"Width": 1920, "Height": 1080}]
 
     def GetCurrentRenderFormatAndCodec(self):
@@ -123,6 +132,18 @@ class RenderDeliverProbeTest(unittest.TestCase):
         self.assertEqual(matrix["pairs_probed"], 2)
         self.assertEqual(matrix["matrix"][0]["codecs"][0]["resolution_count"], 1)
 
+    def test_probe_render_matrix_uses_render_format_id_for_display_name(self):
+        project = RenderProjectStub()
+
+        matrix = _probe_render_matrix(project, {"formats": ["QuickTime"]})
+
+        self.assertEqual(matrix["pairs_probed"], 2)
+        self.assertEqual(matrix["matrix"][0]["format"], "QuickTime")
+        self.assertEqual(matrix["matrix"][0]["extension"], "mov")
+        self.assertEqual(matrix["matrix"][0]["codecs"][0]["codec"], "ProRes422LT")
+        self.assertEqual(project.codec_queries, ["mov"])
+        self.assertEqual(project.resolution_queries[0], ("mov", "ProRes422LT"))
+
     def test_validate_render_settings_requires_temp_target_when_requested(self):
         result = _validate_render_settings_action(
             {"settings": {"TargetDir": os.getcwd(), "SelectAllFrames": True}, "require_temp_target": True}
@@ -161,6 +182,23 @@ class RenderDeliverProbeTest(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["job_id"], "job-1")
         self.assertEqual(project.format_codec["format"], "mp4")
+
+    def test_prepare_render_job_normalizes_display_format_name(self):
+        project = RenderProjectStub()
+
+        result = _prepare_render_job(
+            project,
+            {
+                "target_dir": tempfile.gettempdir(),
+                "custom_name": "prores_lt_proxy",
+                "format": "QuickTime",
+                "codec": "ProRes422LT",
+            },
+        )
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["format_success"])
+        self.assertEqual(project.format_codec, {"format": "mov", "codec": "ProRes422LT"})
 
     def test_render_job_lifecycle_probe_deletes_probe_job(self):
         project = RenderProjectStub()

--- a/tests/test_timeline_conform_probe.py
+++ b/tests/test_timeline_conform_probe.py
@@ -202,8 +202,27 @@ class TimelineConformProbeTest(unittest.TestCase):
             plan = _build_relink_plan(timeline, {"search_roots": [tmp]})
 
         self.assertEqual(missing["missing_count"], 1)
+        self.assertEqual(missing["diagnosis"]["unique_media_pool_item_count"], 1)
+        self.assertEqual(missing["diagnosis"]["primary_cause"], "folder_not_found")
         self.assertTrue(plan["success"])
         self.assertEqual(plan["candidate_count"], 1)
+        self.assertEqual(plan["unique_missing_basename_count"], 1)
+
+    def test_relink_plan_skips_search_when_source_volume_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            replacement = Path(tmp) / "P1047043.MOV"
+            replacement.write_text("replacement", encoding="utf-8")
+            missing_path = "/Volumes/EOS_DIGITAL/DCIM/104_PANA/P1047043.MOV"
+            timeline = self._timeline(missing_path=missing_path)
+            plan = _build_relink_plan(timeline, {"search_roots": [tmp], "sanitized": True})
+
+        self.assertTrue(plan["success"])
+        self.assertTrue(plan["search_skipped"])
+        self.assertEqual(plan["skip_reason"], "missing_source_volume_not_mounted")
+        self.assertEqual(plan["candidate_count"], 0)
+        self.assertEqual(plan["diagnosis"]["primary_cause"], "volume_not_mounted")
+        self.assertEqual(plan["diagnosis"]["missing_volumes"][0]["volume_root_sanitized"], "/Volumes/EOS_DIGITAL/...")
+        self.assertNotIn(tmp, str(plan))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #59.

This PR now covers:
- Normalizes Resolve render format display names such as QuickTime to the API format id such as mov before codec probing and job setup, which restores ProRes LT discovery and setup.
- Adds media_pool.generate_proxy_media_ui_capabilities and media_pool.generate_proxy_media_ui as a guarded macOS System Events fallback for Resolve's native Generate Proxy Media command.
- Keeps the documented API boundary explicit: Resolve exposes LinkProxyMedia, not a documented Generate Proxy Media scripting call.
- Makes the proxy UI capability probe usable without a live Resolve connection, so clients can discover the fallback before Resolve/project preflight.
- Cleans up legacy live-test harness collection so ordinary pytest runs skip Resolve-dependent scripts instead of exiting during collection.

Tests:
- python -m pytest
- python -m pytest tests/test_media_pool_ingest_probe.py tests/test_batch_cli.py::BatchCliRunIntegrationTests::test_run_drives_synthetic_job_to_completion tests/test_resolve20_api.py
- python -m py_compile src/server.py tests/test_media_pool_ingest_probe.py tests/test_batch_cli.py tests/test_resolve20_api.py tests/test_all_tools.py tests/test_phase2_skipped.py tests/test_phase3_final.py tests/test_phase4_remaining.py tests/test_phase5_remaining.py
- git diff --check

Current full-suite result: 839 passed, 18 skipped, 8 warnings.