### PR TITLE
api-truth: record AppendToTimeline clipInfo endFrame exclusive-bound semantics

### DIFF
--- a/src/utils/api_truth.py
+++ b/src/utils/api_truth.py
@@ -487,6 +487,30 @@ API_TRUTH: List[Dict[str, Any]] = [
         "issue": 77,
         "mitigation": ["_verify_clip_property_writeback", "_verify_writeback"],
     },
+    {
+        "symbol": "MediaPool.AppendToTimeline clipInfo endFrame (exclusive bound)",
+        "object": "MediaPool",
+        "signature": "([{mediaPoolItem, startFrame, endFrame, recordFrame, "
+                     "trackIndex, mediaType}]) -> [TimelineItem]",
+        "reality": "clipInfo endFrame is an EXCLUSIVE bound: the appended item's "
+                   "duration is endFrame - startFrame frames, not "
+                   "endFrame - startFrame + 1. Verified by readback probe on "
+                   "Resolve Studio 21.0 — appending {startFrame: 6254, "
+                   "endFrame: 6348} yields a 94-frame item, and 130 such "
+                   "appends whose absolute recordFrames advance by exactly "
+                   "(endFrame - startFrame) assemble a gap-free track whose "
+                   "total length equals the sum of (end - start). Code that "
+                   "assumes an inclusive bound drifts one frame per clip: "
+                   "advancing a record cursor by (end - start + 1) leaves a "
+                   "1-frame hole between consecutive clips, and converting a "
+                   "half-open range with (end - 1) shaves the range's last "
+                   "frame.",
+        "recommended": "Treat [startFrame, endFrame) as half-open everywhere: "
+                       "duration = endFrame - startFrame; next recordFrame = "
+                       "previous recordFrame + duration; no ±1 corrections "
+                       "when mirroring keep-ranges into clipInfos.",
+        "tags": ["timeline", "edit", "off-by-one", "readback"],
+    },
 ]
 
 

--- a/tests/test_api_truth.py
+++ b/tests/test_api_truth.py
@@ -43,6 +43,19 @@ class LookupTest(unittest.TestCase):
             self.assertIn("recommended", e)
             self.assertIsInstance(e.get("tags", []), list)
 
+    def test_append_endframe_exclusive_bound_recorded(self):
+        # AppendToTimeline clipInfo endFrame is a half-open bound (duration =
+        # endFrame - startFrame). The entry must be findable by an agent probing
+        # append placement semantics before batch-assembling clip_infos.
+        hits = lookup_api_truth("endFrame")
+        entry = next(
+            (e for e in hits if "AppendToTimeline clipInfo endFrame" in e["symbol"]),
+            None,
+        )
+        self.assertIsNotNone(entry)
+        self.assertIn("off-by-one", entry["tags"])
+        self.assertIn("exclusive", entry["reality"].lower())
+
 
 class ApiTruthActionTest(unittest.TestCase):
     def test_action_no_connection_needed(self):


### PR DESCRIPTION
## What

Adds one entry to the `api_truth` ledger: **`MediaPool.AppendToTimeline` clipInfo `endFrame` is an exclusive bound** — an appended item's duration is `endFrame - startFrame` frames, not `end - start + 1`. Internal quirk entry (no `submit` key), so `docs/reference/api-limitations.md` is unaffected.

## How it was verified

Live readback probe on Resolve Studio 21.0 (macOS, davinci-resolve-mcp v2.51+), while batch-assembling a second video layer mirrored from an `execute_tighten` plan's keep_ranges:

- Appending `{startFrame: 6254, endFrame: 6348, recordFrame: 0, mediaType: 1}` yields an item of **94 frames** (`GetDuration()` readback), matching `end - start` exactly.
- 130 consecutive appends whose absolute `recordFrame`s advance by exactly `(endFrame - startFrame)` assemble a **gap-free** track (every item's record end == next item's record start), and the track's total length equals `Σ(end - start)`.
- `_build_append_clip_info_dict` (server.py) passes `startFrame`/`endFrame` through verbatim, so the probe measures the raw API bound, not an MCP-side adjustment.

I queried `resolve_control.api_truth` for this before probing and got 0 facts — exactly the situation the ledger exists for, hence this PR.

## Why it matters

Two in-repo call sites currently assume the inclusive bound (filed separately as an issue with measurements): a record cursor advanced by `end - start + 1` leaves a 1-frame hole between consecutive clips, and a keep-range converted with `end - 1` shaves the last frame of every kept segment.

## Test

`tests/test_api_truth.py::test_append_endframe_exclusive_bound_recorded` — lookup regression in the style of the issue #74 entry test. `python -m unittest tests.test_api_truth tests.test_api_truth_mitigations`: 11 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
