### PR TITLE
Verify append-to-timeline by readback

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -9959,6 +9959,143 @@ def _safe_unlink(mp, root, p: Dict[str, Any]):
     return {"success": bool(mp.UnlinkClips(clips)), "count": len(clips), "missing": missing}
 
 
+def _verified_operation(
+    name: str,
+    *,
+    requested: Dict[str, Any],
+    preflight: Dict[str, Any],
+    execution: Dict[str, Any],
+    verification_status: str,
+    readback=None,
+    journal_event=None,
+):
+    return {
+        "name": name,
+        "preflight": preflight,
+        "requested": requested,
+        "execution": execution,
+        "readback": readback,
+        "verified": verification_status == "readback_verified",
+        "verification_status": verification_status,
+        "journal_event": journal_event,
+    }
+
+
+def _timeline_append_readback_snapshot(proj):
+    try:
+        tl = proj.GetCurrentTimeline() if proj else None
+    except Exception as exc:
+        return {"available": False, "error": f"GetCurrentTimeline failed: {exc}"}
+    if not tl:
+        return {"available": False, "error": "No current timeline"}
+
+    timeline = {}
+    try:
+        timeline["name"] = tl.GetName()
+    except Exception:
+        timeline["name"] = None
+    try:
+        timeline["id"] = tl.GetUniqueId()
+    except Exception:
+        timeline["id"] = None
+
+    tracks = {}
+    item_count = 0
+    warnings = []
+    for track_type in ("video", "audio", "subtitle"):
+        track_count = _timeline_track_count(tl, track_type)
+        rows = []
+        for track_index in range(1, track_count + 1):
+            try:
+                items = tl.GetItemListInTrack(track_type, track_index) or []
+            except Exception as exc:
+                warnings.append(f"GetItemListInTrack({track_type}, {track_index}) failed: {exc}")
+                items = []
+            item_count += len(items)
+            rows.append({
+                "track_index": track_index,
+                "item_count": len(items),
+                "item_ids": _timeline_item_ids(items),
+            })
+        tracks[track_type] = {"track_count": track_count, "tracks": rows}
+    return {
+        "available": True,
+        "timeline": timeline,
+        "item_count": item_count,
+        "tracks": tracks,
+        "warnings": warnings,
+    }
+
+
+def _compare_timeline_append_readback(before, observed, expected_count: int):
+    before_count = before.get("item_count") if isinstance(before, dict) and before.get("available") else None
+    after_count = observed.get("item_count") if isinstance(observed, dict) and observed.get("available") else None
+    delta = after_count - before_count if before_count is not None and after_count is not None else None
+    return {
+        "verified": delta is not None and delta >= expected_count and expected_count > 0,
+        "before_item_count": before_count,
+        "after_item_count": after_count,
+        "item_count_delta": delta,
+        "expected_item_count_delta": expected_count,
+    }
+
+
+def _append_to_timeline_with_verification(proj, mp, append_payload, requested: Dict[str, Any], expected_count: int):
+    raw_result = {"value": None}
+    before = _timeline_append_readback_snapshot(proj)
+
+    def mutate():
+        raw_result["value"] = mp.AppendToTimeline(append_payload)
+        return bool(raw_result["value"])
+
+    verification = verify_by_readback(
+        mutate=mutate,
+        observe=lambda: _timeline_append_readback_snapshot(proj),
+        snapshot=lambda: before,
+        compare=lambda before_snapshot, observed: _compare_timeline_append_readback(
+            before_snapshot,
+            observed,
+            expected_count,
+        ),
+        intent=requested,
+        label="media_pool.append_to_timeline",
+    )
+    return raw_result["value"], verification, before
+
+
+def _append_to_timeline_verified_operation(requested: Dict[str, Any], verification: Dict[str, Any], before):
+    success = bool(verification.get("success_raw"))
+    verified = bool(verification.get("verified"))
+    verification_status = "readback_verified" if verified else ("api_failed" if not success else "api_success_unverified")
+    readback = {
+        "before": before,
+        "after": verification.get("observed"),
+        "before_item_count": verification.get("before_item_count"),
+        "after_item_count": verification.get("after_item_count"),
+        "item_count_delta": verification.get("item_count_delta"),
+        "expected_item_count_delta": verification.get("expected_item_count_delta"),
+    }
+    return _verified_operation(
+        "media_pool.append_to_timeline",
+        requested=requested,
+        preflight={
+            "ok": True,
+            "current_timeline_available": bool(isinstance(before, dict) and before.get("available")),
+            "expected_item_count_delta": requested.get("expected_count"),
+        },
+        execution={"api": "MediaPool.AppendToTimeline", "attempted": True, "success": success},
+        readback=readback,
+        verification_status=verification_status,
+        journal_event={
+            "type": "timeline.appended" if verified else ("timeline.append.failed" if not success else "timeline.append.unverified"),
+            "success": success,
+            "verified": verified,
+            "expected_count": requested.get("expected_count"),
+            "item_count_delta": verification.get("item_count_delta"),
+        },
+    )
+
+
 def _link_proxy_checked(root, p: Dict[str, Any]):
     clip = _find_clip(root, p.get("clip_id", ""))
     if not clip:
