### PR TITLE
fix(markers): timeline marker frames are relative to the timeline start

### DIFF
--- a/src/granular/timeline.py
+++ b/src/granular/timeline.py
@@ -461,7 +461,8 @@ def timeline_add_marker(frame_id: int, color: str, name: str, note: str = "", du
     """Add a marker to the current timeline.
 
     Args:
-        frame_id: Frame number for the marker.
+        frame_id: Frame number for the marker, relative to the timeline start
+            (frame 0 = first frame, even when the timeline starts at 01:00:00:00).
         color: Marker color (Blue, Cyan, Green, Yellow, Red, Pink, Purple, Fuchsia, Rose, Lavender, Sky, Mint, Lemon, Sand, Cocoa, Cream).
         name: Marker name.
         note: Marker note. Default: empty.

--- a/src/server.py
+++ b/src/server.py
@@ -1347,6 +1347,46 @@ def _timeline_timecode_to_frame_id(tl, timecode):
     return _timecode_to_frame_id(timecode, fps)
 
 
+def _marker_rebase_to_timeline_start(tl, frame):
+    """Rebase an absolute frame to a Timeline marker frameId.
+
+    Timeline.AddMarker frameIds are relative to the timeline start (frame 0 ==
+    first frame of the timeline), while GetCurrentTimecode and the timecodes
+    shown in the Resolve UI are absolute. GetMarkers() echoes back whatever
+    frameId was passed without validating, so a marker stored at an absolute
+    frame displays past the end of the timeline (invisible in the UI).
+    Frames below the timeline start are treated as already relative (elapsed
+    time), and the frame passes through unchanged when the start frame is
+    unavailable.
+    """
+    start = _timeline_start_frame(tl)
+    if start and frame >= start:
+        return frame - start
+    return frame
+
+
+def _marker_timecode_to_frame_id(tl, timecode):
+    frame, err = _timeline_timecode_to_frame_id(tl, timecode)
+    if err:
+        return None, err
+    return _marker_rebase_to_timeline_start(tl, frame), None
+
+
+def _marker_display_frame(tl, frame):
+    """Absolute frame for driving the playhead at a stored marker frameId.
+
+    Inverse of _marker_rebase_to_timeline_start: stored timeline marker keys
+    are relative to the timeline start, while SetCurrentTimecode is absolute.
+    Frames at or past the start frame are assumed to be legacy absolute keys
+    and pass through unchanged so they still sample the intended frame.
+    """
+    frame = int(frame)
+    start = _timeline_start_frame(tl)
+    if start and frame < start:
+        return frame + start
+    return frame
+
+
 def _frame_id_to_timecode(frame: int, fps: float, separator: str = ":") -> str:
     nominal_fps = max(1, int(round(float(fps))))
     frame = max(0, int(frame))
@@ -1364,6 +1404,7 @@ def _timeline_frame_id_to_timecode(tl, frame: int) -> Tuple[Optional[str], Optio
 
 
 def _current_timeline_frame_id(tl):
+    """Absolute frame at the playhead, matching TimelineItem.GetStart()."""
     if tl is None:
         return None, _err("current playhead marker requires a timeline")
     try:
@@ -1375,23 +1416,37 @@ def _current_timeline_frame_id(tl):
     return _timeline_timecode_to_frame_id(tl, timecode)
 
 
+def _current_timeline_marker_frame_id(tl):
+    frame, err = _current_timeline_frame_id(tl)
+    if err:
+        return None, err
+    return _marker_rebase_to_timeline_start(tl, frame), None
+
+
 def _marker_frame_from_params(p: Dict[str, Any], tl=None, default_to_current=False):
+    """Resolve marker frame params to a marker frameId.
+
+    With a timeline, timecodes (and the playhead default) are rebased so the
+    returned frameId is relative to the timeline start. Raw frame numbers are
+    passed through unchanged: timeline marker frames are relative to the
+    timeline start, clip marker frames are relative to the clip start.
+    """
     raw_timecode = _first_param(p, "timecode", "time_code", "tc")
     if raw_timecode is not None:
-        return _timeline_timecode_to_frame_id(tl, raw_timecode)
+        return _marker_timecode_to_frame_id(tl, raw_timecode)
 
     raw_frame = _first_param(p, "frame", "frame_id", "frameId", "frame_num", "frameNum")
     if raw_frame is not None:
         if isinstance(raw_frame, str):
             lowered = raw_frame.strip().lower()
             if lowered in {"current", "playhead", "current_playhead", "now"}:
-                return _current_timeline_frame_id(tl)
+                return _current_timeline_marker_frame_id(tl)
             if ":" in raw_frame or ";" in raw_frame:
-                return _timeline_timecode_to_frame_id(tl, raw_frame)
+                return _marker_timecode_to_frame_id(tl, raw_frame)
         return _coerce_marker_number(raw_frame, "frame")
 
     if default_to_current:
-        return _current_timeline_frame_id(tl)
+        return _current_timeline_marker_frame_id(tl)
     return None, _err("Missing marker frame. Provide frame, frame_id/frameId, or timecode.")
 
 
@@ -4821,7 +4876,7 @@ def _timeline_thumbnail_contact_sheet(proj, tl, p: Dict[str, Any]) -> Dict[str, 
     sampled = []
     try:
         for sample in samples:
-            timecode, tc_err = _timeline_frame_id_to_timecode(tl, int(sample["frame"]))
+            timecode, tc_err = _timeline_frame_id_to_timecode(tl, _marker_display_frame(tl, sample["frame"]))
             if tc_err:
                 sample["error"] = tc_err.get("error")
                 sampled.append(sample)
@@ -16330,6 +16385,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       apply_look_to_items(target_ids, cdl?|copy_from_item_id?, dry_run?) -> {success}
         # example: action_help(name='<action_name>')
       thumbnail_contact_sheet(frames?|max_samples?, analysis_root?) -> {path, samples}
+        frames are relative to the timeline start (frame 0 = first frame), like marker frameIds.
       marker_thumbnail_review(max_samples?, analysis_root?) -> {path, samples, review_guidance}
       edit_kernel_capabilities() -> {supported, partially_supported, unsupported}
       probe_edit_kernel_item(clip_ids? selected? timeline_item?) -> {items, count}
@@ -16935,6 +16991,12 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
 @_destructive_op("timeline_markers")
 def timeline_markers(action: str, params: Optional[Dict[str, Any]] = None) -> Any:
     """Markers and playhead operations on the current timeline.
+
+    Marker frames are RELATIVE to the timeline start: frame 0 is the first
+    frame of the timeline, even when the timeline starts at 01:00:00:00.
+    Timecode params are absolute timeline timecode as shown in the Resolve UI
+    (timecodes before the start timecode are treated as elapsed time) and are
+    converted to relative frames automatically.
 
     Actions:
       add(frame|frame_id|frameId|timecode?, color?, name?, note?, duration?, custom_data?) -> {success, frame}

--- a/tests/live_marker_validation.py
+++ b/tests/live_marker_validation.py
@@ -5,6 +5,17 @@ Requires DaVinci Resolve Studio running with Preferences > General >
 "External scripting using" set to Local. This creates a disposable project,
 adds timeline markers through the compound server wrappers, verifies them
 through Resolve's marker API, and deletes the disposable project.
+
+Frame convention (verified VISUALLY on Resolve Studio 21, 2026-06-11):
+Timeline.AddMarker frameIds are RELATIVE to the timeline start — frame 0 is
+the first frame of the timeline, even when the timeline starts at
+01:00:00:00. GetMarkers() echoes back whatever frameId was passed without
+validating or normalizing, so add/get round-trips pass even for markers
+stored at absolute frames that display past the end of the timeline
+(invisible in the UI). This harness therefore asserts the RELATIVE
+convention — returned frames must fit within the timeline's visible length —
+instead of trusting round-trips to prove display position. Use --keep-open
+to confirm placement visually.
 """
 
 from __future__ import annotations
@@ -20,6 +31,12 @@ from pathlib import Path
 
 def _install_mcp_stubs() -> None:
     """Let us import src.server without installing MCP deps in this Python."""
+
+    try:
+        import mcp.server.fastmcp  # noqa: F401
+        return  # real SDK available — stubs would shadow it
+    except ImportError:
+        pass
 
     class FastMCP:
         def __init__(self, *args, **kwargs):
@@ -37,6 +54,14 @@ def _install_mcp_stubs() -> None:
 
             return decorate
 
+    class Context:
+        pass
+
+    class Image:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
     def stdio_server(*args, **kwargs):
         raise RuntimeError("stdio_server is not used by the live marker harness")
 
@@ -49,6 +74,8 @@ def _install_mcp_stubs() -> None:
     stdio = types.ModuleType("mcp.server.stdio")
 
     fastmcp.FastMCP = FastMCP
+    fastmcp.Context = Context
+    fastmcp.Image = Image
     stdio.stdio_server = stdio_server
 
     sys.modules.setdefault("anyio", anyio)
@@ -141,6 +168,31 @@ def main() -> int:
 
         current = _require_success("timeline.get_current", server.timeline("get_current"))
         start_frame = int(current["start_frame"])
+        timeline_length = int(current["end_frame"]) - start_frame
+        if timeline_length <= 0:
+            raise AssertionError(f"Timeline has no visible length: {current!r}")
+        tl_obj = proj.GetCurrentTimeline()
+        fps, fps_err = server._timeline_fps(tl_obj)
+        if fps_err:
+            raise AssertionError(f"Could not read timeline fps: {fps_err!r}")
+        nominal_fps = int(round(fps))
+        print(
+            f"Timeline starts at {current['start_timecode']} "
+            f"(frame {start_frame}), visible length {timeline_length} frames"
+        )
+
+        def _require_visible(label, frame):
+            # GetMarkers() echoes any frameId back, so round-trips cannot
+            # prove display position. Marker frames are relative to the
+            # timeline start; a frame past the visible length means the
+            # absolute-frame bug has regressed.
+            if not 0 <= int(frame) <= timeline_length:
+                raise AssertionError(
+                    f"{label}: marker frame {frame} is outside the visible "
+                    f"timeline (0..{timeline_length}) — frameIds must be "
+                    "relative to the timeline start"
+                )
+
         frame_id_marker = f"issue34-frame-id-{int(time.time())}"
         current_marker = f"issue34-current-{int(time.time())}"
         timecode_marker = f"issue34-timecode-{int(time.time())}"
@@ -150,13 +202,18 @@ def main() -> int:
             server.timeline_markers(
                 "add",
                 {
-                    "frame_id": str(start_frame + 12),
+                    "frame_id": "12",
                     "color": "blue",
                     "note": "Issue #34 frame_id alias live test",
                     "customData": frame_id_marker,
                 },
             ),
         )
+        if int(add_frame_id["frame"]) != 12:
+            raise AssertionError(
+                f"frame_id marker: raw frames must pass through unchanged, got {add_frame_id['frame']!r}"
+            )
+        _require_visible("frame_id marker", add_frame_id["frame"])
         print(f"Added frame_id marker at frame {add_frame_id['frame']}")
 
         add_current = _require_success(
@@ -170,21 +227,36 @@ def main() -> int:
                 },
             ),
         )
+        _require_visible("current-playhead marker", add_current["frame"])
         print(f"Added current-playhead marker at frame {add_current['frame']}")
+
+        # Two seconds past the timeline start, expressed as the absolute
+        # timecode the Resolve UI displays (non-drop arithmetic; the
+        # disposable project uses a non-drop frame rate).
+        start_abs_frame, tc_err = server._timecode_to_frame_id(current["start_timecode"], fps)
+        if tc_err:
+            raise AssertionError(f"Could not parse start timecode: {tc_err!r}")
+        marker_timecode = server._frame_id_to_timecode(start_abs_frame + 2 * nominal_fps, fps)
 
         add_timecode = _require_success(
             "timeline_markers.add timecode",
             server.timeline_markers(
                 "add",
                 {
-                    "timecode": "01:00:02:00",
+                    "timecode": marker_timecode,
                     "color": "red",
                     "name": "Issue #34 timecode",
                     "custom_data": timecode_marker,
                 },
             ),
         )
-        print(f"Added timecode marker at frame {add_timecode['frame']}")
+        if int(add_timecode["frame"]) != 2 * nominal_fps:
+            raise AssertionError(
+                f"timecode marker: expected {marker_timecode} to land at relative frame "
+                f"{2 * nominal_fps}, got {add_timecode['frame']!r}"
+            )
+        _require_visible("timecode marker", add_timecode["frame"])
+        print(f"Added timecode marker {marker_timecode} at frame {add_timecode['frame']}")
 
         _require_marker(
             "frame_id marker lookup",

--- a/tests/test_marker_params.py
+++ b/tests/test_marker_params.py
@@ -12,11 +12,23 @@ def _strip_versioning(d):
 
 
 class TimelineStub:
-    def __init__(self, fps="24", current_timecode="01:00:00:12"):
+    """Hour-start timeline by default (start TC 01:00:00:00 @ 24fps -> frame 86400).
+
+    Timeline.AddMarker frameIds are RELATIVE to the timeline start (frame 0 ==
+    first frame), while GetCurrentTimecode/SetCurrentTimecode use absolute
+    timecode as displayed in the Resolve UI. Verified visually on Resolve
+    Studio 21 (2026-06-11); GetMarkers() echoes back whatever frameId was
+    passed, so only display-position conventions like these stubs encode can
+    catch absolute/relative mixups.
+    """
+
+    def __init__(self, fps="24", current_timecode="01:00:00:12", start_frame=86400):
         self.fps = fps
         self.current_timecode = current_timecode
+        self.start_frame = start_frame
         self.add_calls = []
         self.deleted_frames = []
+        self.update_custom_data_calls = []
 
     def GetSetting(self, name):
         if name == "timelineFrameRate":
@@ -25,6 +37,11 @@ class TimelineStub:
 
     def GetCurrentTimecode(self):
         return self.current_timecode
+
+    def GetStartFrame(self):
+        if self.start_frame is None:
+            raise RuntimeError("GetStartFrame unavailable")
+        return self.start_frame
 
     def AddMarker(self, *args):
         self.add_calls.append(args)
@@ -35,6 +52,10 @@ class TimelineStub:
 
     def DeleteMarkerAtFrame(self, frame):
         self.deleted_frames.append(frame)
+        return True
+
+    def UpdateMarkerCustomData(self, frame, data):
+        self.update_custom_data_calls.append((frame, data))
         return True
 
     def GetCurrentClipThumbnailImage(self):
@@ -62,6 +83,8 @@ class TimelineMarkerParamTest(unittest.TestCase):
         compound._get_tl = self.original_get_tl
 
     def test_add_accepts_frame_id_alias_and_defaults_name_duration(self):
+        # Raw frame params are already relative to the timeline start and must
+        # not be reinterpreted, even on an hour-start timeline.
         out = compound.timeline_markers(
             "add",
             {
@@ -78,16 +101,18 @@ class TimelineMarkerParamTest(unittest.TestCase):
             (42, "Blue", "Needs review", "Needs review", 1, "marker-1"),
         )
 
-    def test_add_defaults_to_current_playhead(self):
+    def test_add_defaults_to_current_playhead_relative_to_start(self):
+        # Playhead TC 01:00:00:12 on an hour-start timeline is marker frame 12.
         out = compound.timeline_markers("add", {"color": "green"})
 
-        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 86412})
+        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 12})
         self.assertEqual(
             self.timeline.add_calls[-1],
-            (86412, "Green", "Marker", "", 1, ""),
+            (12, "Green", "Marker", "", 1, ""),
         )
 
     def test_add_accepts_timecode_with_nominal_ntsc_rate(self):
+        # 01:00:10:00 @ 23.976 (nominal 24) is 86640 absolute -> 240 relative.
         self.timeline.fps = "23.976"
 
         out = compound.timeline_markers(
@@ -95,17 +120,81 @@ class TimelineMarkerParamTest(unittest.TestCase):
             {"timecode": "01:00:10:00", "color": "red", "name": "TC"},
         )
 
-        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 86640})
+        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 240})
         self.assertEqual(
             self.timeline.add_calls[-1],
-            (86640, "Red", "TC", "", 1, ""),
+            (240, "Red", "TC", "", 1, ""),
         )
+
+    def test_add_timecode_below_start_treated_as_elapsed(self):
+        # A timecode before the timeline start timecode cannot be absolute;
+        # treat it as elapsed time from the first frame.
+        out = compound.timeline_markers(
+            "add",
+            {"timecode": "00:00:10:00", "color": "red", "name": "Elapsed"},
+        )
+
+        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 240})
+
+    def test_add_timecode_on_zero_start_timeline(self):
+        self.timeline.start_frame = 0
+
+        out = compound.timeline_markers(
+            "add",
+            {"timecode": "00:00:10:00", "color": "red", "name": "ZeroStart"},
+        )
+
+        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 240})
+
+    def test_add_playhead_without_start_frame_keeps_absolute(self):
+        # If GetStartFrame is unavailable the conversion cannot be rebased;
+        # fall back to the unrebased frame instead of erroring.
+        self.timeline.start_frame = None
+
+        out = compound.timeline_markers("add", {"color": "green"})
+
+        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 86412})
 
     def test_delete_at_frame_accepts_frame_id_alias(self):
         out = compound.timeline_markers("delete_at_frame", {"frameId": 123})
 
         self.assertEqual(_strip_versioning(out), {"success": True})
         self.assertEqual(self.timeline.deleted_frames, [123])
+
+    def test_delete_at_frame_accepts_timecode_relative_to_start(self):
+        # Stored marker keys are relative, so timecode lookups must rebase to
+        # match the stored key.
+        out = compound.timeline_markers("delete_at_frame", {"timecode": "01:00:00:12"})
+
+        self.assertEqual(_strip_versioning(out), {"success": True})
+        self.assertEqual(self.timeline.deleted_frames, [12])
+
+    def test_update_custom_data_accepts_timecode_relative_to_start(self):
+        out = compound.timeline_markers(
+            "update_custom_data",
+            {"timecode": "01:00:00:12", "customData": "marker-2"},
+        )
+
+        self.assertEqual(_strip_versioning(out), {"success": True})
+        self.assertEqual(self.timeline.update_custom_data_calls, [(12, "marker-2")])
+
+    def test_current_timeline_frame_id_stays_absolute(self):
+        # Non-marker callers (duplicate-clip record frames) need the absolute
+        # frame that matches TimelineItem.GetStart().
+        frame, err = compound._current_timeline_frame_id(self.timeline)
+
+        self.assertIsNone(err)
+        self.assertEqual(frame, 86412)
+
+    def test_marker_display_frame_rebases_stored_markers_to_absolute(self):
+        # Contact sheets drive SetCurrentTimecode (absolute), so stored
+        # relative marker frames must be rebased the other way.
+        self.assertEqual(compound._marker_display_frame(self.timeline, 12), 86412)
+        # Legacy markers stored at absolute frames still sample the intended
+        # spot instead of pointing past the end of the timeline.
+        self.assertEqual(compound._marker_display_frame(self.timeline, 86412), 86412)
+        self.timeline.start_frame = 0
+        self.assertEqual(compound._marker_display_frame(self.timeline, 12), 12)
 
     def test_invalid_timecode_returns_error(self):
         out = compound.timeline_markers("add", {"timecode": "01:00:00"})

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -6,6 +6,7 @@ import sqlite3
 import subprocess
 import tempfile
 import unittest
+from typing import Any, Dict, Optional
 
 from src import server as _server_module
 from src.server import (


### PR DESCRIPTION
## Summary
- `Timeline.AddMarker` frameIds are relative to the timeline start (frame 0 = first frame; verified visually on Resolve Studio 21), but the generic marker path converted timecodes and the playhead default to absolute frames — so `timeline_markers` add/delete_at_frame/update_custom_data/get_custom_data, `sync_marker_custom_data`, `normalize_marker_payload`, and `create_variant_from_ranges` markers landed ~1 hour past the end of hour-start timelines (stored and echoed by `GetMarkers()`, invisible in the UI).
- New `_marker_timecode_to_frame_id` / `_current_timeline_marker_frame_id` rebase conversions by `tl.GetStartFrame()`; timecodes before the start timecode are treated as already-elapsed, and raw `frame` params pass through unchanged (now documented as relative-to-timeline-start). `_current_timeline_frame_id` stays absolute for the duplicate-clip `at_playhead` record-frame path (record frames match `GetStart()`), pinned by a test.
- `thumbnail_contact_sheet` / `marker_thumbnail_review` had the mirror-image bug (stored relative keys fed to `SetCurrentTimecode`, which is absolute); `_marker_display_frame` rebases the other way with a guard so legacy absolute-stored markers still sample the intended frame.
- `tests/test_marker_params.py` now stubs an hour-start timeline so absolute/relative mixups can't pass silently; `tests/live_marker_validation.py` asserts the relative convention with visible-range checks (GetMarkers round-trips echo any frameId back, so they cannot validate display position) and its MCP stubs no longer shadow a real installed SDK. Also fixes a missing `typing` import that prevented `tests/test_media_analysis.py` from importing at all.

## Test Plan
- [x] `PYTHONPATH=. venv/bin/python -m unittest tests.test_marker_params -v` — 14/14 green (watched fail first, TDD)
- [x] Full stub-based unit suite — 1018 tests green
- [x] `PYTHONPATH=. venv/bin/python tests/live_marker_validation.py` against Resolve Studio 21.0.0.48 — passed on an hour-start timeline (raw 12 → 12, playhead → 120, timecode 01:00:02:00 → 48); disposable project cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)