### PR TITLE
fix(bin): advanced launcher fails on Windows with ERR_UNSUPPORTED_ESM_URL_SCHEME

### DIFF
--- a/bin/davinci-resolve-advanced-mcp.mjs
+++ b/bin/davinci-resolve-advanced-mcp.mjs
@@ -10,11 +10,11 @@
  * the repo root for the published package.)
  */
 
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverEntry = path.resolve(__dirname, '..', 'resolve-advanced', 'server', 'index.mjs');
 
-const { startServer } = await import(serverEntry);
+const { startServer } = await import(pathToFileURL(serverEntry).href);
 await startServer();


### PR DESCRIPTION
## Problem

On Windows, `davinci-resolve-advanced-mcp` crashes at launch, before the MCP server can boot:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

`bin/davinci-resolve-advanced-mcp.mjs` resolves the server entry to an absolute filesystem path and passes it directly to dynamic `import()`:

```js
const serverEntry = path.resolve(__dirname, '..', 'resolve-advanced', 'server', 'index.mjs');
const { startServer } = await import(serverEntry);
```

On macOS/Linux this happens to work because a POSIX absolute path is also a valid URL path. On Windows the resolved path is e.g. `C:\Users\me\...\resolve-advanced\server\index.mjs`; the ESM loader parses that string as a URL, reads the drive letter as the protocol (`c:`), and throws. The launcher is dead on arrival on every Windows install.

## Fix

Convert the path to a `file://` URL with `pathToFileURL()` before importing — the canonical cross-platform way to hand an absolute path to `import()`:

```js
const { startServer } = await import(pathToFileURL(serverEntry).href);
```

No behavior change on macOS/Linux (`pathToFileURL()` yields an equivalent `file://` URL there too), and it also handles paths containing spaces or other special characters correctly on every platform.

## Verification

Windows 11, Node v24.12.0, v2.62.1 checkout:

- Unpatched: the launcher exits immediately with the `ERR_UNSUPPORTED_ESM_URL_SCHEME` error above.
- Patched: the stdio MCP server boots normally and serves tools over a live MCP session.

`node --check` passes on the modified file. This is the only dynamic `import()` call site in the repo that receives an absolute filesystem path — the others use relative or package specifiers and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