@@ -13965,7 +14102,18 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
                 if row_err:
                     return row_err
                 built.append(row)
-            result = mp.AppendToTimeline(built)
+            requested = {
+                "mode": "clip_infos",
+                "clip_info_count": len(raw),
+                "expected_count": len(built),
+            }
+            result, verification, before = _append_to_timeline_with_verification(
+                proj,
+                mp,
+                built,
+                requested,
+                len(built),
+            )
             if not result:
                 return _err("Failed to append clip_infos to timeline")
             items_out = []
@@ -13974,14 +14122,38 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
                 if item_err:
                     return item_err
                 items_out.append(item_out)
-            return _ok(count=len(result), items=items_out)
+            out = _ok(count=len(result), items=items_out)
+            out["verified_operation"] = _append_to_timeline_verified_operation(
+                requested,
+                verification,
+                before,
+            )
+            return out
         clip_ids = p.get("clip_ids")
         if not clip_ids:
             return _err("Provide clip_ids (simple append) or clip_infos (positioned append)")
         clips = [_find_clip(root, cid) for cid in clip_ids]
         clips = [c for c in clips if c]
-        result = mp.AppendToTimeline(clips)
-        return _ok(count=len(result) if result else 0)
+        requested = {
+            "mode": "clip_ids",
+            "clip_ids": list(clip_ids),
+            "resolved_clip_count": len(clips),
+            "expected_count": len(clips),
+        }
+        result, verification, before = _append_to_timeline_with_verification(
+            proj,
+            mp,
+            clips,
+            requested,
+            len(clips),
+        )
+        out = _ok(count=len(result) if result else 0)
+        out["verified_operation"] = _append_to_timeline_verified_operation(
+            requested,
+            verification,
+            before,
+        )
+        return out
     elif action == "import_media":
         if p.get("clip_infos") is not None:
             raw = p["clip_infos"]

