### PR TITLE
Fix project lint for audio-only timelines

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -12746,13 +12746,36 @@ def _project_lint_live(r, pm) -> Dict[str, Any]:
         except Exception:
             pass
         item_count = 0
+        video_item_count = 0
+        audio_item_count = 0
+        subtitle_item_count = 0
         try:
-            vc = int(tl.GetTrackCount("video") or 0)
-            for ti in range(1, vc + 1):
-                item_count += len(tl.GetItemListInTrack("video", ti) or [])
+            for track_type, key in (
+                ("video", "video_item_count"),
+                ("audio", "audio_item_count"),
+                ("subtitle", "subtitle_item_count"),
+            ):
+                track_total = 0
+                track_count = int(tl.GetTrackCount(track_type) or 0)
+                for ti in range(1, track_count + 1):
+                    track_total += len(tl.GetItemListInTrack(track_type, ti) or [])
+                if key == "video_item_count":
+                    video_item_count = track_total
+                elif key == "audio_item_count":
+                    audio_item_count = track_total
+                elif key == "subtitle_item_count":
+                    subtitle_item_count = track_total
+                item_count += track_total
         except Exception:
             pass
-        timelines.append({"name": tl.GetName(), "fps": fps, "item_count": item_count})
+        timelines.append({
+            "name": tl.GetName(),
+            "fps": fps,
+            "item_count": item_count,
+            "video_item_count": video_item_count,
+            "audio_item_count": audio_item_count,
+            "subtitle_item_count": subtitle_item_count,
+        })
     state["timelines"] = timelines
     settings: Dict[str, Any] = {}
     try:

--- a/src/utils/project_lint.py
+++ b/src/utils/project_lint.py
@@ -50,6 +50,15 @@ def _color_science_unset(settings: Dict[str, Any]) -> bool:
     return mode in ("", "davinciYRGB")
 
 
+def _timeline_has_items(timeline: Dict[str, Any]) -> bool:
+    if int(timeline.get("item_count") or 0) > 0:
+        return True
+    for key in ("video_item_count", "audio_item_count", "subtitle_item_count"):
+        if int(timeline.get(key) or 0) > 0:
+            return True
+    return False
+
+
 def lint_state(state: Dict[str, Any]) -> List[Issue]:
     """Return graded issues for a project state dict, most-severe first."""
     issues: List[Issue] = []
@@ -73,7 +82,7 @@ def lint_state(state: Dict[str, Any]) -> List[Issue]:
         ))
 
     for tl in timelines:
-        if (tl.get("item_count") or 0) == 0:
+        if not _timeline_has_items(tl):
             issues.append(Issue(
                 "warning", "empty_timeline",
                 f"Timeline '{tl.get('name')}' has no clips.",

--- a/tests/test_project_lint.py
+++ b/tests/test_project_lint.py
@@ -42,6 +42,12 @@ class ProjectLintTest(unittest.TestCase):
                  "timelines": [{"name": "A", "fps": 24, "item_count": 0}]}
         self.assertIn("empty_timeline", _codes(state))
 
+    def test_audio_only_timeline_is_not_empty(self):
+        state = {"project": "S", "current_timeline": "Music",
+                 "timelines": [{"name": "Music", "fps": 24, "item_count": 0,
+                                "video_item_count": 0, "audio_item_count": 1}]}
+        self.assertNotIn("empty_timeline", _codes(state))
+
     def test_color_science_unset_info(self):
         state = {"project": "S", "current_timeline": "A",
                  "timelines": [{"name": "A", "fps": 24, "item_count": 1}],

--- a/tests/test_spec_lint_wiring.py
+++ b/tests/test_spec_lint_wiring.py
@@ -214,6 +214,15 @@ class LintWiringTest(unittest.TestCase):
         out = server._project_lint_live(FakeResolve(pm), pm)
         self.assertIn("empty_timeline", {i["code"] for i in out["issues"]})
 
+    def test_lint_audio_only_timeline_is_not_empty(self):
+        tl = FakeTimeline("Music", tracks={
+            ("audio", 1): [FakeItem(0, 240, "music_master", "m1")],
+        }, settings={"timelineFrameRate": "24"})
+        proj = FakeProject("Show", timelines=[tl])
+        pm = FakePM(proj)
+        out = server._project_lint_live(FakeResolve(pm), pm)
+        self.assertNotIn("empty_timeline", {i["code"] for i in out["issues"]})
+
 
 class SpecActionWiringTest(unittest.TestCase):
     def test_diff_to_spec_inline(self):


### PR DESCRIPTION
## Summary
- count audio and subtitle timeline items in the live project-lint state
- avoid warning that audio-only timelines are empty
- add unit and wiring coverage for audio-only timelines

## Tests
- python -m pytest tests/test_project_lint.py tests/test_spec_lint_wiring.py -q