### PR TITLE
Fix analysis reuse capability gate

### DIFF
--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -5155,7 +5155,15 @@ async def execute_plan_async(
                 for clip in blocked
             ],
         }
-    if plan.get("capability_gaps"):
+    executing_clips = [
+        clip for clip in plan.get("clips", [])
+        if not (
+            isinstance(clip, dict)
+            and clip.get("skip_execution")
+            and (clip.get("existing_report") or {}).get("path")
+        )
+    ]
+    if plan.get("capability_gaps") and executing_clips:
         return {
             "success": False,
             "error": "Cannot execute analysis with missing required capabilities",
@@ -5204,17 +5212,13 @@ async def execute_plan_async(
         and vision_uses_chat_context(options, caps)
         and not _coerce_bool(params.get("confirm_deep") or params.get("confirmDeep"), default=False)
     ):
-        executing = [
-            clip for clip in plan.get("clips", [])
-            if not (clip.get("skip_execution") and (clip.get("existing_report") or {}).get("path"))
-        ]
-        estimated_frames = sum(int(c.get("analysis_keyframe_budget") or 0) for c in executing)
+        estimated_frames = sum(int(c.get("analysis_keyframe_budget") or 0) for c in executing_clips)
         return {
             "success": True,
             "status": "confirmation_required",
             "reason": "deep_depth_cost_estimate",
             "estimate": {
-                "clip_count": len(executing),
+                "clip_count": len(executing_clips),
                 "estimated_frames": estimated_frames,
                 "estimated_vision_tokens": estimated_frames * AVG_VISION_TOKENS_PER_FRAME,
                 "tokens_per_frame_assumption": AVG_VISION_TOKENS_PER_FRAME,

--- a/tests/test_marker_params.py
+++ b/tests/test_marker_params.py
@@ -76,11 +76,14 @@ class FiveArgMarkerStub:
 class TimelineMarkerParamTest(unittest.TestCase):
     def setUp(self):
         self.original_get_tl = compound._get_tl
+        self.original_is_destructive = compound._destructive_hook.is_destructive
         self.timeline = TimelineStub()
         compound._get_tl = lambda: (None, self.timeline, None)
+        compound._destructive_hook.is_destructive = lambda *args, **kwargs: False
 
     def tearDown(self):
         compound._get_tl = self.original_get_tl
+        compound._destructive_hook.is_destructive = self.original_is_destructive
 
     def test_add_accepts_frame_id_alias_and_defaults_name_duration(self):
         # Raw frame params are already relative to the timeline start and must

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -3235,6 +3235,7 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                 "session_only": True,
                 "cleanup_frames": False,
                 "max_analysis_frames": 1,
+                "transcription": {"enabled": False},
                 "vision": {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER},
             }
             caps = detect_capabilities(env={})
@@ -3289,6 +3290,7 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                 "session_only": True,
                 "cleanup_frames": True,
                 "max_analysis_frames": 3,
+                "transcription": {"enabled": False},
                 "vision": {"enabled": True, "provider": HOST_CHAT_PATHS_PROVIDER},
             }
             caps = detect_capabilities(env={})


### PR DESCRIPTION
## Summary

- avoid blocking execution when all planned clip work is already satisfied by reusable analysis reports
- reuse the same fresh-analysis clip set for capability gating and deep-analysis cost estimates
- make related tests less dependent on optional local environment state

## Why

The planner can record capability gaps for work that would be required during fresh analysis. If a later reuse decision means there is no fresh clip analysis left to run, those gaps should not stop execution of the reuse-only path.

This keeps capability checks strict for new analysis while allowing valid cached analysis results to be reused.

## Validation

- `python -m pytest tests/test_media_analysis.py tests/test_marker_params.py`
- `python tests/test_import.py`
- `git diff --check`
