### PR TITLE
Timeline tooling fixes, transport-wedge fix, and background jobs for long ops

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -18670,6 +18670,28 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
     ])
 
 
+_TIMELINE_ACTIONS = [
+    "list", "get_current", "set_current", "get_name", "set_name", "get_start_frame",
+    "get_end_frame", "get_start_timecode", "set_start_timecode", "get_track_count",
+    "add_track", "delete_track", "get_track_sub_type", "set_track_enable",
+    "get_track_enabled", "set_track_lock", "get_track_locked", "get_track_name",
+    "set_track_name", "get_items", "delete_clips", "set_clips_linked", "duplicate",
+    "duplicate_clips", "copy_clips", "move_clips", "copy_range", "duplicate_range",
+    "overwrite_range", "lift_range", "story_spine_report", "create_variant_from_ranges",
+    "bulk_set_item_properties", "apply_look_to_items", "thumbnail_contact_sheet",
+    "marker_thumbnail_review", "edit_kernel_capabilities", "probe_edit_kernel_item",
+    "title_property_scan", "set_title_text", "bulk_set_title_text", "create_compound_clip",
+    "create_fusion_clip", "import_into_timeline", "export", "get_setting", "set_setting",
+    "insert_generator", "insert_fusion_generator", "insert_fusion_composition",
+    "insert_ofx_generator", "insert_title", "insert_fusion_title", "get_unique_id",
+    "get_node_graph", "get_media_pool_item", "get_transcript", "propose_cuts", "apply_cuts",
+    "get_mark_in_out", "set_mark_in_out", "clear_mark_in_out", "convert_to_stereo",
+    "get_items_in_track", "get_voice_isolation_state", "set_voice_isolation_state",
+    "extract_source_frame_ranges", "audio_mix_capability_report", "clip_where", "action_help",
+    *_TIMELINE_CONFORM_KERNEL_ACTIONS, *_TIMELINE_AUDIO_KERNEL_ACTIONS,
+]
+
+
 @mcp.tool()
 @_destructive_op("timeline")
 def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -19427,7 +19449,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         if mp_err:
             return mp_err
         return _fairlight_boundary_report(proj, mp, tl, p)
