### PR TITLE
edit_engine: dedupe identical plan_tighten skipped rows into one entry with a count

### DIFF
--- a/src/utils/edit_engine.py
+++ b/src/utils/edit_engine.py
@@ -339,6 +339,29 @@ def _gaps_in_range(
     return gaps
 
 
+def _dedupe_skipped(skipped: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse identical (item, reason) skip rows into one entry with a count.
+
+    A timeline layer cut into many segments from one unanalyzed source clip
+    otherwise reports the same skip once per segment (87 identical rows in a
+    real two-layer session), which bloats the plan payload without adding
+    signal. First occurrence order is preserved.
+    """
+    out: List[Dict[str, Any]] = []
+    index: Dict[Tuple[Any, Any], Dict[str, Any]] = {}
+    for row in skipped:
+        key = (row.get("item"), row.get("reason"))
+        hit = index.get(key)
+        if hit is None:
+            hit = dict(row)
+            hit["count"] = 1
+            index[key] = hit
+            out.append(hit)
+        else:
+            hit["count"] += 1
+    return out
+
+
 def plan_tighten(
     project_root: str,
     *,
@@ -440,6 +463,7 @@ def plan_tighten(
                 },
             })
 
+    skipped = _dedupe_skipped(skipped)
     if not lifts:
         return {
             "success": False,

--- a/tests/test_edit_engine.py
+++ b/tests/test_edit_engine.py
@@ -193,6 +193,27 @@ class PlanTightenTests(EditEngineBase):
         self.assertEqual(len(plan["skipped"]), 1)
         self.assertIn("no analysis", plan["skipped"][0]["reason"])
 
+    def test_skipped_rows_deduped_with_count(self) -> None:
+        # One unanalyzed source cut into many timeline segments must report a
+        # single skip row with a count, not one identical row per segment
+        # (a real two-layer session produced 87 duplicates).
+        plan = edit_engine.plan_tighten(
+            self.root,
+            items=[
+                self._item(),
+                self._item(media_ref="unknown-clip", item_name="Mystery.mp4"),
+                self._item(media_ref="unknown-clip", item_name="Mystery.mp4",
+                           timeline_start_frame=480, timeline_end_frame=960),
+                self._item(media_ref="unknown-clip", item_name="Mystery.mp4",
+                           timeline_start_frame=960, timeline_end_frame=1440),
+            ],
+            timeline_name="TL", timeline_fps=24.0,
+        )
+        self.assertTrue(plan["success"])
+        self.assertEqual(len(plan["skipped"]), 1)
+        self.assertEqual(plan["skipped"][0]["count"], 3)
+        self.assertIn("no analysis", plan["skipped"][0]["reason"])
+
     def test_lifts_ordered_latest_first(self) -> None:
         # Two items, each with a dead-air tail.
         items = [


### PR DESCRIPTION
## What

`plan_tighten` appends one `{item, reason}` row to `skipped` per timeline item. When a whole layer's source has no analysis, that repeats the identical row once per segment.

Real session that motivated this: a 25-minute dual-layer talking-head timeline, each layer cut into 87 segments, second layer (screen recording) intentionally unanalyzed → the plan payload and the MCP response each carried **87 identical** `{"item": "recording_….mp4", "reason": "no analysis for source media (db_ingest or analyze first)"}` rows. Zero added signal, meaningful added tokens for MCP clients.

## Change

`_dedupe_skipped()` collapses identical `(item, reason)` rows into a single entry with a `count` field, preserving first-occurrence order. Applied once at the end of the scan loop, so both the `No dead-air lifts found` early return and the saved/echoed plan use the deduped list.

Backward compatibility: the list shape and the `item`/`reason` keys are unchanged; existing consumers only see fewer duplicate rows plus a new `count` key (`count: 1` for singletons).

## Test

`tests/test_edit_engine.py::test_skipped_rows_deduped_with_count` — one unanalyzed source cut into 3 segments reports a single row with `count: 3`. Full module: `python -m unittest tests.test_edit_engine` → 31 tests, all pass (existing `test_unanalyzed_media_skipped_with_reason` unchanged and green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