--- a/tests/test_media_pool_append_verification.py
+++ b/tests/test_media_pool_append_verification.py
@@ -1,0 +1,153 @@
+import unittest
+from unittest import mock
+
+import src.server as s
+from src.utils.readback import reset_verification_stats, verification_stats
+
+
+class ClipStub:
+    def __init__(self, unique_id="clip-1", name="source.mov"):
+        self.unique_id = unique_id
+        self.name = name
+
+    def GetUniqueId(self):
+        return self.unique_id
+
+    def GetName(self):
+        return self.name
+
+
+class FolderStub:
+    def __init__(self, clips=None):
+        self.clips = clips or []
+
+    def GetClipList(self):
+        return list(self.clips)
+
+    def GetSubFolderList(self):
+        return []
+
+
+class TimelineItemStub:
+    def __init__(self, unique_id, name):
+        self.unique_id = unique_id
+        self.name = name
+
+    def GetUniqueId(self):
+        return self.unique_id
+
+    def GetName(self):
+        return self.name
+
+
+class TimelineStub:
+    def __init__(self):
+        self.items = []
+
+    def GetName(self):
+        return "Timeline 1"
+
+    def GetUniqueId(self):
+        return "timeline-1"
+
+    def GetTrackCount(self, track_type):
+        return 1 if track_type == "video" else 0
+
+    def GetItemListInTrack(self, track_type, track_index):
+        if track_type == "video" and track_index == 1:
+            return list(self.items)
+        return []
+
+
+class ProjectStub:
+    def __init__(self, timeline):
+        self.timeline = timeline
+
+    def GetCurrentTimeline(self):
+        return self.timeline
+
+
+class MediaPoolStub:
+    def __init__(self, root, timeline):
+        self.root = root
+        self.timeline = timeline
+
+    def GetRootFolder(self):
+        return self.root
+
+    def AppendToTimeline(self, clips):
+        appended = []
+        for index, row in enumerate(clips, start=1):
+            clip = row.get("mediaPoolItem") if isinstance(row, dict) else row
+            item = TimelineItemStub(f"timeline-item-{index}", clip.GetName())
+            self.timeline.items.append(item)
+            appended.append(item)
+        return appended
+
+
+class MediaPoolAppendVerificationTest(unittest.TestCase):
+    def test_append_to_timeline_simple_updates_verified_operation_and_stats(self):
+        reset_verification_stats()
+        clip = ClipStub()
+        timeline = TimelineStub()
+        project = ProjectStub(timeline)
+        media_pool = MediaPoolStub(FolderStub([clip]), timeline)
+
+        with mock.patch.object(s, "_get_mp", return_value=(None, project, media_pool, None)):
+            result = s.media_pool("append_to_timeline", {"clip_ids": ["clip-1"]})
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["count"], 1)
+        operation = result["verified_operation"]
+        self.assertEqual(operation["name"], "media_pool.append_to_timeline")
+        self.assertTrue(operation["verified"])
+        self.assertEqual(operation["verification_status"], "readback_verified")
+        self.assertEqual(operation["execution"]["success"], True)
+        self.assertEqual(operation["readback"]["item_count_delta"], 1)
+
+        stats = verification_stats()
+        self.assertEqual(stats["total"], 1)
+        self.assertEqual(stats["verified"], 1)
+        self.assertEqual(stats["contradicted"], 0)
+        self.assertEqual(stats["unverified"], 0)
+
+    def test_append_to_timeline_clip_infos_updates_verified_operation_and_stats(self):
+        reset_verification_stats()
+        clip = ClipStub()
+        timeline = TimelineStub()
+        project = ProjectStub(timeline)
+        media_pool = MediaPoolStub(FolderStub([clip]), timeline)
+
+        with mock.patch.object(s, "_get_mp", return_value=(None, project, media_pool, None)):
+            result = s.media_pool(
+                "append_to_timeline",
+                {
+                    "clip_infos": [
+                        {
+                            "clip_id": "clip-1",
+                            "start_frame": 0,
+                            "end_frame": 24,
+                            "record_frame": 0,
+                            "track_index": 1,
+                            "media_type": 1,
+                        }
+                    ]
+                },
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["items"][0]["timeline_item_id"], "timeline-item-1")
+        operation = result["verified_operation"]
+        self.assertEqual(operation["name"], "media_pool.append_to_timeline")
+        self.assertTrue(operation["verified"])
+        self.assertEqual(operation["verification_status"], "readback_verified")
+        self.assertEqual(operation["readback"]["item_count_delta"], 1)
+
+        stats = verification_stats()
+        self.assertEqual(stats["total"], 1)
+        self.assertEqual(stats["verified"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap MediaPool.AppendToTimeline calls with readback verification
- report before/after timeline item counts in verified_operation
- add focused tests for clip id and clipInfo append paths

## Tests
- python -m pytest tests/test_media_pool_append_verification.py tests/test_verification_stats.py -q