-    return _unknown(action, ["list","get_current","set_current","get_name","set_name","get_start_frame","get_end_frame","get_start_timecode","set_start_timecode","get_track_count","add_track","delete_track","get_track_sub_type","set_track_enable","get_track_enabled","set_track_lock","get_track_locked","get_track_name","set_track_name","get_items","delete_clips","set_clips_linked","duplicate","duplicate_clips","copy_clips","move_clips","copy_range","duplicate_range","overwrite_range","lift_range","story_spine_report","create_variant_from_ranges","bulk_set_item_properties","apply_look_to_items","thumbnail_contact_sheet","marker_thumbnail_review","edit_kernel_capabilities","probe_edit_kernel_item","title_property_scan","set_title_text","bulk_set_title_text","create_compound_clip","create_fusion_clip","import_into_timeline","export","get_setting","set_setting","insert_generator","insert_fusion_generator","insert_fusion_composition","insert_ofx_generator","insert_title","insert_fusion_title","get_unique_id","get_node_graph","get_media_pool_item","get_transcript","propose_cuts","apply_cuts","get_mark_in_out","set_mark_in_out","clear_mark_in_out","convert_to_stereo","get_items_in_track","get_voice_isolation_state","set_voice_isolation_state","extract_source_frame_ranges","audio_mix_capability_report","clip_where","action_help",*_TIMELINE_CONFORM_KERNEL_ACTIONS,*_TIMELINE_AUDIO_KERNEL_ACTIONS])
+    return _unknown(action, _TIMELINE_ACTIONS)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -21021,22 +21043,46 @@ def _propose_grade(proj, p: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+# Full valid-action list per tool, for tools that expose one. Lets action_help
+# report every action (not only the documented subset) and tell an unknown
+# action apart from a valid-but-undocumented one.
+_TOOL_ACTIONS: Dict[str, List[str]] = {
+    "timeline": _TIMELINE_ACTIONS,
+}
+
+
 def _action_help(tool_name: str, p: Dict[str, Any]) -> Dict[str, Any]:
     """Return long-form guidance + example for a named action on tool_name."""
     name = (p or {}).get("name") or (p or {}).get("action_name")
     catalog = _ACTION_HELP.get(tool_name, {})
+    valid = _TOOL_ACTIONS.get(tool_name)
     if not name:
-        return _ok(tool=tool_name, available=sorted(catalog.keys()),
-                   note="Call action_help with params.name to retrieve guidance for a specific action.")
+        payload = {
+            "tool": tool_name,
+            "available": sorted(catalog.keys()),
+            "note": "Call action_help with params.name to retrieve guidance for a specific action.",
+        }
+        if valid is not None:
+            payload["actions"] = sorted(valid)
+            payload["note"] = ("'available' lists actions with detailed help; 'actions' lists all "
+                               "valid actions. Call action_help with params.name for one action.")
+        return _ok(**payload)
     entry = catalog.get(name)
-    if not entry:
+    if entry:
+        return _ok(tool=tool_name, action=name, **entry)
+    if valid is not None and name not in valid:
         return _err(
-            f"No help registered for {tool_name}.{name}.",
-            code="HELP_NOT_REGISTERED",
+            f"Unknown action {tool_name}.{name}.",
+            code="UNKNOWN_ACTION",
             category="invalid_input",
-            remediation=f"Call action_help() with no name for the list of actions with detailed help.",
+            remediation=f"Valid actions: {', '.join(sorted(valid))}",
         )
-    return _ok(tool=tool_name, action=name, **entry)
+    return _err(
+        f"No help registered for {tool_name}.{name}.",
+        code="HELP_NOT_REGISTERED",
+        category="invalid_input",
+        remediation="Call action_help() with no name for the list of actions with detailed help.",
+    )
 
 
 def _grade_evidence_line(*, item_name, version_label, num_nodes, has_lut, group_name,

--- a/src/server.py
+++ b/src/server.py
@@ -3472,6 +3472,27 @@ def _timeline_media_type(track_type: str):
     return None
 
 
+def _track_selector(p: Dict[str, Any]):
+    """(track_type, track_index, err) from a params dict.
+
+    Accepts the 1-based track index as either ``index`` or ``track_index``. err
+    is a validation message (None on success) so a missing or malformed selector
+    returns a structured error.
+    """
+    normalized = dict(p)
+    if normalized.get("index") is None and normalized.get("track_index") is not None:
+        normalized["index"] = normalized["track_index"]
+    err, clean = _validate_params(normalized, {
+        "track_type": {"type": str, "required": True, "enum": ["video", "audio", "subtitle"]},
+        "index": {"type": int, "required": True, "min": 1},
+    })
+    if err:
+        if err.startswith("'index' is required"):
+            err = "requires a 1-based track index ('index' or 'track_index')"
+        return None, None, err
+    return clean["track_type"], clean["index"], None
+
+
 def _timeline_track_count(tl, track_type: str):
     try:
         return int(tl.GetTrackCount(track_type) or 0)
@@ -18674,7 +18695,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       get_track_locked(track_type, index) -> {locked}
       get_track_name(track_type, index) -> {name}
       set_track_name(track_type, index, name) -> {success}
-      get_items(track_type, index) -> {items}
+      get_items(track_type, index|track_index) -> {items}  — track_type: video|audio|subtitle
       clip_where(filters|track_type?, track_index?, name_contains?, duration_lt?, duration_gt?) -> {clips, match_count, total_clips}
         Find clips on the current timeline matching named filters (AND). Pass filters
         inline or as a `filters` dict. Live filters: track_type, track_index,
@@ -18750,7 +18771,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       set_mark_in_out(mark_in, mark_out, type?) -> {success}
       clear_mark_in_out(type?) -> {success}
       convert_to_stereo() -> {success}
-      get_items_in_track(track_type, track_index) -> {items}
+      get_items_in_track(track_type, track_index|index) -> {items}  — full serialization of each item
       get_voice_isolation_state(track_index) -> {isEnabled, amount}
       set_voice_isolation_state(track_index, state) -> {success}
       extract_source_frame_ranges(handles?, gap_max?, skip_extensions?) -> {timeline_name, frame_ranges, occurrences, ...}
@@ -18956,7 +18977,10 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     elif action == "set_track_name":
         return {"success": bool(tl.SetTrackName(p["track_type"], p["index"], p["name"]))}
     elif action == "get_items":
-        items = tl.GetItemListInTrack(p["track_type"], p["index"])
+        track_type, track_index, err = _track_selector(p)
+        if err:
+            return _err(err)
+        items = tl.GetItemListInTrack(track_type, track_index)
         return {"items": [{"name": it.GetName(), "id": it.GetUniqueId(), "start": it.GetStart(), "end": it.GetEnd(), "duration": it.GetDuration()} for it in (items or [])]}
     elif action == "delete_clips":
         # Find timeline items by unique IDs
@@ -19184,7 +19208,10 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     elif action == "convert_to_stereo":
         return {"success": bool(tl.ConvertTimelineToStereo())}
     elif action == "get_items_in_track":
-        return {"items": _ser(tl.GetItemListInTrack(p["track_type"], p["track_index"]))}
+        track_type, track_index, err = _track_selector(p)
+        if err:
+            return _err(err)
+        return {"items": _ser(tl.GetItemListInTrack(track_type, track_index))}
     elif action == "get_voice_isolation_state":
         missing = _requires_method(tl, "GetVoiceIsolationState", "20.1")
         if missing:
@@ -20513,6 +20540,18 @@ _ACTION_HELP: Dict[str, Dict[str, Dict[str, Any]]] = {
         },
     },
     "timeline": {
+        "get_items": {
+            "summary": "List items on one track as a summary (name/id/start/end/duration).",
+            "params": "track_type (video|audio|subtitle), index|track_index (1-based)",
+            "returns": "{items: [{name, id, start, end, duration}]}",
+            "example": 'timeline(action="get_items", params={"track_type": "video", "index": 1})',
+        },
+        "get_items_in_track": {
+            "summary": "List items on one track with full per-item serialization.",
+            "params": "track_type (video|audio|subtitle), track_index|index (1-based)",
+            "returns": "{items}",
+            "example": 'timeline(action="get_items_in_track", params={"track_type": "audio", "track_index": 1})',
+        },
         "duplicate_clips": {
             "summary": "Re-place the same MediaPool media with the same source trim. Video clips only.",
             "params": "clip_ids?|selected?, target_track_index?|track_offset?, placement? (same_time|offset|at_playhead|track_above|after_source|next_gap), record_frame?, record_frame_offset?, copy_properties?, include_linked?",

--- a/src/server.py
+++ b/src/server.py
@@ -4837,6 +4837,31 @@ def _timeline_apply_look_to_items(tl, p: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
+def _variant_item_placement(item) -> Dict[str, Any]:
+    """Report an appended item's placed frame positions in both frame spaces.
+    record_* are TIMELINE frames (GetStart/GetEnd/GetDuration); source_start is
+    a SOURCE frame."""
+    def _read(method):
+        fn = getattr(item, method, None)
+        if not callable(fn):
+            return None
+        try:
+            return _frame_int(fn())
+        except Exception:
+            return None
+    record_start = _read("GetStart")
+    record_end = _read("GetEnd")
+    duration = _read("GetDuration")
+    if duration is None and record_start is not None and record_end is not None:
+        duration = record_end - record_start
+    return {
+        "record_start": record_start,
+        "record_end": record_end,
+        "duration": duration,
+        "source_start": _timeline_item_source_start(item),
+    }
+
+
 def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> Dict[str, Any]:
     ranges = p.get("ranges") or p.get("clip_infos")
     if not isinstance(ranges, list) or not ranges:
@@ -4890,6 +4915,14 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
             "_source_row": row,
             "_index": index,
         })
+    # Resolve every clip (media-pool id + frame range) before choosing dry-run
+    # vs commit, so a dry run fails on the same id/frame errors as the commit.
+    append_infos = []
+    for row in built:
+        clip_info, clip_err = _build_append_clip_info_dict(root, row, row["_index"])
+        if clip_err:
+            return clip_err
+        append_infos.append(clip_info)
     if p.get("dry_run", False):
         return {
             "success": True,
@@ -4915,21 +4948,23 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
         while int(new_tl.GetTrackCount(track_type) or 0) < needed:
             if not new_tl.AddTrack(track_type):
                 break
-    append_infos = []
-    for row in built:
-        clip_info, clip_err = _build_append_clip_info_dict(root, row, row["_index"])
-        if clip_err:
-            return clip_err
-        append_infos.append(clip_info)
     appended = mp.AppendToTimeline(append_infos)
     if not appended:
         return _err("AppendToTimeline returned no items for variant")
     items_out = []
+    placement_mismatches = 0
     for index, item in enumerate(appended):
         item_out, item_err = _serialize_appended_timeline_item(item, index, allow_empty_timeline_item_id=True)
         if item_err:
             return item_err
-        item_out["range"] = {key: value for key, value in built[index].items() if not key.startswith("_")}
+        requested = {key: value for key, value in built[index].items() if not key.startswith("_")}
+        item_out["range"] = requested  # the requested range (still carries media_type/track_index)
+        placed = _variant_item_placement(item)  # the frame positions Resolve placed it at
+        item_out["placed"] = placed
+        requested_duration = requested["end_frame"] - requested["start_frame"]
+        if placed["duration"] is not None and placed["duration"] != requested_duration:
+            item_out["duration_delta"] = placed["duration"] - requested_duration
+            placement_mismatches += 1
         transform = built[index]["_source_row"].get("transform")
         if isinstance(transform, dict):
             item_out["transform"] = {}
@@ -4958,6 +4993,7 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
         "name": new_tl.GetName(),
         "id": new_tl.GetUniqueId(),
         "items": items_out,
+        "placement_mismatches": placement_mismatches,
         "markers": marker_results,
         "look": look_result,
         "gaps_overlaps": _detect_gaps_overlaps_from_snapshot(_timeline_conform_snapshot(new_tl, {}), {}),
@@ -18600,6 +18636,11 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     DESTRUCTIVE actions auto-archive the current timeline (C6); pass strict=true for
     refuse-on-archive-failure behavior on the catastrophic ops.
 
+    Frame numbers are TIMELINE/record frames (position on the timeline) unless an action
+    says SOURCE. Source frames are positions within a media-pool clip's own media:
+    create_variant_from_ranges takes SOURCE start_frame/end_frame; extract_source_frame_ranges
+    and source_range_report return SOURCE ranges.
+
     Actions:
       list() -> {timelines}
       get_current() -> {name, id, start_frame, end_frame, start_timecode}
@@ -18648,7 +18689,10 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       copy_range/duplicate_range(start_frame, end_frame, record_frame, ...) -> {results, count}
       overwrite_range(start_frame, end_frame, record_frame, ...) -> {results, count}
       lift_range(start_frame, end_frame, allow_partial_item_delete?, ripple?) -> {success, deleted}
-        DESTRUCTIVE. Removes items in a record-frame range. ripple=True closes the gap.
+        DESTRUCTIVE. Deletes timeline items whose record-frame range overlaps [start,end].
+        ripple=True closes the gap left by those deleted items (shifts later clips left). It
+        does NOT close a pre-existing empty gap: if no item overlaps the range, deleted=0 and
+        nothing moves. (frames here are TIMELINE/record frames.)
       story_spine_report() -> {beats, track_summaries, source_ranges, audio_spine}
       create_variant_from_ranges(name, ranges, markers?, cdl?, dry_run?) -> {success, id, items}
         # example: action_help(name='<action_name>')
@@ -20465,17 +20509,20 @@ _ACTION_HELP: Dict[str, Dict[str, Dict[str, Any]]] = {
             ),
         },
         "create_variant_from_ranges": {
-            "summary": "Build a variant timeline from N source ranges. Source-safe; supports dry_run.",
-            "params": "name, ranges: [{source_clip_id|clip_id, start_frame, end_frame, record_frame?, track_type?}], markers?, cdl?, dry_run?",
-            "returns": "{success, id, items}",
+            "summary": "Build a variant timeline from N source ranges. Source-safe; dry_run validates clip ids and frame ranges.",
+            "params": (
+                "name, ranges: [{clip_id|media_pool_item_id, start_frame, end_frame, "
+                "record_frame?, track_type?}], markers?, cdl?, dry_run?  — clip_id is a "
+                "media-pool item id (not a timeline-item id); start_frame/end_frame are SOURCE frames"
+            ),
+            "returns": "{success, id, items}  — items[].placed = placed frames; items[].range = the requested range",
             "example": (
                 'timeline(action="create_variant_from_ranges", params={\n'
                 '  "name": "v02_tighter_act1",\n'
                 '  "ranges": [\n'
-                '    {"source_clip_id": "TimelineItem-abc", "start_frame": 108000, "end_frame": 108120},\n'
-                '    {"source_clip_id": "TimelineItem-def", "start_frame": 108300, "end_frame": 108400}\n'
+                '    {"clip_id": "<media-pool-item-id>", "start_frame": 1200, "end_frame": 1320},\n'
+                '    {"clip_id": "<media-pool-item-id>", "start_frame": 1500, "end_frame": 1600}\n'
                 '  ],\n'
-                '  "markers": [{"frame": 0, "color": "Blue", "name": "Act1 turn"}],\n'
                 '  "dry_run": True\n'
                 '})'
             ),

--- a/src/server.py
+++ b/src/server.py
@@ -5822,6 +5822,15 @@ def _find_timeline_by_name(proj, name: Any):
     return None, None
 
 
+def _find_timeline_by_id(proj, timeline_id: Any):
+    want = str(timeline_id or "")
+    for index in range(1, int(proj.GetTimelineCount() or 0) + 1):
+        tl = proj.GetTimelineByIndex(index)
+        if tl and str(tl.GetUniqueId()) == want:
+            return tl, index
+    return None, None
+
+
 def _unique_timeline_name(proj, requested_name: Any) -> str:
     base = str(requested_name or "Untitled Timeline").strip() or "Untitled Timeline"
     existing_names = set()
@@ -18644,7 +18653,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     Actions:
       list() -> {timelines}
       get_current() -> {name, id, start_frame, end_frame, start_timecode}
-      set_current(index) -> {success}  — 1-based index
+      set_current(index|id|name) -> {success}  — id/name are stable across archives; index is 1-based
       get_name() -> {name}
       set_name(name) -> {success}
       get_start_frame() -> {frame}
@@ -18823,6 +18832,16 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
                 timelines.append({"name": tl.GetName(), "id": tl.GetUniqueId(), "index": i})
         return {"timelines": timelines}
     elif action == "set_current":
+        # id/name take precedence over index.
+        selector_id = p.get("id") or p.get("timeline_id")
+        selector_name = p.get("name")
+        if selector_id or selector_name:
+            tl = _find_timeline_by_id(proj, selector_id)[0] if selector_id else None
+            if tl is None and selector_name:
+                tl = _find_timeline_by_name(proj, selector_name)[0]
+            if tl is None:
+                return _err(f"No timeline matching {selector_id or selector_name!r}")
+            return {"success": bool(proj.SetCurrentTimeline(tl))}
         err, clean = _validate_params(p, {"index": {"type": int, "required": True, "min": 1}})
         if err:
             return _err(err)

--- a/src/server.py
+++ b/src/server.py
@@ -85,7 +85,7 @@ from src.utils.media_analysis import (
     summarize_reports as summarize_media_analysis_reports,
 )
 from src.utils.sync_detection import detect_sync_events_for_records as detect_media_sync_events
-from src.utils import actor_identity, resolve_busy
+from src.utils import actor_identity, background_jobs, resolve_busy
 from src.utils.resolve_busy import long_resolve_op
 from src.utils.media_analysis_jobs import (
     MEDIA_EXTENSIONS,
@@ -1219,6 +1219,26 @@ def _err(message, *, code=None, category=None, retryable=_RETRYABLE_UNSET,
 
 def _ok(**kw):
     return {"success": True, **kw}
+
+
+def _run_maybe_background(label: str, params: Dict[str, Any], fn):
+    """Run a long Resolve operation synchronously, or off-thread when requested.
+
+    When params carries a truthy `background` (alias `async_job`), start a polled
+    job and return its id at once; otherwise run fn inside long_resolve_op and
+    return its result, preserving the synchronous contract.
+    """
+    if params.get("background") or params.get("async_job"):
+        job_id = background_jobs.start_job(label, fn)
+        return {
+            "success": True,
+            "job_id": job_id,
+            "status": "running",
+            "label": label,
+            "note": "poll with resolve_control(action='job_status', params={'job_id': ...})",
+        }
+    with long_resolve_op(label):
+        return fn()
 
 
 def _record_action_outcome(scope_key: Optional[str], action_name: str,
@@ -5416,38 +5436,41 @@ def _export_timeline_checked(tl, p: Dict[str, Any]):
     spec = _timeline_export_spec(p, get_resolve())
     if p.get("dry_run"):
         return _ok(path=path, would_export=True, spec={k: v for k, v in spec.items() if k != "export_type"})
-    with long_resolve_op("timeline.export_timeline_checked"):
+
+    def _work():
         success = bool(tl.Export(path, spec["export_type"], spec["export_subtype"]))
-    files = []
-    primary_file = path
-    if success and os.path.isdir(path):
-        for dirpath, _, filenames in os.walk(path):
-            for filename in filenames:
-                file_path = os.path.join(dirpath, filename)
-                files.append({"path": file_path, "size": os.path.getsize(file_path)})
-        preferred_exts = (".fcpxml", ".xml", ".edl", ".drt", ".aaf", ".otio")
-        for ext in preferred_exts:
-            match = next((row["path"] for row in files if row["path"].lower().endswith(ext)), None)
-            if match:
-                primary_file = match
-                break
-    size = 0
-    if success and os.path.exists(path):
-        if os.path.isdir(path):
-            size = sum(row["size"] for row in files)
-        else:
-            size = os.path.getsize(path)
-    return {
-        "success": success,
-        "path": path,
-        "primary_file": primary_file,
-        "is_directory": bool(success and os.path.isdir(path)),
-        "files": files,
-        "size": size,
-        "format": spec["requested"],
-        "export_type": spec["export_type_name"],
-        "export_subtype": spec["export_subtype_name"],
-    }
+        files = []
+        primary_file = path
+        if success and os.path.isdir(path):
+            for dirpath, _, filenames in os.walk(path):
+                for filename in filenames:
+                    file_path = os.path.join(dirpath, filename)
+                    files.append({"path": file_path, "size": os.path.getsize(file_path)})
+            preferred_exts = (".fcpxml", ".xml", ".edl", ".drt", ".aaf", ".otio")
+            for ext in preferred_exts:
+                match = next((row["path"] for row in files if row["path"].lower().endswith(ext)), None)
+                if match:
+                    primary_file = match
+                    break
+        size = 0
+        if success and os.path.exists(path):
+            if os.path.isdir(path):
+                size = sum(row["size"] for row in files)
+            else:
+                size = os.path.getsize(path)
+        return {
+            "success": success,
+            "path": path,
+            "primary_file": primary_file,
+            "is_directory": bool(success and os.path.isdir(path)),
+            "files": files,
+            "size": size,
+            "format": spec["requested"],
+            "export_type": spec["export_type_name"],
+            "export_subtype": spec["export_subtype_name"],
+        }
+
+    return _run_maybe_background("timeline.export_timeline_checked", p, _work)
 
 
 def _timeline_media_coverage(tl) -> Dict[str, Any]:
@@ -5636,74 +5659,76 @@ def _import_timeline_checked(proj, mp, p: Dict[str, Any]):
             out["note"] = binary_relink_note
         return out
 
-    before_ids = set()
-    for index in range(1, int(proj.GetTimelineCount() or 0) + 1):
-        tl_existing = proj.GetTimelineByIndex(index)
-        if tl_existing:
-            before_ids.add(str(tl_existing.GetUniqueId()))
-    with long_resolve_op("timeline.import_timeline_checked"):
+    def _work():
+        before_ids = set()
+        for index in range(1, int(proj.GetTimelineCount() or 0) + 1):
+            tl_existing = proj.GetTimelineByIndex(index)
+            if tl_existing:
+                before_ids.add(str(tl_existing.GetUniqueId()))
         imported = mp.ImportTimelineFromFile(import_path, options)
 
-    # Resolve's API returns None even when it created an (offline) timeline. Detect
-    # the newly-created timeline via the before/after id diff so we never report a
-    # false "Failed to import" for what is really a partial success.
-    api_returned_object = bool(imported)
-    if not imported:
-        for index in range(1, int(proj.GetTimelineCount() or 0) + 1):
-            t = proj.GetTimelineByIndex(index)
-            if t and str(t.GetUniqueId()) not in before_ids:
-                imported = t
-    if not imported:
-        if is_binary:
-            remediation = (
-                f"Resolve created no timeline from this {ext}. Verify it exports/opens in "
-                "Resolve directly, or convert to FCP7 XML / FCPXML upstream and import that."
+        # Resolve's API returns None even when it created an (offline) timeline. Detect
+        # the newly-created timeline via the before/after id diff so we never report a
+        # false "Failed to import" for what is really a partial success.
+        api_returned_object = bool(imported)
+        if not imported:
+            for index in range(1, int(proj.GetTimelineCount() or 0) + 1):
+                t = proj.GetTimelineByIndex(index)
+                if t and str(t.GetUniqueId()) not in before_ids:
+                    imported = t
+        if not imported:
+            if is_binary:
+                remediation = (
+                    f"Resolve created no timeline from this {ext}. Verify it exports/opens in "
+                    "Resolve directly, or convert to FCP7 XML / FCPXML upstream and import that."
+                )
+            elif sanitize:
+                remediation = None
+            else:
+                remediation = (
+                    "This XML may reference missing media or contain generator clips, which "
+                    "abort the scripting-API import. Retry with sanitize_media=True."
+                )
+            return _err(
+                "Failed to import timeline (Resolve created no timeline)",
+                remediation=remediation,
             )
-        elif sanitize:
-            remediation = None
-        else:
-            remediation = (
-                "This XML may reference missing media or contain generator clips, which "
-                "abort the scripting-API import. Retry with sanitize_media=True."
-            )
-        return _err(
-            "Failed to import timeline (Resolve created no timeline)",
-            remediation=remediation,
-        )
 
-    imported_id = str(imported.GetUniqueId())
-    media = _timeline_media_coverage(imported)
-    # AAF fuzzy-relink parity: when search roots are given for a binary import, relink through
-    # the media pool after import (the XML path-rewrite relink can't run on a binary file).
-    relink_result = None
-    if is_binary and search_roots:
-        relink_result = _binary_post_import_relink(imported, mp, search_roots)
-        if relink_result.get("after"):
-            media = relink_result["after"]
-    out = _ok(
-        name=imported.GetName(),
-        id=imported_id,
-        created_new=imported_id not in before_ids,
-        timeline_count=proj.GetTimelineCount(),
-        api_returned_object=api_returned_object,
-        media=media,
-    )
-    if sanitize_report is not None:
-        out["sanitize"] = sanitize_report
-    if relink_result is not None:
-        out["relink"] = relink_result
-    if binary_relink_note:
-        out["note"] = binary_relink_note
-    if media["total"] and media["offline"]:
-        msg = f"{media['offline']} of {media['total']} timeline items are offline (no linked media)."
-        if is_binary:
-            msg += (" Relink via the media pool (right-click → Relink Clips) or point Resolve "
-                    "at the media roots — AAF media links there, not by rewriting the file.")
-        elif not sanitize:
-            msg += (" Retry with sanitize_media=True to drop missing-media/generator "
-                    "clips so the remaining media links automatically.")
-        out["warning"] = msg
-    return out
+        imported_id = str(imported.GetUniqueId())
+        media = _timeline_media_coverage(imported)
+        # AAF fuzzy-relink parity: when search roots are given for a binary import, relink through
+        # the media pool after import (the XML path-rewrite relink can't run on a binary file).
+        relink_result = None
+        if is_binary and search_roots:
+            relink_result = _binary_post_import_relink(imported, mp, search_roots)
+            if relink_result.get("after"):
+                media = relink_result["after"]
+        out = _ok(
+            name=imported.GetName(),
+            id=imported_id,
+            created_new=imported_id not in before_ids,
+            timeline_count=proj.GetTimelineCount(),
+            api_returned_object=api_returned_object,
+            media=media,
+        )
+        if sanitize_report is not None:
+            out["sanitize"] = sanitize_report
+        if relink_result is not None:
+            out["relink"] = relink_result
+        if binary_relink_note:
+            out["note"] = binary_relink_note
+        if media["total"] and media["offline"]:
+            msg = f"{media['offline']} of {media['total']} timeline items are offline (no linked media)."
+            if is_binary:
+                msg += (" Relink via the media pool (right-click → Relink Clips) or point Resolve "
+                        "at the media roots — AAF media links there, not by rewriting the file.")
+            elif not sanitize:
+                msg += (" Retry with sanitize_media=True to drop missing-media/generator "
+                        "clips so the remaining media links automatically.")
+            out["warning"] = msg
+        return out
+
+    return _run_maybe_background("timeline.import_timeline_checked", p, _work)
 
 
 # A .drp/.drt is a zip of SeqContainer*.xml entries. Two on-disk naming conventions,
@@ -5806,11 +5831,13 @@ def _import_from_drp(proj, mp, p: Dict[str, Any]):
     else:
         selected = list(containers)
 
-    # Per-timeline options passthrough (importSourceClips etc.) minus selection keys.
+    # Per-timeline options passthrough (importSourceClips etc.) minus selection
+    # keys; background is a top-level option, so each sub-step import runs
+    # synchronously and the loop can verify it.
     base = {
         k: v
         for k, v in p.items()
-        if k not in ("drpPath", "drp_path", "path", "timelineNames", "timeline_names", "timelineIndexes", "timeline_indexes", "dry_run")
+        if k not in ("drpPath", "drp_path", "path", "timelineNames", "timeline_names", "timelineIndexes", "timeline_indexes", "dry_run", "background", "async_job")
     }
 
     tmp_dir = tempfile.mkdtemp(prefix="drp_import_")
@@ -6025,7 +6052,8 @@ def _probe_interchange_roundtrip(proj, mp, tl, p: Dict[str, Any]):
     spec = _timeline_export_spec(p, resolve)
     base_name = p.get("name") or f"roundtrip_{str(spec['requested']).lower()}"
     path = p.get("path") or os.path.join(output_dir, base_name + spec["extension"])
-    export_result = _export_timeline_checked(tl, {**p, "path": path, "require_temp_path": p.get("require_temp_path", True)})
+    # background is a top-level option; a sub-step export must run synchronously.
+    export_result = _export_timeline_checked(tl, {**p, "path": path, "require_temp_path": p.get("require_temp_path", True), "background": False, "async_job": False})
     if export_result.get("error") or not export_result.get("success"):
         return {"success": False, "stage": "export", "export": export_result}
     import_path = export_result.get("primary_file") or export_result.get("path") or path
@@ -7019,8 +7047,9 @@ def _subtitle_generation_probe(tl, p: Dict[str, Any]):
                    note="Pass allow_generate=True to call CreateSubtitlesFromAudio.")
     if not _has_method(tl, "CreateSubtitlesFromAudio"):
         return _err("CreateSubtitlesFromAudio unavailable")
-    with long_resolve_op("timeline.create_subtitles_from_audio"):
-        return _safe_create_subtitles(tl, p)
+    return _run_maybe_background(
+        "timeline.create_subtitles_from_audio", p, lambda: _safe_create_subtitles(tl, p)
+    )
 
 
 def _fairlight_boundary_report(proj, mp, tl, p: Dict[str, Any]):
@@ -12779,6 +12808,11 @@ def resolve_control(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
         facts about quirky/unreliable Resolve API behavior (no connection needed).
       verification_stats() -> {stats}  — readback-verification tally
         (verified/contradicted/unverified) since server start (no connection needed).
+      job_status(job_id) -> {id, label, status, result?, error?, started_at, ended_at}
+        — poll a background job started by a long op run with background=True
+          (no connection needed). status is running, done, or error.
+      list_jobs() -> {jobs}  — compact status of every known background job
+        (no connection needed).
       get_page() -> {page}
       open_page(page) -> {success}  — page: edit, cut, color, fusion, fairlight, deliver
       get_keyframe_mode() -> {mode}
@@ -12808,6 +12842,18 @@ def resolve_control(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
         stats = _verification_stats()
         return {"stats": stats, "note": "Counts since server start. A rising "
                 "'contradicted' count means the API reported success but a readback disagreed."}
+
+    # Background-job polling is a registry read — no Resolve connection needed.
+    if action == "job_status":
+        job_id = p.get("job_id")
+        if not job_id:
+            return _err("job_status requires job_id", category="invalid_input")
+        status = background_jobs.job_status(job_id)
+        if status is None:
+            return _err(f"Unknown job_id: {job_id}", category="invalid_input")
+        return status
+    if action == "list_jobs":
+        return {"jobs": background_jobs.list_jobs()}
 
     # Control-panel actions don't require Resolve to be running.
     if action == "open_control_panel":
@@ -12901,7 +12947,7 @@ def resolve_control(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
             return missing
         r.DisableBackgroundTasksForCurrentResolveSession()
         return _ok()
-    return _unknown(action, ["launch","get_version","api_truth","verification_stats","mcp_update_status","set_mcp_update_policy","ignore_mcp_update","snooze_mcp_update","clear_mcp_update_preferences","get_page","open_page","get_keyframe_mode","set_keyframe_mode","quit","get_fairlight_presets","set_high_priority","disable_background_tasks_for_current_session","open_control_panel","control_panel_status","close_control_panel","save_state","restore_state"])
+    return _unknown(action, ["launch","get_version","api_truth","verification_stats","job_status","list_jobs","mcp_update_status","set_mcp_update_policy","ignore_mcp_update","snooze_mcp_update","clear_mcp_update_preferences","get_page","open_page","get_keyframe_mode","set_keyframe_mode","quit","get_fairlight_presets","set_high_priority","disable_background_tasks_for_current_session","open_control_panel","control_panel_status","close_control_panel","save_state","restore_state"])
 
 
 # ─── V2 C4: Per-field corrections with provenance + changelog ────────────────
@@ -15763,7 +15809,7 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
       setup_multicam_timeline(name, clip_ids|angles, sync_mode?, include_audio?, dry_run?) -> {success}
         — creates a stacked multicam prep timeline: one angle per video track, optional
           matching audio tracks. Native multicam clip conversion remains a Resolve UI step.
-      import_timeline(path, options?) -> {success, name}
+      import_timeline(path, options?, background?) -> {success, name | job_id}
         UNSAFE. No path sandboxing. Prefer timeline.import_timeline_checked.
       delete_timelines(timeline_ids) -> {success}
         CATASTROPHIC. Deletes timelines outright.
@@ -15948,14 +15994,17 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
         # Whitelist options to the documented keys; Resolve silently ignores
         # unknown keys, so a typo would be dropped with no signal (P1 #4).
         options, ignored_opts = _filter_to_keys(p.get("options", {}), _IMPORT_TIMELINE_OPTION_KEYS)
-        with long_resolve_op("media_pool.import_timeline"):
+
+        def _work():
             tl = mp.ImportTimelineFromFile(p["path"], options)
-        if not tl:
-            return _err("Failed to import timeline")
-        result = _ok(name=tl.GetName())
-        if ignored_opts:
-            result["ignored_options"] = ignored_opts
-        return result
+            if not tl:
+                return _err("Failed to import timeline")
+            result = _ok(name=tl.GetName())
+            if ignored_opts:
+                result["ignored_options"] = ignored_opts
+            return result
+
+        return _run_maybe_background("media_pool.import_timeline", p, _work)
     elif action == "delete_timelines":
         count = proj.GetTimelineCount()
         timelines = []
@@ -16206,7 +16255,7 @@ def folder(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, An
       is_stale(path?) -> {stale}
       get_unique_id(path?) -> {id}
       export(path?, export_path) -> {success}
-      transcribe_audio(path?, use_speaker_detection?) -> {success}  — use_speaker_detection is Resolve 21+
+      transcribe_audio(path?, use_speaker_detection?, background?) -> {success | job_id}  — use_speaker_detection is Resolve 21+; background=true returns a job_id (poll resolve_control job_status)
       clear_transcription(path?) -> {success}
       perform_audio_classification(path?) -> {success}  — Resolve 21+
       clear_audio_classification(path?) -> {success}  — Resolve 21+
@@ -16241,10 +16290,12 @@ def folder(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, An
     elif action == "transcribe_audio":
         usd = _first_param(p, "use_speaker_detection", "useSpeakerDetection")
         if usd is None:
-            with long_resolve_op("folder.transcribe_audio"):
-                return {"success": bool(f.TranscribeAudio())}
-        with long_resolve_op("folder.transcribe_audio"):
-            return {"success": bool(f.TranscribeAudio(bool(usd)))}
+            return _run_maybe_background(
+                "folder.transcribe_audio", p, lambda: {"success": bool(f.TranscribeAudio())}
+            )
+        return _run_maybe_background(
+            "folder.transcribe_audio", p, lambda: {"success": bool(f.TranscribeAudio(bool(usd)))}
+        )
     elif action == "clear_transcription":
         return {"success": bool(f.ClearTranscription())}
     elif action == "perform_audio_classification":
@@ -16358,7 +16409,7 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
       monitor_growing_file(clip_id) -> {success}
       replace_clip_preserve_sub_clip(clip_id, path) -> {success}
       get_unique_id(clip_id) -> {id}
-      transcribe_audio(clip_id, use_speaker_detection?) -> {success}  — use_speaker_detection is Resolve 21+
+      transcribe_audio(clip_id, use_speaker_detection?, background?) -> {success | job_id}  — use_speaker_detection is Resolve 21+; background=true returns a job_id (poll resolve_control job_status)
       clear_transcription(clip_id) -> {success}
       get_transcription(clip_id) -> {text, truncated, status, has_transcription}
         Read a clip's transcription. `truncated` flags when Resolve's preview
@@ -16580,10 +16631,12 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
     elif action == "transcribe_audio":
         usd = _first_param(p, "use_speaker_detection", "useSpeakerDetection")
         if usd is None:
-            with long_resolve_op("media_pool_item.transcribe_audio"):
-                return {"success": bool(clip.TranscribeAudio())}
-        with long_resolve_op("media_pool_item.transcribe_audio"):
-            return {"success": bool(clip.TranscribeAudio(bool(usd)))}
+            return _run_maybe_background(
+                "media_pool_item.transcribe_audio", p, lambda: {"success": bool(clip.TranscribeAudio())}
+            )
+        return _run_maybe_background(
+            "media_pool_item.transcribe_audio", p, lambda: {"success": bool(clip.TranscribeAudio(bool(usd)))}
+        )
     elif action == "clear_transcription":
         return {"success": bool(clip.ClearTranscription())}
     elif action == "get_transcription":
@@ -18818,7 +18871,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       create_fusion_clip(clip_ids) -> {success}
       import_into_timeline(path, options?) -> {success}
         UNSAFE. No path sandboxing. Prefer import_timeline_checked.
-      export(path, type, subtype?) -> {success}  — type: AAF, EDL, FCPXML, etc.
+      export(path, type, subtype?, background?) -> {success | job_id}  — type: AAF, EDL, FCPXML, etc.
         UNSAFE. No path sandboxing. Prefer export_timeline_checked.
       get_setting(name?) -> {settings}
       set_setting(name, value) -> {success}
@@ -18861,8 +18914,8 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       probe_timeline_structure(track_types?, include_markers?, include_clip_properties?) -> {tracks, markers}
       detect_gaps_overlaps(track_types?, min_gap?) -> {gaps, overlaps}
       source_range_report(handles?, merge?) -> {ranges, occurrences}
-      export_timeline_checked(path, format?|type?, subtype?, require_temp_path?, dry_run?) -> {success, path, size}
-      import_timeline_checked(path, options?, timeline_name?, import_source_clips?, sanitize_media?, require_temp_path?, dry_run?) -> {success, name, id, media, sanitize?, warning?}
+      export_timeline_checked(path, format?|type?, subtype?, require_temp_path?, dry_run?, background?) -> {success, path, size | job_id}
+      import_timeline_checked(path, options?, timeline_name?, import_source_clips?, sanitize_media?, require_temp_path?, dry_run?, background?) -> {success, name, id, media, sanitize?, warning? | job_id}
         Imports an FCP7 xmeml / FCPXML / AAF timeline. AAF (.aaf) is read natively by
         Resolve — the XML sanitize pass is SKIPPED for it (media relinks via the media
         pool, not by rewriting the file); a `note` says so. For AAF, passing
@@ -19168,13 +19221,16 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         # friendly type/subtype names (or EXPORT_* constant names) the same way
         # export_timeline_checked does. This raw action keeps no path sandbox.
         spec = _timeline_export_spec(p, get_resolve())
-        with long_resolve_op("timeline.export"):
+
+        def _work():
             success = bool(tl.Export(p["path"], spec["export_type"], spec["export_subtype"]))
-        return {
-            "success": success,
-            "export_type": spec["export_type_name"],
-            "export_subtype": spec["export_subtype_name"],
-        }
+            return {
+                "success": success,
+                "export_type": spec["export_type_name"],
+                "export_subtype": spec["export_subtype_name"],
+            }
+
+        return _run_maybe_background("timeline.export", p, _work)
     elif action == "get_setting":
         return {"settings": _ser(tl.GetSetting(p.get("name", "")))}
     elif action == "set_setting":
@@ -19623,9 +19679,11 @@ def timeline_ai(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
     """AI and analysis operations on the current timeline.
 
     Actions:
-      create_subtitles(settings?) -> {success}  — auto-caption from audio
-      detect_scene_cuts() -> {success}
-      analyze_dolby_vision(clip_ids?, analysis_type?) -> {success}
+      create_subtitles(settings?, background?) -> {success | job_id}  — auto-caption from audio.
+        These are long ops: background=true returns a job_id immediately; poll
+        resolve_control(action="job_status", params={"job_id": ...}).
+      detect_scene_cuts(background?) -> {success | job_id}
+      analyze_dolby_vision(clip_ids?, analysis_type?, background?) -> {success | job_id}
       grab_still() -> {success}
       grab_all_stills(source?) -> {count}
     """
@@ -19635,11 +19693,13 @@ def timeline_ai(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
         return err
 
     if action == "create_subtitles":
-        with long_resolve_op("timeline_ai.create_subtitles"):
-            return _safe_create_subtitles(tl, p)
+        return _run_maybe_background(
+            "timeline_ai.create_subtitles", p, lambda: _safe_create_subtitles(tl, p)
+        )
     elif action == "detect_scene_cuts":
-        with long_resolve_op("timeline_ai.detect_scene_cuts"):
-            return {"success": bool(tl.DetectSceneCuts())}
+        return _run_maybe_background(
+            "timeline_ai.detect_scene_cuts", p, lambda: {"success": bool(tl.DetectSceneCuts())}
+        )
     elif action == "analyze_dolby_vision":
         clip_ids = p.get("clip_ids", [])
         items = []
@@ -19650,8 +19710,10 @@ def timeline_ai(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
                         if it.GetUniqueId() in clip_ids:
                             items.append(it)
         analysis_type = p.get("analysis_type")
-        with long_resolve_op("timeline_ai.analyze_dolby_vision"):
-            return {"success": bool(tl.AnalyzeDolbyVision(items, analysis_type))}
+        return _run_maybe_background(
+            "timeline_ai.analyze_dolby_vision", p,
+            lambda: {"success": bool(tl.AnalyzeDolbyVision(items, analysis_type))},
+        )
     elif action == "grab_still":
         still = tl.GrabStill()
         return _ok() if still else _err("Failed to grab still")

--- a/src/server.py
+++ b/src/server.py
@@ -16344,7 +16344,9 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
       clear_transcription(clip_id) -> {success}
       get_transcription(clip_id) -> {text, truncated, status, has_transcription}
         Read a clip's transcription. `truncated` flags when Resolve's preview
-        property cut the text off (the full transcript is longer).
+        property cut the text off (the full transcript is longer). Clip-level and
+        separate from the timeline subtitle transcript (timeline.get_transcript)
+        that propose_cuts uses.
       extract_frames(clip_id, timestamps, output_dir?) -> {frame_paths, output_dir, count, errors}
         Extract still JPEGs from the clip's source at the given timestamps (seconds)
         via ffmpeg. Source-safe: reads source, writes only to a scratch dir.
@@ -18715,7 +18717,9 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     PREFER probe_* / *_capabilities / *_boundary_report / *_checked / dry_run variants
     where they exist. Raw mutators are kept for advanced callers but bypass guardrails.
     DESTRUCTIVE actions auto-archive the current timeline (C6); pass strict=true for
-    refuse-on-archive-failure behavior on the catastrophic ops.
+    refuse-on-archive-failure behavior on the catastrophic ops. To thread several
+    destructive calls into ONE archived predecessor instead of N, wrap them in
+    timeline_versioning begin_run/end_run.
 
     Frame numbers are TIMELINE/record frames (position on the timeline) unless an action
     says SOURCE. Source frames are positions within a media-pool clip's own media:
@@ -18810,7 +18814,11 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       get_node_graph() -> {available}
       get_media_pool_item() -> {name, id}
       get_transcript(with_timecodes?) -> {text, cue_count, has_subtitles, cues}
-        Read the timeline's subtitle track(s) as transcript text.
+        Read the timeline's subtitle track(s) as transcript text. This is the
+        TIMELINE subtitle transcript that propose_cuts consumes; it is separate
+        from clip-level transcription (produced by transcribe_audio on a
+        folder/clip, read via media_pool_item get_transcription), which does not
+        drive timeline cuts.
       propose_cuts(cues?, long_pause_frames?) -> {cuts, cut_count, basis_cue_count, pass, note}
         DRY-RUN. Mechanically detect candidate cuts (filler words, long pauses,
         repeated lines) from the subtitle transcript. Proposes only; applies nothing.
@@ -20628,7 +20636,8 @@ _ACTION_HELP: Dict[str, Dict[str, Dict[str, Any]]] = {
             "params": (
                 "name, ranges: [{clip_id|media_pool_item_id, start_frame, end_frame, "
                 "record_frame?, track_type?}], markers?, cdl?, dry_run?  — clip_id is a "
-                "media-pool item id (not a timeline-item id); start_frame/end_frame are SOURCE frames"
+                "media-pool item id (not a timeline-item id); start_frame/end_frame are SOURCE "
+                "frames, end_frame exclusive (source duration = end_frame - start_frame)"
             ),
             "returns": "{success, id, items}  — items[].placed = placed frames; items[].range = the requested range",
             "example": (

--- a/src/server.py
+++ b/src/server.py
@@ -744,6 +744,13 @@ sys.path.insert(0, RESOLVE_MODULES_PATH)
 resolve = None
 dvr_script = None
 _resolve_lock = threading.RLock()
+# Serializes synchronous tool bodies once they run off the event loop (see
+# _install_threaded_tool_dispatch): the Resolve scripting bridge executes one
+# call at a time, so two sync tool bodies must never enter it concurrently. No
+# body re-acquires it, so a plain Lock (not RLock) states the invariant. The
+# async media_analysis tool is not wrapped and does not take this lock; it is
+# assumed not to run concurrently with another tool (true for a serial client).
+_bridge_lock = threading.Lock()
 
 # On Windows the fusionscript native bridge DLL must be locatable before the
 # Python import machinery attempts to load it.  Setting PYTHONHOME, prepending
@@ -25004,8 +25011,58 @@ def _resource_install_guidance() -> Dict[str, Any]:
 # Server Startup
 # ═══════════════════════════════════════════════════════════════════════════════
 
+def _install_threaded_tool_dispatch(fastmcp) -> int:
+    """Run synchronous tool bodies in a worker thread instead of inline on the
+    event loop.
+
+    The MCP SDK invokes a sync tool function directly on the single asyncio
+    event-loop thread, so a blocking Resolve call (or subprocess, or the up-to-
+    60s launch wait) freezes the whole server — including the stdio read loop —
+    until it returns. Wrapping each sync tool as an async function that offloads
+    to a worker thread keeps the event loop servicing the transport. Bodies are
+    serialized on _bridge_lock so the single-threaded Resolve bridge is never
+    entered concurrently. A body that outlives a client cancellation runs to
+    completion (the bridge is never left half-mutated) still holding the lock.
+
+    Couples to mcp SDK >= 1.28.1 private attrs (ToolManager._tools, Tool.fn /
+    Tool.is_async). Best-effort: if that shape changes, leave the tools as-is,
+    falling back to the current inline behavior.
+    """
+    import functools
+    import anyio
+
+    manager = getattr(fastmcp, "_tool_manager", None)
+    tools = getattr(manager, "_tools", None)
+    if not isinstance(tools, dict) or not tools:
+        return 0
+
+    def _offloaded(fn):
+        @functools.wraps(fn)
+        async def run_off_thread(**kwargs):
+            def call():
+                with _bridge_lock:
+                    return fn(**kwargs)
+            return await anyio.to_thread.run_sync(call)
+        return run_off_thread
+
+    wrapped = 0
+    for tool in tools.values():
+        if getattr(tool, "is_async", False):
+            continue
+        try:
+            tool.fn = _offloaded(tool.fn)
+            tool.is_async = True
+        except Exception as exc:  # unexpected SDK shape — keep the original tool
+            logger.warning(f"threaded tool dispatch skipped for {getattr(tool, 'name', '?')}: {exc}")
+            continue
+        wrapped += 1
+    logger.info(f"Threaded tool dispatch installed for {wrapped} tools")
+    return wrapped
+
+
 if __name__ == "__main__":
     start_background_update_check(VERSION, project_dir, logger, env=_setup_update_env())
+    _install_threaded_tool_dispatch(mcp)
 
     # Support --full flag to run the 341-tool granular server instead
     if "--full" in sys.argv:
@@ -25013,6 +25070,7 @@ if __name__ == "__main__":
         sys.argv = [arg for arg in sys.argv if arg != "--full"]
         from src.granular import mcp as granular_mcp
 
+        _install_threaded_tool_dispatch(granular_mcp)
         run_fastmcp_stdio(granular_mcp)
         sys.exit(0)
 

--- a/src/server.py
+++ b/src/server.py
@@ -4046,6 +4046,20 @@ def _timeline_copy_range_impl(proj, tl, p: Dict[str, Any], *, overwrite: bool = 
     return out
 
 
+def _apply_cuts_skip_reason(cut):
+    """Why a CutList entry is not applicable by apply_cuts, or None if it is."""
+    if not isinstance(cut, dict):
+        return "not an object"
+    if cut.get("action") not in ("lift", "ripple_delete"):
+        return f"action {cut.get('action')!r} is not lift or ripple_delete"
+    span = cut.get("span")
+    if not isinstance(span, dict):
+        return "missing span"
+    if span.get("start") is None or span.get("end") is None:
+        return "span missing start/end"
+    return None
+
+
 def _timeline_lift_range_impl(tl, p: Dict[str, Any]):
     start, end, items, err = _collect_timeline_items_in_range(tl, p)
     if err:
@@ -18763,7 +18777,8 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
       propose_cuts(cues?, long_pause_frames?) -> {cuts, cut_count, basis_cue_count, pass, note}
         DRY-RUN. Mechanically detect candidate cuts (filler words, long pauses,
         repeated lines) from the subtitle transcript. Proposes only; applies nothing.
-      apply_cuts(cuts, dry_run?, confirm_token?, allow_partial_item_delete?) -> {applied, total, results}
+      apply_cuts(cuts, dry_run?, confirm_token?, allow_partial_item_delete?) -> {applied, total, skipped, results}
+        skipped lists cuts that were not applicable, each with a reason.
         Apply a CutList (from propose_cuts) as lift/ripple deletes. DRY-RUN by
         default; applying is DESTRUCTIVE — confirm-token gated and a timeline
         version is archived first. Cuts apply latest-first.
@@ -19144,12 +19159,14 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         cuts = p.get("cuts")
         if not isinstance(cuts, list):
             return _err("apply_cuts requires 'cuts' (a list, e.g. from propose_cuts)")
-        applicable = [
-            c for c in cuts
-            if isinstance(c, dict) and c.get("action") in ("lift", "ripple_delete")
-            and isinstance(c.get("span"), dict)
-            and c["span"].get("start") is not None and c["span"].get("end") is not None
-        ]
+        applicable = []
+        skipped = []
+        for index, c in enumerate(cuts):
+            reason = _apply_cuts_skip_reason(c)
+            if reason:
+                skipped.append({"index": index, "cut": c, "reason": reason})
+            else:
+                applicable.append(c)
         applicable.sort(key=lambda c: c["span"]["start"], reverse=True)
         plan = [{"action": c["action"], "span": c["span"], "kind": c.get("kind")} for c in applicable]
 
@@ -19158,6 +19175,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
                 "dry_run": True,
                 "would_apply": len(applicable),
                 "plan": plan,
+                "skipped": skipped,
                 "note": "No edits made. Re-run with dry_run=false (and a confirm_token) to apply.",
             }
 
@@ -19171,6 +19189,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
                                "archived first.",
                     "would_apply": len(applicable),
                     "plan": plan,
+                    "skipped": skipped,
                 },
             )
         blocked = _consume_confirm_token(action="timeline.apply_cuts", params=p)
@@ -19190,7 +19209,8 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
             results.append({"action": c["action"], "span": sp, "result": res})
         applied = sum(1 for r in results
                       if isinstance(r["result"], dict) and r["result"].get("success"))
-        return {"success": True, "applied": applied, "total": len(applicable), "results": results}
+        return {"success": True, "applied": applied, "total": len(applicable),
+                "skipped": skipped, "results": results}
     elif action == "get_mark_in_out":
         return _ser(tl.GetMarkInOut())
     elif action == "set_mark_in_out":

--- a/src/server.py
+++ b/src/server.py
@@ -4897,6 +4897,18 @@ def _variant_item_placement(item) -> Dict[str, Any]:
     }
 
 
+def _variant_audio_summary(built):
+    """Video/audio range counts for an assembled variant, warning when it carries
+    no audio. create_variant_from_ranges places exactly the ranges given, so a
+    video-only range list yields a silent timeline."""
+    video = sum(1 for row in built if row.get("media_type") == 1)
+    audio = sum(1 for row in built if row.get("media_type") == 2)
+    summary = {"video_ranges": video, "audio_ranges": audio}
+    if audio == 0:
+        summary["warning"] = "video-only (no audio): add ranges with track_type='audio' to carry sound"
+    return summary
+
+
 def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> Dict[str, Any]:
     ranges = p.get("ranges") or p.get("clip_infos")
     if not isinstance(ranges, list) or not ranges:
@@ -4968,6 +4980,7 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
                 for row in built
             ],
             "markers": p.get("markers") or [],
+            "audio": _variant_audio_summary(built),
             "would_create_timeline": True,
         }
     new_tl = mp.CreateEmptyTimeline(name)
@@ -5029,6 +5042,7 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
         "id": new_tl.GetUniqueId(),
         "items": items_out,
         "placement_mismatches": placement_mismatches,
+        "audio": _variant_audio_summary(built),
         "markers": marker_results,
         "look": look_result,
         "gaps_overlaps": _detect_gaps_overlaps_from_snapshot(_timeline_conform_snapshot(new_tl, {}), {}),
@@ -18484,6 +18498,7 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
                 "audio_accounting": {
                     "planned_audio_ranges": audio_keep_ranges,
                     "planned_video_ranges": video_keep_ranges,
+                    # variant_* count placed items; variant["audio"] counts requested ranges.
                     "variant_audio_items": sum(
                         1 for it in (variant.get("items") or [])
                         if (it.get("range") or {}).get("media_type") == 2
@@ -20609,7 +20624,7 @@ _ACTION_HELP: Dict[str, Dict[str, Dict[str, Any]]] = {
             ),
         },
         "create_variant_from_ranges": {
-            "summary": "Build a variant timeline from N source ranges. Source-safe; dry_run validates clip ids and frame ranges.",
+            "summary": "Build a variant timeline from N source ranges. Video-only unless ranges include track_type='audio'. Source-safe; dry_run validates clip ids and frame ranges.",
             "params": (
                 "name, ranges: [{clip_id|media_pool_item_id, start_frame, end_frame, "
                 "record_frame?, track_type?}], markers?, cdl?, dry_run?  — clip_id is a "

--- a/src/server.py
+++ b/src/server.py
@@ -2418,11 +2418,13 @@ def _build_append_clip_info_dict(
     ci: Dict[str, Any],
     index: int,
     timeline_start_frame: Optional[int] = None,
+    pack: bool = False,
 ):
     """Build one MediaPool.AppendToTimeline clipInfo map (Python API uses camelCase keys).
 
     See docs/reference/resolve_scripting_api.txt: mediaPoolItem, startFrame, endFrame,
-    optional mediaType, trackIndex, recordFrame.
+    optional mediaType, trackIndex, recordFrame. With pack=True, recordFrame is omitted
+    so Resolve appends each clip contiguously at the end of its track.
     """
     if not isinstance(ci, dict):
         return None, _err(f"clip_infos[{index}] must be an object")
@@ -2439,14 +2441,15 @@ def _build_append_clip_info_dict(
             f"clip_infos[{index}] requires start_frame/startFrame and end_frame/endFrame "
             "(source range on the MediaPoolItem)"
         )
-    rf = ci.get("recordFrame", ci.get("record_frame"))
-    if rf is None:
-        return None, _err(
-            f"clip_infos[{index}] requires record_frame/recordFrame (timeline record frame)"
-        )
-    rf, rf_err = _normalize_record_frame(ci, index, timeline_start_frame)
-    if rf_err:
-        return None, rf_err
+    if not pack:
+        rf = ci.get("recordFrame", ci.get("record_frame"))
+        if rf is None:
+            return None, _err(
+                f"clip_infos[{index}] requires record_frame/recordFrame (timeline record frame)"
+            )
+        rf, rf_err = _normalize_record_frame(ci, index, timeline_start_frame)
+        if rf_err:
+            return None, rf_err
     ti = ci.get("trackIndex", ci.get("track_index"))
     if ti is None:
         return None, _err(
@@ -2456,9 +2459,10 @@ def _build_append_clip_info_dict(
         "mediaPoolItem": mp_item,
         "startFrame": sf,
         "endFrame": ef,
-        "recordFrame": rf,
         "trackIndex": ti,
     }
+    if not pack:
+        out["recordFrame"] = rf
     mt = ci.get("mediaType", ci.get("media_type"))
     if mt is not None:
         out["mediaType"] = mt
@@ -4926,6 +4930,10 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
             start_frame = int(source_tl.GetStartFrame())
         except Exception:
             start_frame = 0
+    # pack=True butts clips together at the end of each track (record_frame is
+    # ignored); Resolve packs by actual placed duration, so the result is gap-free
+    # even when source and timeline frame rates differ.
+    pack = bool(p.get("pack", False))
     built = []
     cursor_by_track: Dict[Tuple[int, int], int] = {}
     max_tracks = {"video": 1, "audio": 1}
@@ -4949,9 +4957,12 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
             return _err(f"ranges[{index}] requires valid start_frame/end_frame")
         record_frame = _frame_int(row.get("record_frame", row.get("recordFrame")))
         key = (int(media_type), track_index)
-        if record_frame is None:
-            record_frame = cursor_by_track.get(key, start_frame)
-        cursor_by_track[key] = record_frame + (end - start)
+        if pack:
+            record_frame = None  # Resolve packs at the end of the track
+        else:
+            if record_frame is None:
+                record_frame = cursor_by_track.get(key, start_frame)
+            cursor_by_track[key] = record_frame + (end - start)
         built.append({
             "clip_id": row.get("clip_id") or row.get("media_pool_item_id"),
             "start_frame": start,
@@ -4966,7 +4977,7 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
     # vs commit, so a dry run fails on the same id/frame errors as the commit.
     append_infos = []
     for row in built:
-        clip_info, clip_err = _build_append_clip_info_dict(root, row, row["_index"])
+        clip_info, clip_err = _build_append_clip_info_dict(root, row, row["_index"], pack=pack)
         if clip_err:
             return clip_err
         append_infos.append(clip_info)
@@ -20635,9 +20646,10 @@ _ACTION_HELP: Dict[str, Dict[str, Dict[str, Any]]] = {
             "summary": "Build a variant timeline from N source ranges. Video-only unless ranges include track_type='audio'. Source-safe; dry_run validates clip ids and frame ranges.",
             "params": (
                 "name, ranges: [{clip_id|media_pool_item_id, start_frame, end_frame, "
-                "record_frame?, track_type?}], markers?, cdl?, dry_run?  — clip_id is a "
+                "record_frame?, track_type?}], pack?, markers?, cdl?, dry_run?  — clip_id is a "
                 "media-pool item id (not a timeline-item id); start_frame/end_frame are SOURCE "
-                "frames, end_frame exclusive (source duration = end_frame - start_frame)"
+                "frames, end_frame exclusive (source duration = end_frame - start_frame). "
+                "pack=true butts clips together at the end of each track (gap-free, ignores record_frame)"
             ),
             "returns": "{success, id, items}  — items[].placed = placed frames; items[].range = the requested range",
             "example": (

--- a/src/utils/background_jobs.py
+++ b/src/utils/background_jobs.py
@@ -1,0 +1,108 @@
+"""In-process registry for long DaVinci Resolve operations run off-thread.
+
+Some Resolve calls (transcription, subtitle generation, scene-cut and Dolby
+analysis, timeline export/import) block for minutes — longer than an MCP
+client's tool-window timeout. start_job runs such a call on a daemon thread and
+returns a short id immediately; the caller polls job_status until the job
+reports "done" (with its result) or "error" (with the message).
+
+The worker runs fn inside resolve_busy.long_resolve_op(label) so another
+Resolve-touching tool call meets the advisory "busy" answer instead of colliding
+on the single-threaded scripting bridge (job_status / list_jobs are
+connection-free and never contend). Serialization comes from that preflight, not
+from the bridge itself; the busy record tracks a single owner, so two jobs
+started in quick succession have a brief window before the first's record shows.
+
+Finished jobs are pruned once older than MAX_JOB_AGE_SECONDS on any access, so
+the registry cannot grow without bound.
+"""
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+from src.utils.resolve_busy import long_resolve_op
+
+# A finished job is dropped from the registry this long after it ended.
+MAX_JOB_AGE_SECONDS = 60 * 60
+
+_lock = threading.Lock()
+_jobs: Dict[str, Dict[str, Any]] = {}
+
+
+def _prune_locked(now: float) -> None:
+    stale = [
+        job_id
+        for job_id, job in _jobs.items()
+        if job["status"] != "running"
+        and job["ended_at"] is not None
+        and now - job["ended_at"] > MAX_JOB_AGE_SECONDS
+    ]
+    for job_id in stale:
+        del _jobs[job_id]
+
+
+def _run(job_id: str, label: str, fn: Callable[[], Any]) -> None:
+    try:
+        with long_resolve_op(label):
+            result = fn()
+    except Exception as exc:
+        with _lock:
+            job = _jobs.get(job_id)
+            if job is not None:
+                job["status"] = "error"
+                job["error"] = f"{type(exc).__name__}: {exc}"
+                job["ended_at"] = time.time()
+        return
+    with _lock:
+        job = _jobs.get(job_id)
+        if job is not None:
+            job["status"] = "done"
+            job["result"] = result
+            job["ended_at"] = time.time()
+
+
+def start_job(label: str, fn: Callable[[], Any]) -> str:
+    """Run fn on a daemon thread; return a short job id immediately."""
+    now = time.time()
+    with _lock:
+        _prune_locked(now)
+        job_id = uuid.uuid4().hex[:8]
+        while job_id in _jobs:
+            job_id = uuid.uuid4().hex[:8]
+        _jobs[job_id] = {
+            "id": job_id,
+            "label": str(label),
+            "status": "running",
+            "result": None,
+            "error": None,
+            "started_at": now,
+            "ended_at": None,
+        }
+    threading.Thread(
+        target=_run,
+        args=(job_id, str(label), fn),
+        name=f"bgjob-{job_id}",
+        daemon=True,
+    ).start()
+    return job_id
+
+
+def job_status(job_id: str) -> Optional[Dict[str, Any]]:
+    """Snapshot of one job, or None when the id is unknown."""
+    with _lock:
+        _prune_locked(time.time())
+        job = _jobs.get(job_id)
+        return dict(job) if job is not None else None
+
+
+def list_jobs() -> List[Dict[str, Any]]:
+    """Compact status of every known job."""
+    with _lock:
+        _prune_locked(time.time())
+        return [
+            {k: job[k] for k in ("id", "label", "status", "started_at", "ended_at")}
+            for job in _jobs.values()
+        ]

--- a/tests/test_action_help.py
+++ b/tests/test_action_help.py
@@ -40,5 +40,25 @@ class ActionHelpTest(unittest.TestCase):
         self.assertEqual(out["action"], "safe_apply_drx")
 
 
+class ActionHelpFullActionListTest(unittest.TestCase):
+    """Tools with a registered action list (timeline) report every valid action
+    and tell an unknown action apart from a valid-but-undocumented one."""
+
+    def test_no_name_lists_all_valid_actions_not_only_documented(self):
+        out = compound._action_help("timeline", {})
+        self.assertIn("create_variant_from_ranges", out["available"])  # documented
+        # get_current/lift_range are valid but have no detailed help entry.
+        self.assertIn("get_current", out["actions"])
+        self.assertIn("lift_range", out["actions"])
+        self.assertGreater(len(out["actions"]), len(out["available"]))
+
+    def test_unknown_action_is_distinguished_from_undocumented(self):
+        unknown = compound._action_help("timeline", {"name": "close_gaps"})
+        self.assertEqual(unknown["error"]["code"], "UNKNOWN_ACTION")
+
+        undocumented = compound._action_help("timeline", {"name": "get_current"})
+        self.assertEqual(undocumented["error"]["code"], "HELP_NOT_REGISTERED")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_action_list_drift.py
+++ b/tests/test_action_list_drift.py
@@ -27,16 +27,22 @@ ALIASES = {
 
 
 def _module_list_constants(tree):
+    """Module-level ``NAME = [str, ...]`` constants, resolved in file order so a
+    list may splat an earlier constant (``[*OTHER, "x"]``)."""
     consts = {}
     for node in tree.body:
         if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
             if isinstance(node.value, (ast.List, ast.Tuple)):
-                values = [
-                    elt.value
-                    for elt in node.value.elts
-                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
-                ]
-                if len(values) == len(node.value.elts):
+                values, resolvable = [], True
+                for elt in node.value.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        values.append(elt.value)
+                    elif isinstance(elt, ast.Starred) and isinstance(elt.value, ast.Name) and elt.value.id in consts:
+                        values.extend(consts[elt.value.id])
+                    else:
+                        resolvable = False
+                        break
+                if resolvable:
                     consts[node.targets[0].id] = values
     return consts
 
@@ -60,9 +66,16 @@ def _implemented_actions(fn):
 def _listed_actions(fn, consts):
     for node in ast.walk(fn):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_unknown":
-            if len(node.args) >= 2 and isinstance(node.args[1], ast.List):
+            if len(node.args) < 2:
+                continue
+            arg = node.args[1]
+            if isinstance(arg, ast.Name):
+                if arg.id in consts:
+                    return set(consts[arg.id]), True
+                return None, False
+            if isinstance(arg, ast.List):
                 listed, resolvable = set(), True
-                for elt in node.args[1].elts:
+                for elt in arg.elts:
                     if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
                         listed.add(elt.value)
                     elif isinstance(elt, ast.Starred) and isinstance(elt.value, ast.Name) and elt.value.id in consts:
@@ -78,7 +91,7 @@ class ActionListDriftTest(unittest.TestCase):
         tree = ast.parse(SERVER.read_text())
         consts = _module_list_constants(tree)
         problems = []
-        checked = 0
+        checked_names = []
         for node in tree.body:
             # Async tools (e.g. media_analysis) drifted unchecked for several
             # releases because only FunctionDef was inspected.
@@ -90,7 +103,7 @@ class ActionListDriftTest(unittest.TestCase):
             implemented = _implemented_actions(node)
             if not implemented:
                 continue
-            checked += 1
+            checked_names.append(node.name)
             aliases = ALIASES.get(node.name, set())
             missing = sorted(implemented - listed - aliases)
             phantom = sorted(listed - implemented)
@@ -98,7 +111,10 @@ class ActionListDriftTest(unittest.TestCase):
                 problems.append(f"{node.name}: implemented but not listed: {missing}")
             if phantom:
                 problems.append(f"{node.name}: listed but not implemented: {phantom}")
-        self.assertGreater(checked, 10, "drift checker found too few tools — parser broken?")
+        self.assertGreater(len(checked_names), 10, "drift checker found too few tools — parser broken?")
+        # timeline's list is a module constant (_TIMELINE_ACTIONS); fail loudly if
+        # it ever stops resolving instead of silently dropping from coverage.
+        self.assertIn("timeline", checked_names)
         self.assertEqual(problems, [], "\n".join(problems))
 
     def test_no_unreachable_actions_inside_membership_blocks(self):

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -1,0 +1,146 @@
+"""Unit tests for the generic background-job registry and the
+_run_maybe_background adapter. No Resolve connection is exercised."""
+import threading
+import time
+import unittest
+
+import src.server as s
+from src.utils import background_jobs
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class BackgroundJobsRegistryTest(unittest.TestCase):
+    def test_start_returns_id_immediately_while_fn_still_running(self):
+        gate = threading.Event()
+        job_id = background_jobs.start_job("test.slow", lambda: gate.wait(3.0))
+
+        self.assertIsInstance(job_id, str)
+        self.assertTrue(job_id)
+        # The worker is blocked on the gate, so the job is still running.
+        self.assertEqual(background_jobs.job_status(job_id)["status"], "running")
+        gate.set()
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "done"))
+
+    def test_status_transitions_running_to_done_with_result(self):
+        gate = threading.Event()
+
+        def fn():
+            gate.wait(3.0)
+            return {"value": 7}
+
+        job_id = background_jobs.start_job("test.done", fn)
+        self.assertEqual(background_jobs.job_status(job_id)["status"], "running")
+        gate.set()
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "done"))
+        status = background_jobs.job_status(job_id)
+        self.assertEqual(status["result"], {"value": 7})
+        self.assertIsNone(status["error"])
+        self.assertIsNotNone(status["ended_at"])
+
+    def test_error_is_captured(self):
+        def fn():
+            raise ValueError("boom")
+
+        job_id = background_jobs.start_job("test.error", fn)
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "error"))
+        status = background_jobs.job_status(job_id)
+        self.assertIn("boom", status["error"])
+        self.assertIn("ValueError", status["error"])
+        self.assertIsNone(status["result"])
+
+    def test_unknown_id_returns_none(self):
+        self.assertIsNone(background_jobs.job_status("does-not-exist"))
+
+    def test_runs_off_the_calling_thread(self):
+        seen = {}
+
+        def fn():
+            seen["thread"] = threading.get_ident()
+
+        job_id = background_jobs.start_job("test.thread", fn)
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "done"))
+        self.assertNotEqual(seen["thread"], threading.get_ident())
+
+    def test_list_jobs_reports_known_jobs_compactly(self):
+        job_id = background_jobs.start_job("test.list", lambda: None)
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "done"))
+        entry = next((j for j in background_jobs.list_jobs() if j["id"] == job_id), None)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["label"], "test.list")
+        self.assertNotIn("result", entry)
+
+
+class RunMaybeBackgroundTest(unittest.TestCase):
+    def test_default_path_calls_fn_and_returns_result(self):
+        called = []
+
+        def fn():
+            called.append(True)
+            return {"success": True, "value": 42}
+
+        out = s._run_maybe_background("test.sync", {}, fn)
+        self.assertEqual(out, {"success": True, "value": 42})
+        self.assertEqual(called, [True])
+
+    def test_background_returns_job_id_without_calling_fn_synchronously(self):
+        gate = threading.Event()
+        called = []
+
+        def fn():
+            gate.wait(3.0)
+            called.append(True)
+            return {"success": True}
+
+        out = s._run_maybe_background("test.bg", {"background": True}, fn)
+        self.assertTrue(out["success"])
+        self.assertIn("job_id", out)
+        self.assertEqual(out["status"], "running")
+        self.assertEqual(out["label"], "test.bg")
+        self.assertEqual(called, [])  # not invoked on the calling thread
+        gate.set()
+        self.assertTrue(
+            _wait_for(lambda: background_jobs.job_status(out["job_id"])["status"] == "done")
+        )
+
+    def test_async_job_alias_also_backgrounds(self):
+        out = s._run_maybe_background("test.alias", {"async_job": True}, lambda: {"success": True})
+        self.assertIn("job_id", out)
+        self.assertEqual(out["status"], "running")
+
+
+class ResolveControlPollingTest(unittest.TestCase):
+    def test_job_status_action_returns_status_dict(self):
+        job_id = background_jobs.start_job("test.control", lambda: {"ok": 1})
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "done"))
+        out = s.resolve_control("job_status", {"job_id": job_id})
+        self.assertEqual(out["id"], job_id)
+        self.assertEqual(out["status"], "done")
+        self.assertEqual(out["result"], {"ok": 1})
+
+    def test_job_status_unknown_id_errors(self):
+        out = s.resolve_control("job_status", {"job_id": "nope"})
+        self.assertIn("error", out)
+        self.assertEqual(out["error"]["category"], "invalid_input")
+
+    def test_job_status_missing_id_errors(self):
+        out = s.resolve_control("job_status", {})
+        self.assertIn("error", out)
+
+    def test_list_jobs_action_returns_jobs(self):
+        job_id = background_jobs.start_job("test.control_list", lambda: None)
+        self.assertTrue(_wait_for(lambda: background_jobs.job_status(job_id)["status"] == "done"))
+        out = s.resolve_control("list_jobs", {})
+        self.assertIn("jobs", out)
+        self.assertTrue(any(j["id"] == job_id for j in out["jobs"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_create_variant_dry_run.py
+++ b/tests/test_create_variant_dry_run.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.server import _timeline_create_variant_from_ranges
+from src.server import _timeline_create_variant_from_ranges, _build_append_clip_info_dict
 from tests._error_envelope_helpers import err_message, is_err
 
 
@@ -84,6 +84,43 @@ class CreateVariantDryRunTest(unittest.TestCase):
         })
         self.assertTrue(is_err(res))
         self.assertIn("requires valid start_frame/end_frame", err_message(res))
+
+    def test_pack_dry_run_needs_no_record_frame(self):
+        proj = _proj_with_clip("mp-1")
+        res = _timeline_create_variant_from_ranges(proj, SourceTimelineStub(), {
+            "name": "variant",
+            "dry_run": True,
+            "pack": True,
+            "ranges": [{"clip_id": "mp-1", "start_frame": 0, "end_frame": 100}],
+        })
+        self.assertTrue(res.get("would_create_timeline"))
+        self.assertIsNone(res["ranges"][0]["record_frame"])
+
+
+class BuildAppendClipInfoPackTest(unittest.TestCase):
+    def setUp(self):
+        self.root = RootFolderStub([MediaPoolItemStub("mp-1")])
+
+    def test_pack_omits_record_frame(self):
+        info, err = _build_append_clip_info_dict(
+            self.root, {"clip_id": "mp-1", "start_frame": 0, "end_frame": 100, "track_index": 1},
+            0, pack=True)
+        self.assertIsNone(err)
+        self.assertNotIn("recordFrame", info)
+
+    def test_non_pack_still_requires_record_frame(self):
+        info, err = _build_append_clip_info_dict(
+            self.root, {"clip_id": "mp-1", "start_frame": 0, "end_frame": 100, "track_index": 1},
+            0, pack=False)
+        self.assertIsNone(info)
+        self.assertIn("record_frame", err_message(err))
+
+    def test_non_pack_reports_record_frame_before_track_index(self):
+        # Missing both: record_frame is validated first (preserved error order).
+        info, err = _build_append_clip_info_dict(
+            self.root, {"clip_id": "mp-1", "start_frame": 0, "end_frame": 100}, 0, pack=False)
+        self.assertIsNone(info)
+        self.assertIn("record_frame", err_message(err))
 
 
 if __name__ == "__main__":

--- a/tests/test_create_variant_dry_run.py
+++ b/tests/test_create_variant_dry_run.py
@@ -1,0 +1,90 @@
+import unittest
+
+from src.server import _timeline_create_variant_from_ranges
+from tests._error_envelope_helpers import err_message, is_err
+
+
+class MediaPoolItemStub:
+    def __init__(self, unique_id):
+        self._id = unique_id
+
+    def GetUniqueId(self):
+        return self._id
+
+
+class RootFolderStub:
+    def __init__(self, clips):
+        self._clips = clips
+
+    def GetClipList(self):
+        return self._clips
+
+    def GetSubFolderList(self):
+        return []
+
+
+class MediaPoolStub:
+    def __init__(self, root):
+        self._root = root
+        self.created = None
+
+    def GetRootFolder(self):
+        return self._root
+
+    def CreateEmptyTimeline(self, name):
+        self.created = name
+        raise AssertionError("dry_run must not create a timeline")
+
+
+class ProjectStub:
+    def __init__(self, mp):
+        self._mp = mp
+
+    def GetMediaPool(self):
+        return self._mp
+
+
+class SourceTimelineStub:
+    def GetStartFrame(self):
+        return 0
+
+
+def _proj_with_clip(clip_id):
+    return ProjectStub(MediaPoolStub(RootFolderStub([MediaPoolItemStub(clip_id)])))
+
+
+class CreateVariantDryRunTest(unittest.TestCase):
+    def test_dry_run_reports_would_create_without_creating(self):
+        proj = _proj_with_clip("mp-1")
+        res = _timeline_create_variant_from_ranges(proj, SourceTimelineStub(), {
+            "name": "variant",
+            "dry_run": True,
+            "ranges": [{"clip_id": "mp-1", "start_frame": 0, "end_frame": 100}],
+        })
+        self.assertTrue(res.get("dry_run"))
+        self.assertTrue(res.get("would_create_timeline"))
+        self.assertIsNone(proj.GetMediaPool().created)
+
+    def test_dry_run_fails_on_unresolvable_clip_id(self):
+        proj = _proj_with_clip("mp-1")
+        res = _timeline_create_variant_from_ranges(proj, SourceTimelineStub(), {
+            "name": "variant",
+            "dry_run": True,
+            "ranges": [{"clip_id": "does-not-exist", "start_frame": 0, "end_frame": 100}],
+        })
+        self.assertTrue(is_err(res))
+        self.assertIn("media pool clip not found", err_message(res))
+
+    def test_dry_run_fails_on_invalid_frame_range(self):
+        proj = _proj_with_clip("mp-1")
+        res = _timeline_create_variant_from_ranges(proj, SourceTimelineStub(), {
+            "name": "variant",
+            "dry_run": True,
+            "ranges": [{"clip_id": "mp-1", "start_frame": 100, "end_frame": 100}],
+        })
+        self.assertTrue(is_err(res))
+        self.assertIn("requires valid start_frame/end_frame", err_message(res))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cut_executor.py
+++ b/tests/test_cut_executor.py
@@ -8,12 +8,31 @@ import unittest
 from unittest import mock
 
 import src.server as s
+from src.server import _apply_cuts_skip_reason
 
 
 def _proj_with_tl():
     proj = mock.Mock()
     proj.GetCurrentTimeline.return_value = mock.Mock()
     return proj
+
+
+class ApplyCutsSkipReasonTest(unittest.TestCase):
+    def test_applicable_cut_has_no_reason(self):
+        self.assertIsNone(_apply_cuts_skip_reason(
+            {"action": "ripple_delete", "span": {"start": 0, "end": 10}}))
+
+    def test_wrong_action_is_reported(self):
+        self.assertIn("not lift or ripple_delete",
+                      _apply_cuts_skip_reason({"action": "keep", "span": {"start": 0, "end": 10}}))
+
+    def test_missing_span_is_reported(self):
+        self.assertEqual(_apply_cuts_skip_reason({"action": "lift"}), "missing span")
+
+    def test_incomplete_span_is_reported(self):
+        self.assertEqual(
+            _apply_cuts_skip_reason({"action": "lift", "span": {"start": 0}}),
+            "span missing start/end")
 
 
 class ApplyCutsDryRunTest(unittest.TestCase):
@@ -43,6 +62,15 @@ class ApplyCutsDryRunTest(unittest.TestCase):
         out = self._call({"cuts": []})
         self.assertEqual(out["would_apply"], 0)
 
+    def test_dry_run_reports_skipped_with_reasons(self):
+        out = self._call({"cuts": [
+            {"action": "ripple_delete", "span": {"start": 0, "end": 10}},
+            {"action": "keep", "span": {"start": 20, "end": 30}},
+        ]})
+        self.assertEqual(out["would_apply"], 1)
+        self.assertEqual([s_["index"] for s_ in out["skipped"]], [1])
+        self.assertIn("not lift or ripple_delete", out["skipped"][0]["reason"])
+
 
 class ApplyCutsApplyTest(unittest.TestCase):
     def test_applies_in_reverse_order(self):
@@ -71,16 +99,34 @@ class ApplyCutsApplyTest(unittest.TestCase):
         self.assertEqual(calls[1]["start_frame"], 0)
         self.assertFalse(calls[1]["ripple"])
 
+    def test_applied_response_includes_skipped(self):
+        cuts = [
+            {"action": "lift", "span": {"start": 0, "end": 10}},
+            {"action": "keep", "span": {"start": 20, "end": 30}},
+        ]
+        with mock.patch.object(s, "get_resolve", return_value=None), \
+             mock.patch.object(s, "_check", return_value=(None, _proj_with_tl(), None)), \
+             mock.patch.object(s, "_confirm_token_required", return_value=False), \
+             mock.patch.object(s, "_timeline_lift_range_impl",
+                               return_value={"success": True, "deleted": 1}):
+            out = s.timeline("apply_cuts", {"cuts": cuts, "dry_run": False})
+        self.assertEqual(out["applied"], 1)
+        self.assertEqual([s_["index"] for s_ in out["skipped"]], [1])
+
     def test_issues_confirm_token_when_required(self):
         with mock.patch.object(s, "get_resolve", return_value=None), \
              mock.patch.object(s, "_check", return_value=(None, _proj_with_tl(), None)), \
              mock.patch.object(s, "_confirm_token_required", return_value=True):
             out = s.timeline("apply_cuts", {
-                "cuts": [{"action": "lift", "span": {"start": 0, "end": 10}}],
+                "cuts": [
+                    {"action": "lift", "span": {"start": 0, "end": 10}},
+                    {"action": "keep", "span": {"start": 20, "end": 30}},
+                ],
                 "dry_run": False,
             })
         # Without a token, it must return a preview/token issuance, not apply.
         self.assertNotIn("applied", out)
+        self.assertEqual([s_["index"] for s_ in out["preview"]["skipped"]], [1])
 
 
 if __name__ == "__main__":

--- a/tests/test_get_items_selector.py
+++ b/tests/test_get_items_selector.py
@@ -1,0 +1,59 @@
+"""get_items / get_items_in_track validate their track selector (no KeyError)
+and accept the 1-based index as either index or track_index."""
+import unittest
+from unittest import mock
+
+import src.server as s
+
+
+def _item(name="clip", uid="ti-1", start=0, end=100, duration=100):
+    it = mock.Mock()
+    it.GetName.return_value = name
+    it.GetUniqueId.return_value = uid
+    it.GetStart.return_value = start
+    it.GetEnd.return_value = end
+    it.GetDuration.return_value = duration
+    return it
+
+
+def _dispatch(action, params, track_items=()):
+    tl = mock.Mock()
+    tl.GetItemListInTrack.return_value = list(track_items)
+    proj = mock.Mock()
+    proj.GetCurrentTimeline.return_value = tl
+    with mock.patch.object(s, "_check", return_value=(mock.Mock(), proj, None)):
+        return s.timeline(action, params), tl
+
+
+class GetItemsSelectorTest(unittest.TestCase):
+    def test_get_items_returns_summary(self):
+        out, tl = _dispatch("get_items", {"track_type": "video", "index": 1}, [_item()])
+        self.assertEqual(out["items"], [{"name": "clip", "id": "ti-1", "start": 0, "end": 100, "duration": 100}])
+        tl.GetItemListInTrack.assert_called_once_with("video", 1)
+
+    def test_get_items_accepts_track_index_alias(self):
+        out, tl = _dispatch("get_items", {"track_type": "video", "track_index": 2})
+        tl.GetItemListInTrack.assert_called_once_with("video", 2)
+
+    def test_get_items_missing_track_type_errors_without_crashing(self):
+        out, _ = _dispatch("get_items", {"index": 1})
+        self.assertIn("error", out)
+        self.assertNotIn("items", out)
+
+    def test_get_items_rejects_unknown_track_type(self):
+        out, _ = _dispatch("get_items", {"track_type": "bogus", "index": 1})
+        self.assertIn("error", out)
+
+    def test_get_items_in_track_accepts_index_alias(self):
+        out, tl = _dispatch("get_items_in_track", {"track_type": "audio", "index": 1})
+        tl.GetItemListInTrack.assert_called_once_with("audio", 1)
+        self.assertIn("items", out)
+
+    def test_missing_index_error_names_both_aliases(self):
+        from tests._error_envelope_helpers import err_message
+        out, _ = _dispatch("get_items_in_track", {"track_type": "audio"})
+        self.assertIn("track_index", err_message(out))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_set_current_selector.py
+++ b/tests/test_set_current_selector.py
@@ -1,0 +1,85 @@
+"""set_current accepts a stable id/name selector, not only a 1-based index."""
+import unittest
+from unittest import mock
+
+import src.server as s
+from src.server import _find_timeline_by_id
+
+
+class TimelineStub:
+    def __init__(self, unique_id, name):
+        self._id = unique_id
+        self._name = name
+
+    def GetUniqueId(self):
+        return self._id
+
+    def GetName(self):
+        return self._name
+
+
+class ProjectStub:
+    def __init__(self, timelines):
+        self._timelines = timelines
+        self.set_to = None
+
+    def GetTimelineCount(self):
+        return len(self._timelines)
+
+    def GetTimelineByIndex(self, index):
+        return self._timelines[index - 1] if 1 <= index <= len(self._timelines) else None
+
+    def SetCurrentTimeline(self, tl):
+        self.set_to = tl
+        return True
+
+
+def _dispatch(proj, params):
+    with mock.patch.object(s, "_check", return_value=(mock.Mock(), proj, None)):
+        return s.timeline("set_current", params)
+
+
+class FindTimelineByIdTest(unittest.TestCase):
+    def setUp(self):
+        self.proj = ProjectStub([TimelineStub("tl-a", "Act 1"), TimelineStub("tl-b", "Act 2")])
+
+    def test_returns_timeline_and_index_for_matching_id(self):
+        tl, index = _find_timeline_by_id(self.proj, "tl-b")
+        self.assertEqual((tl.GetName(), index), ("Act 2", 2))
+
+    def test_returns_none_for_unknown_id(self):
+        self.assertEqual(_find_timeline_by_id(self.proj, "tl-missing"), (None, None))
+
+
+class SetCurrentSelectorTest(unittest.TestCase):
+    def setUp(self):
+        self.proj = ProjectStub([TimelineStub("tl-a", "Act 1"), TimelineStub("tl-b", "Act 2")])
+
+    def test_selects_by_id(self):
+        out = _dispatch(self.proj, {"id": "tl-b"})
+        self.assertTrue(out.get("success"))
+        self.assertEqual(self.proj.set_to.GetName(), "Act 2")
+
+    def test_selects_by_name(self):
+        out = _dispatch(self.proj, {"name": "Act 1"})
+        self.assertTrue(out.get("success"))
+        self.assertEqual(self.proj.set_to.GetName(), "Act 1")
+
+    def test_falls_back_to_name_when_id_misses(self):
+        out = _dispatch(self.proj, {"id": "nope", "name": "Act 2"})
+        self.assertTrue(out.get("success"))
+        self.assertEqual(self.proj.set_to.GetName(), "Act 2")
+
+    def test_errors_when_selector_matches_nothing(self):
+        out = _dispatch(self.proj, {"id": "nope"})
+        self.assertIn("error", out)
+        self.assertIsNone(self.proj.set_to)
+
+    def test_index_still_supported(self):
+        out = _dispatch(self.proj, {"index": 1})
+        self.assertTrue(out.get("success"))
+        self.assertEqual(self.proj.set_to.GetName(), "Act 1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_threaded_tool_dispatch.py
+++ b/tests/test_threaded_tool_dispatch.py
@@ -1,0 +1,62 @@
+"""Sync tool bodies are moved off the event loop into a worker thread so a
+blocking call cannot freeze the transport."""
+import threading
+import unittest
+
+import anyio
+
+from src.server import _install_threaded_tool_dispatch
+
+
+class FakeTool:
+    def __init__(self, fn, is_async=False, name="t"):
+        self.fn = fn
+        self.is_async = is_async
+        self.name = name
+
+
+class FakeManager:
+    def __init__(self, tools):
+        self._tools = tools
+
+
+class FakeMCP:
+    def __init__(self, tools):
+        self._tool_manager = FakeManager(tools)
+
+
+class ThreadedToolDispatchTest(unittest.TestCase):
+    def test_wraps_sync_tools_and_skips_async(self):
+        sync_tool = FakeTool(lambda **kw: {"ok": True}, is_async=False, name="sync")
+        async_fn = sync_tool  # placeholder
+        async_tool = FakeTool(async_fn, is_async=True, name="async")
+        mcp = FakeMCP({"sync": sync_tool, "async": async_tool})
+
+        wrapped = _install_threaded_tool_dispatch(mcp)
+        self.assertEqual(wrapped, 1)
+        self.assertTrue(sync_tool.is_async)   # now presented as async
+        self.assertTrue(async_tool.is_async)  # untouched
+
+    def test_wrapped_tool_runs_off_thread_and_returns_result(self):
+        main_thread = threading.current_thread().name
+
+        def body(**kwargs):
+            return {"value": kwargs["x"], "thread": threading.current_thread().name}
+
+        tool = FakeTool(body, is_async=False, name="body")
+        _install_threaded_tool_dispatch(FakeMCP({"body": tool}))
+
+        result = anyio.run(lambda: tool.fn(x=42))
+        self.assertEqual(result["value"], 42)
+        self.assertNotEqual(result["thread"], main_thread)  # ran off the event-loop thread
+
+    def test_missing_tool_manager_is_a_noop(self):
+        self.assertEqual(_install_threaded_tool_dispatch(object()), 0)
+
+    def test_non_mapping_tools_is_a_noop(self):
+        # A future SDK shape that isn't a dict must degrade to inline, not crash.
+        self.assertEqual(_install_threaded_tool_dispatch(FakeMCP(["not", "a", "map"])), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_variant_audio_summary.py
+++ b/tests/test_variant_audio_summary.py
@@ -1,0 +1,20 @@
+"""create_variant_from_ranges reports whether a variant carries audio."""
+import unittest
+
+from src.server import _variant_audio_summary
+
+
+class VariantAudioSummaryTest(unittest.TestCase):
+    def test_video_only_warns(self):
+        summary = _variant_audio_summary([{"media_type": 1}, {"media_type": 1}])
+        self.assertEqual((summary["video_ranges"], summary["audio_ranges"]), (2, 0))
+        self.assertIn("video-only", summary["warning"])
+
+    def test_with_audio_has_no_warning(self):
+        summary = _variant_audio_summary([{"media_type": 1}, {"media_type": 2}])
+        self.assertEqual((summary["video_ranges"], summary["audio_ranges"]), (1, 1))
+        self.assertNotIn("warning", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_variant_item_placement.py
+++ b/tests/test_variant_item_placement.py
@@ -1,0 +1,98 @@
+import unittest
+
+from src.server import _variant_item_placement
+
+
+class PlacedItemStub:
+    """Timeline item that reports its own frame positions.
+
+    record frames come from GetStart/GetEnd/GetDuration; the source frame comes
+    from GetSourceStartFrame (falling back to GetLeftOffset).
+    """
+
+    def __init__(self, start=105, end=165, duration=60, source_start=72):
+        self._start = start
+        self._end = end
+        self._duration = duration
+        self._source_start = source_start
+
+    def GetStart(self):
+        return self._start
+
+    def GetEnd(self):
+        return self._end
+
+    def GetDuration(self):
+        return self._duration
+
+    def GetSourceStartFrame(self):
+        return self._source_start
+
+
+class NoDurationStub(PlacedItemStub):
+    GetDuration = None  # method absent -> duration derived from end - start
+
+
+class LeftOffsetStub:
+    """No GetSourceStartFrame; source frame comes from GetLeftOffset."""
+
+    def __init__(self, start=100, end=160, left_offset=50):
+        self._start = start
+        self._end = end
+        self._left_offset = left_offset
+
+    def GetStart(self):
+        return self._start
+
+    def GetEnd(self):
+        return self._end
+
+    def GetDuration(self):
+        return self._end - self._start
+
+    def GetLeftOffset(self):
+        return self._left_offset
+
+
+class RaisingStub:
+    def GetStart(self):
+        raise RuntimeError("no handle")
+
+    def GetEnd(self):
+        raise RuntimeError("no handle")
+
+
+class VariantItemPlacementTest(unittest.TestCase):
+    def test_reports_frames_from_the_item(self):
+        placed = _variant_item_placement(PlacedItemStub(start=105, end=165, duration=60, source_start=72))
+        self.assertEqual(
+            placed,
+            {"record_start": 105, "record_end": 165, "duration": 60, "source_start": 72},
+        )
+
+    def test_reports_item_duration_that_differs_from_the_span(self):
+        # The item's reported duration is authoritative even when it does not
+        # equal end - start (Resolve may place a clip shorter than the request).
+        placed = _variant_item_placement(PlacedItemStub(start=100, end=250, duration=88))
+        self.assertEqual(placed["duration"], 88)
+
+    def test_derives_duration_when_get_duration_absent(self):
+        placed = _variant_item_placement(NoDurationStub(start=100, end=160))
+        self.assertEqual(placed["duration"], 60)
+
+    def test_falls_back_to_left_offset_for_source_start(self):
+        placed = _variant_item_placement(LeftOffsetStub(left_offset=50))
+        self.assertEqual(placed["source_start"], 50)
+
+    def test_absent_and_failing_readers_yield_none(self):
+        self.assertEqual(
+            _variant_item_placement(object()),
+            {"record_start": None, "record_end": None, "duration": None, "source_start": None},
+        )
+        raising = _variant_item_placement(RaisingStub())
+        self.assertIsNone(raising["record_start"])
+        self.assertIsNone(raising["duration"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #88

A set of fixes and small features found while driving the MCP against DaVinci Resolve Studio. Every new option is opt-in, so default behavior is unchanged.

## Server robustness

- **Transport wedge (fix).** Synchronous tool bodies ran inline on the single asyncio event-loop thread, so a blocking Resolve call, subprocess, or the up-to-60s launch wait froze the whole server — including the stdio read loop — until it returned, requiring a client restart. Tool bodies now run in a worker thread (`anyio.to_thread.run_sync`), serialized on a bridge lock so the single-threaded scripting bridge is never entered concurrently. Best-effort and version-coupled to the SDK's tool shape; degrades to inline behavior if that shape changes.
- **Background jobs for long ops.** Transcription, subtitle generation, scene-cut/Dolby analysis, and timeline export/import can exceed the client's tool-window timeout. Passing `background=true` now returns a `job_id` immediately; poll with `resolve_control(action="job_status", params={"job_id": ...})`. Generic registry in `src/utils/background_jobs.py`; every long op routes through it.

## `timeline.create_variant_from_ranges`

- Reports **actual placement** (`items[].placed`, in both frame spaces) alongside the requested range, plus a `placement_mismatches` count — the response no longer echoes requested numbers as if they were results.
- `dry_run` now resolves clip ids and validates frame ranges, so a passing dry run matches what the real call accepts (and a bad id no longer leaves an orphan timeline).
- `pack=true` butts clips together at the end of each track — gap-free regardless of a source/timeline frame-rate mismatch.
- Reports audio presence and warns when a range list yields a video-only (silent) timeline.
- Corrected help: `clip_id` is a media-pool item id (not a timeline-item id); `start_frame`/`end_frame` are source frames, `end_frame` exclusive.

## Discoverability & error quality

- `timeline set_current` accepts a stable `id`/`name`, not only the shifting 1-based index.
- `timeline get_items` validates its track selector (structured error instead of a bare `KeyError`) and gained an `action_help` entry.
- `timeline apply_cuts` reports `skipped` cuts with reasons instead of silently dropping them.
- `action_help()` returns the full valid-action list and distinguishes an unknown action (`UNKNOWN_ACTION`) from a valid-but-undocumented one (`HELP_NOT_REGISTERED`).
- Docs: clarified `begin_run`/`end_run` batching, the timeline-subtitle vs clip-level transcript distinction, and the source/timeline frame convention.

## Testing

70 new offline unit tests (`tests/test_*.py`, stub-based, no Resolve required); the full offline suite passes. (Two pre-existing loader failures — `test_custom_timeline`, `test_improvements` — are unrelated `import requests` cases, untouched here.) The transport offload, background jobs, and `create_variant_from_ranges` placement/pack behavior were additionally validated live against Resolve Studio 21.
