### PR TITLE
fix(graph): SetLUT fails for LUTs installed by the dctl tool (user LUT dir not resolved)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -22070,7 +22070,26 @@ def graph(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
     elif action == "get_lut":
         return {"lut": g.GetLUT(p["node_index"])}
     elif action == "set_lut":
-        return {"success": bool(g.SetLUT(p["node_index"], p["lut_path"]))}
+        node_index = p["node_index"]
+        lut_path = p["lut_path"]
+        ok = bool(g.SetLUT(node_index, lut_path))
+        if not ok:
+            # Resolve resolves LUTs for SetLUT only against the master LUT dir,
+            # not the per-user dir that dctl install writes to. Relocate and retry.
+            relocated = _ensure_lut_in_master(lut_path)
+            if relocated:
+                try:
+                    _, proj, _lut_err = _check()
+                    if proj:
+                        proj.RefreshLUTList()
+                except Exception:
+                    pass
+                ok = bool(g.SetLUT(node_index, relocated))
+                if ok:
+                    return {"success": True, "resolved_lut": relocated,
+                            "note": "LUT copied into the master LUT dir; "
+                                    "SetLUT does not resolve the user LUT dir."}
+        return {"success": ok}
     elif action == "get_node_cache":
         return {"cache": g.GetNodeCacheMode(p["node_index"])}
     elif action == "set_node_cache":
@@ -23769,6 +23788,62 @@ def _dctl_dir(category: str = "lut") -> str:
         return paths["aces_odt_dir"]
     raise ValueError(f"Unknown DCTL category '{category}'. "
                      "Valid: lut, aces_idt, aces_odt")
+
+
+def _master_lut_dir() -> str:
+    """Return Resolve's master (system) LUT directory.
+
+    Resolve's Graph.SetLUT() resolves relative LUT names, and even absolute
+    paths, ONLY against the master LUT root -- NOT the per-user LUT dir that
+    _dctl_dir('lut') / dctl install writes to. Verified live on Resolve Studio
+    21.0.2: SetLUT(1, 'Foo.cube') succeeds when Foo.cube is in the master dir,
+    and returns False for the same file in the user dir or via an absolute
+    user-dir path.
+    """
+    plat = platform.system().lower()
+    if plat == "windows":
+        programdata = os.environ.get("PROGRAMDATA", r"C:\\ProgramData")
+        return os.path.join(programdata, "Blackmagic Design",
+                            "DaVinci Resolve", "Support", "LUT")
+    if plat == "linux":
+        for cand in ("/opt/resolve/LUT", "/home/resolve/LUT"):
+            if os.path.isdir(cand):
+                return cand
+        return "/opt/resolve/LUT"
+    # darwin / default
+    return "/Library/Application Support/Blackmagic Design/DaVinci Resolve/LUT"
+
+
+def _ensure_lut_in_master(lut_path: str) -> Optional[str]:
+    """Make a LUT resolvable by Graph.SetLUT().
+
+    Locates the file named by lut_path (absolute, user LUT dir, or already in
+    the master dir), copies it into the master LUT dir when needed, and returns
+    the basename to hand back to SetLUT. Returns None if the source cannot be
+    found or the master dir is not writable.
+    """
+    master = _master_lut_dir()
+    base = os.path.basename(lut_path)
+    candidates = []
+    if os.path.isabs(lut_path):
+        candidates.append(lut_path)
+    else:
+        try:
+            candidates.append(os.path.join(_dctl_dir("lut"), lut_path))
+        except Exception:
+            pass
+        candidates.append(os.path.join(master, lut_path))
+    src = next((c for c in candidates if os.path.isfile(c)), None)
+    if not src:
+        return None
+    dst = os.path.join(master, base)
+    if os.path.abspath(src) != os.path.abspath(dst):
+        try:
+            os.makedirs(master, exist_ok=True)
+            shutil.copy2(src, dst)
+        except Exception:
+            return None
+    return base
 
 
 def _validate_dctl_name(name: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Problem

`graph set_lut` always returns `{"success": false}` for any LUT or DCTL that was installed via the `dctl` tool, and `get_lut` confirms the node stays empty. This makes it impossible to apply a LUT/DCTL to a node through the API even though `SetCDL` on the same node graph works fine.

## Root cause

`dctl install` (and the `dctl_dir` in `utils/platform.py`) writes LUTs/DCTLs to the **per-user** LUT directory:

- macOS: `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/LUT`

But Resolve's `Graph.SetLUT()` resolves LUT names — and even absolute paths — **only against the master (system) LUT directory**:

- macOS: `/Library/Application Support/Blackmagic Design/DaVinci Resolve/LUT`

So a file the `dctl` tool just installed can never be found by `SetLUT`.

### Verified live (DaVinci Resolve Studio 21.0.2)

```
SetLUT(1, "Foo.cube")               -> True    # Foo.cube in master LUT dir
SetLUT(1, "Foo.cube")               -> False   # same file only in user LUT dir
SetLUT(1, "/abs/user/dir/Foo.cube") -> False   # absolute path to user dir
```

Reproduced with both `.cube` and `.dctl`, relative and absolute paths, node indices 0 and 1.

## Fix

When `SetLUT` fails, locate the LUT (absolute path / user LUT dir / master dir), copy it into the master LUT dir, call `RefreshLUTList()`, and retry with the basename. No behavior change when `SetLUT` already succeeds.

Adds two helpers next to the existing DCTL helpers: `_master_lut_dir()` (per-platform master LUT root) and `_ensure_lut_in_master()`.

### After the fix (same machine, end to end)

```
BEFORE (user dir)  SetLUT = False
AFTER  (relocated) SetLUT = True    GetLUT = 'Foo.cube'
```

## Notes / scope

- Master-dir paths used: macOS `/Library/Application Support/Blackmagic Design/DaVinci Resolve/LUT`; Windows `%PROGRAMDATA%\Blackmagic Design\DaVinci Resolve\Support\LUT`; Linux `/opt/resolve/LUT` (falls back gracefully). Only macOS was verified live.
- Copying into the master dir may require write access to a system directory; on failure the helper returns `None` and the original `False` is surfaced unchanged.
- The granular `graph_set_lut` in `src/granular/graph.py` has the same limitation and could get the same treatment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
