### PR TITLE
Support media pool bins in project specs

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -12553,6 +12553,35 @@ class _SpecLiveExecutor:
         self._spec = spec
         self._proj = pm.GetCurrentProject()
 
+    def _media_pool_bin_paths(self) -> List[str]:
+        if not self._proj or not getattr(self._spec, "bins", None):
+            return []
+        try:
+            mp = self._proj.GetMediaPool()
+            root = mp.GetRootFolder() if mp else None
+        except Exception:
+            return []
+        if root is None:
+            return []
+        paths: List[str] = []
+
+        def walk(folder, prefix: str) -> None:
+            paths.append(prefix)
+            try:
+                subfolders = folder.GetSubFolderList() or []
+            except Exception:
+                subfolders = []
+            for subfolder in subfolders:
+                try:
+                    name = subfolder.GetName()
+                except Exception:
+                    name = ""
+                if name:
+                    walk(subfolder, f"{prefix}/{name}")
+
+        walk(root, "Master")
+        return paths
+
     def live_state(self) -> Dict[str, Any]:
         proj = self._proj
         projects = list(self._pm.GetProjectListInCurrentFolder() or [])
@@ -12602,6 +12631,7 @@ class _SpecLiveExecutor:
             "project": proj.GetName() if proj else None,
             "projects": projects,
             "settings": settings,
+            "bins": self._media_pool_bin_paths(),
             "timelines": timelines,
         }
 
@@ -12622,6 +12652,18 @@ class _SpecLiveExecutor:
             return bool(self._proj.SetSetting(key, str(value)))
         except Exception:
             return False
+
+    def ensure_bin(self, path: str) -> bool:
+        if not self._proj:
+            return False
+        try:
+            mp = self._proj.GetMediaPool()
+        except Exception:
+            return False
+        if mp is None:
+            return False
+        _, err = _ensure_folder_path(mp, path)
+        return err is None
 
     def ensure_timeline(self, name: str, fps: Optional[float]) -> bool:
         if not self._proj:

--- a/src/utils/project_spec.py
+++ b/src/utils/project_spec.py
@@ -83,6 +83,7 @@ class Spec:
     project: str
     color_preset: Optional[str] = None
     settings: Dict[str, str] = field(default_factory=dict)
+    bins: List[str] = field(default_factory=list)
     timelines: List[TimelineSpec] = field(default_factory=list)
     hooks: List[Hook] = field(default_factory=list)
 
@@ -145,6 +146,15 @@ def spec_from_dict(data: Dict[str, Any]) -> Spec:
     if not isinstance(settings, dict):
         raise SpecError("`settings` must be a mapping.")
 
+    bins: List[str] = []
+    for raw_bin in data.get("bins") or []:
+        if isinstance(raw_bin, str) and raw_bin.strip():
+            bins.append(raw_bin.strip().strip("/"))
+        elif isinstance(raw_bin, dict) and raw_bin.get("path"):
+            bins.append(str(raw_bin["path"]).strip().strip("/"))
+        else:
+            raise SpecError(f"Each bin needs a non-empty path: {raw_bin!r}")
+
     timelines: List[TimelineSpec] = []
     for raw_tl in (data.get("timelines") or []):
         if not isinstance(raw_tl, dict) or not raw_tl.get("name"):
@@ -160,6 +170,7 @@ def spec_from_dict(data: Dict[str, Any]) -> Spec:
         project=str(project),
         color_preset=preset,
         settings={str(k): str(v) for k, v in settings.items()},
+        bins=bins,
         timelines=timelines,
         hooks=_parse_hooks(data.get("hooks")),
     )
@@ -252,6 +263,15 @@ def plan_spec(spec: Spec, live: Dict[str, Any]) -> Dict[str, Any]:
                 f"{live_settings.get(key)!r} -> {want!r}", {"key": key, "value": want},
             ))
 
+    # Media Pool bins. Paths are slash-delimited from Master, e.g.
+    # "Master/Media/Scene_01"; creation is idempotent in the executor.
+    live_bins = set(live.get("bins") or [])
+    for bin_path in spec.bins:
+        if bin_path in live_bins:
+            actions.append(Action("noop", f"bin:{bin_path}", "exists"))
+        else:
+            actions.append(Action("ensure", f"bin:{bin_path}", "ensure media-pool bin", {"path": bin_path}))
+
     # Timelines + their settings + markers. NOTE: `fps` is a *creation-time*
     # property handled by ensure_timeline — Resolve refuses SetSetting on
     # timelineFrameRate after a timeline exists — so it is never emitted as a
@@ -300,6 +320,7 @@ def _spec_desired_state(spec: Spec) -> Dict[str, Any]:
     return {
         "project": spec.project,
         "settings": {k: _norm_setting_value(v) for k, v in effective_settings(spec).items()},
+        "bins": list(spec.bins),
         "timelines": [
             {
                 "name": tl.name,
@@ -324,6 +345,7 @@ def _spec_normalized_state(live: Dict[str, Any], spec: Spec) -> Dict[str, Any]:
     return {
         "project": live.get("project"),
         "settings": {k: _norm_setting_value(live_settings.get(k)) for k in desired if k in live_settings},
+        "bins": [path for path in (live.get("bins") or []) if path in set(spec.bins)],
         "timelines": [
             {
                 "name": name,
@@ -356,6 +378,7 @@ def apply_spec(
         ensure_timeline(name, fps) -> bool
         set_timeline_setting(timeline_name, key, value) -> bool
         add_marker(timeline_name, marker: dict) -> bool
+        ensure_bin(path) -> bool
 
     Hooks execute only when `run_hooks=True` AND a `run_hook` callable is given —
     arbitrary shell from a spec stays opt-in. Failures accumulate when
@@ -396,6 +419,9 @@ def apply_spec(
             continue
         _record(bool(executor.set_project_setting(key, desired[key])),
                 f"project:{spec.project}/setting:{key}", str(desired[key]))
+
+    for bin_path in spec.bins:
+        _record(bool(executor.ensure_bin(bin_path)), f"bin:{bin_path}")
 
     # Timelines. `fps` is creation-time only (ensure_timeline); never set as a
     # post-creation timelineFrameRate setting — Resolve refuses that.

--- a/tests/test_project_spec.py
+++ b/tests/test_project_spec.py
@@ -37,11 +37,15 @@ class FakeExecutor:
     def add_marker(self, tl, marker):
         return self._ok("add_marker", f"timeline:{tl}/marker:{marker.get('frame')}")
 
+    def ensure_bin(self, path):
+        return self._ok("ensure_bin", f"bin:{path}")
+
 
 SPEC_DICT = {
     "project": "MyShow",
     "color_preset": "rec709_gamma24",
     "settings": {"timelineFrameRate": "24"},
+    "bins": ["Master/Admin", "Master/Media/Scene_01"],
     "timelines": [
         {"name": "Edit_v2", "fps": 24,
          "markers": [{"frame": 0, "color": "Blue", "name": "HEAD"}]},
@@ -55,6 +59,7 @@ class SpecLoadTest(unittest.TestCase):
         spec = ps.spec_from_dict(SPEC_DICT)
         self.assertEqual(spec.project, "MyShow")
         self.assertEqual(spec.color_preset, "rec709_gamma24")
+        self.assertEqual(spec.bins, ["Master/Admin", "Master/Media/Scene_01"])
         self.assertEqual(len(spec.timelines), 1)
         self.assertEqual(spec.timelines[0].fps, 24)
         self.assertEqual(len(spec.hooks), 2)
@@ -159,6 +164,15 @@ class PlanTest(unittest.TestCase):
         marker_actions = [a for a in plan["actions"] if "marker" in a["target"]]
         self.assertTrue(all(a["op"] == "noop" for a in marker_actions))
 
+    def test_missing_bins_are_ensured(self):
+        spec = ps.spec_from_dict({"project": "S", "bins": ["Master/Media/Scene_01"]})
+        plan = ps.plan_spec(spec, {"project": "S", "projects": ["S"], "settings": {}, "bins": ["Master"]})
+
+        bin_actions = [a for a in plan["actions"] if a["target"].startswith("bin:")]
+
+        self.assertEqual(bin_actions[0]["op"], "ensure")
+        self.assertEqual(bin_actions[0]["target"], "bin:Master/Media/Scene_01")
+
 
 class ApplyTest(unittest.TestCase):
     def test_dry_run_does_not_execute(self):
@@ -175,6 +189,7 @@ class ApplyTest(unittest.TestCase):
         self.assertTrue(out["success"])
         tags = {t for t, _ in ex.calls}
         self.assertIn("ensure_project", tags)
+        self.assertIn("ensure_bin", tags)
         self.assertIn("ensure_timeline", tags)
         self.assertIn("add_marker", tags)
 

--- a/tests/test_spec_lint_wiring.py
+++ b/tests/test_spec_lint_wiring.py
@@ -87,14 +87,35 @@ class FakeTimeline:
         return "01:00:00:00"
 
 
+class FakeFolder:
+    def __init__(self, name):
+        self.name = name
+        self.subfolders = []
+
+    def GetName(self):
+        return self.name
+
+    def GetSubFolderList(self):
+        return list(self.subfolders)
+
+
 class FakeMediaPool:
     def __init__(self, project):
         self._project = project
+        self._root = FakeFolder("Master")
 
     def CreateEmptyTimeline(self, name):
         tl = FakeTimeline(name)
         self._project._timelines.append(tl)
         return tl
+
+    def GetRootFolder(self):
+        return self._root
+
+    def AddSubFolder(self, parent, name):
+        folder = FakeFolder(name)
+        parent.subfolders.append(folder)
+        return folder
 
 
 class FakeProject:
@@ -241,6 +262,17 @@ class SpecActionWiringTest(unittest.TestCase):
         self.assertIn("Edit_v2", names)
         new_tl = next(tl for tl in proj._timelines if tl.GetName() == "Edit_v2")
         self.assertIn(0, new_tl.GetMarkers())
+
+    def test_apply_spec_creates_media_pool_bins(self):
+        proj = FakeProject("Show", timelines=[], settings={})
+        pm = FakePM(proj)
+        spec = {"project": "Show", "bins": ["Master/Media/Scene_01"]}
+
+        out = server._spec_action(FakeResolve(pm), pm, "apply_spec", {"spec": spec})
+
+        self.assertTrue(out["success"], out)
+        plan = server._spec_action(FakeResolve(pm), pm, "diff_to_spec", {"spec": spec})
+        self.assertEqual(plan["change_count"], 0, plan["actions"])
 
     def test_apply_spec_idempotent_second_run(self):
         proj = FakeProject("Show", timelines=[], settings={})


### PR DESCRIPTION
## Summary
- add an optional bins list to declarative project specs
- plan missing media-pool bins as ensure actions and treat existing bins as no-ops
- wire the live executor to create missing bin paths idempotently

## Tests
- python -m pytest tests/test_project_spec.py tests/test_spec_lint_wiring.py tests/test_import.py -q