### PR TITLE
Add waveform silence ripple (Resolve Ripple Delete Silence parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## Unreleased
+
+### Added
+
+- **`plan_silence_ripple` / `execute_silence_ripple`** — waveform-driven dead-air
+  removal that mirrors Resolve's *Ripple Delete Silence* dialog (ffmpeg
+  `silencedetect` → keep-range variant assembly). Tunable `threshold_db`,
+  `min_strip_frames`, `pre_head_frames`, and `post_tail_frames`. Original
+  timeline is never mutated; execution is confirm-gated like `execute_tighten`.
+  New module: `src/utils/silence_ripple.py`; tests in
+  `tests/test_silence_ripple.py` and `tests/test_edit_engine.py`.
+
 ## What's New in v2.62.3
 
 A single grading fix (PR #90, by @Mldphotohraphie), extended and hardened. No

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -820,6 +820,14 @@ clip-count readback plus `brain_edits` rationale rows.
   speech-driven cut was previously silent — #67); pass
   `include_audio=false` for a video-only assembly, and the
   `execute_tighten` readback carries an `audio_accounting` block.
+- `plan_silence_ripple(timeline_name?, track_index?, threshold_db?,
+  min_strip_frames?, pre_head_frames?, post_tail_frames?, include_audio?)` —
+  waveform silence strips via ffmpeg `silencedetect`, mirroring Resolve's
+  *Clip → Audio Operations → Ripple Delete Silence* (defaults: −30 dB,
+  10-frame minimum strip, 0 pre-head, 1 post-tail frame). Items without
+  readable file paths land in `skipped`. `execute_silence_ripple(plan_id)`
+  assembles a tightened VARIANT timeline from keep ranges — same safety model
+  as `execute_tighten` (original untouched, confirm token, audio mirroring).
 - `plan_swap(timeline_start_frame | item_name, kind="visual"|"text",
   limit?)` — alternates for one timeline item via the similarity index,
   filtered to shots long enough to fill the slot exactly.

--- a/src/server.py
+++ b/src/server.py
@@ -1045,6 +1045,7 @@ _TOKEN_GATED_DESTRUCTIVE_ACTIONS = frozenset({
     # Phase E edit-engine loops: plan → confirm → execute.
     ("edit_engine", "execute_selects"),
     ("edit_engine", "execute_tighten"),
+    ("edit_engine", "execute_silence_ripple"),
     ("edit_engine", "execute_swap"),
     ("graph", "apply_grade_from_drx"),
     ("graph", "reset_all_grades"),
@@ -18420,6 +18421,12 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
       block and a compact structural_diff (counts + a small sample); the full
       per-item diff is persisted in the plan record (get_plan → execution_summary)
       and returned inline only when include_details=true.
+    - plan_silence_ripple(timeline_name?, track_index?, threshold_db?,
+      min_strip_frames?, pre_head_frames?, post_tail_frames?, include_audio?)
+      — waveform silence strips via ffmpeg silencedetect (Resolve's Ripple Delete
+      Silence parity). Items without readable file paths are skipped.
+    - execute_silence_ripple(plan_id, confirm_token?, include_details?) —
+      same variant assembly as execute_tighten; original timeline untouched.
     - plan_swap(track_index?, timeline_start_frame | item_name, kind?, limit?)
       — alternates for one timeline item via the similarity index.
     - execute_swap(plan_id, alternate_index, confirm_token?) — replaces the
@@ -18491,6 +18498,26 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
             target_ratio=p.get("target_ratio") or p.get("targetRatio"),
             min_pause_seconds=float(p.get("min_pause_seconds") or p.get("minPauseSeconds") or _edit_engine_mod.DEFAULT_MIN_PAUSE_SECONDS),
             handle_seconds=float(p.get("handle_seconds") or p.get("handleSeconds") or _edit_engine_mod.DEFAULT_HANDLE_SECONDS),
+            include_audio=str(p.get("include_audio", p.get("includeAudio", True))).strip().lower() not in {"false", "0", "no", "none", "off"},
+        )
+
+    if action == "plan_silence_ripple":
+        _r, proj, project_root, err = _project_context(need_resolve=True)
+        if err:
+            return err
+        tl = (_find_timeline_by_name(proj, p.get("timeline_name") or p.get("timelineName"))[0] if (p.get("timeline_name") or p.get("timelineName")) else proj.GetCurrentTimeline())
+        if not tl:
+            return _err("Timeline not found")
+        items = _edit_engine_collect_items(tl, track_index=p.get("track_index") or p.get("trackIndex"))
+        return _edit_engine_mod.plan_silence_ripple(
+            project_root,
+            items=items,
+            timeline_name=tl.GetName(),
+            timeline_fps=_edit_engine_timeline_fps(tl),
+            threshold_db=float(p.get("threshold_db") if p.get("threshold_db") is not None else p.get("thresholdDb") if p.get("thresholdDb") is not None else _edit_engine_mod.DEFAULT_SILENCE_THRESHOLD_DB),
+            min_strip_frames=float(p.get("min_strip_frames") if p.get("min_strip_frames") is not None else p.get("minStripFrames") if p.get("minStripFrames") is not None else _edit_engine_mod.DEFAULT_SILENCE_MIN_STRIP_FRAMES),
+            pre_head_frames=float(p.get("pre_head_frames") if p.get("pre_head_frames") is not None else p.get("preHeadFrames") if p.get("preHeadFrames") is not None else _edit_engine_mod.DEFAULT_SILENCE_PRE_HEAD_FRAMES),
+            post_tail_frames=float(p.get("post_tail_frames") if p.get("post_tail_frames") is not None else p.get("postTailFrames") if p.get("postTailFrames") is not None else _edit_engine_mod.DEFAULT_SILENCE_POST_TAIL_FRAMES),
             include_audio=str(p.get("include_audio", p.get("includeAudio", True))).strip().lower() not in {"false", "0", "no", "none", "off"},
         )
 
@@ -18769,6 +18796,141 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
             "plan_id": plan.get("plan_id"),
         }
 
+    if action == "execute_silence_ripple":
+        _r, proj, project_root, err = _project_context(need_resolve=True)
+        if err:
+            return err
+        plan = _edit_engine_mod.load_plan(project_root, str(p.get("plan_id") or p.get("planId") or ""))
+        if not plan or plan.get("_corrupt"):
+            return _err("plan not found (or failed its fingerprint check) — re-plan")
+        if plan.get("kind") != "silence_ripple":
+            return _err(f"plan {plan.get('plan_id')} is a {plan.get('kind')} plan")
+        lifts = plan.get("lifts") or []
+        keep_ranges = plan.get("keep_ranges") or []
+        if not keep_ranges:
+            return _err("plan has no keep_ranges — re-plan with this version")
+        audio_keep_ranges = sum(1 for r in keep_ranges if str(r.get("track_type", "video")).lower() == "audio")
+        video_keep_ranges = len(keep_ranges) - audio_keep_ranges
+        settings = plan.get("settings") or {}
+        if "confirm_token" not in p and "confirmToken" not in p and _confirm_token_required():
+            return _issue_confirm_token(
+                action="edit_engine.execute_silence_ripple", params=p,
+                preview={
+                    "operation": "edit_engine.execute_silence_ripple",
+                    "warning": (
+                        "Assembles a silence-ripple VARIANT timeline from waveform "
+                        "keep ranges; the original timeline is not modified."
+                    ),
+                    "timeline_name": plan.get("timeline_name"),
+                    "lift_count": len(lifts),
+                    "keep_range_count": len(keep_ranges),
+                    "video_keep_range_count": video_keep_ranges,
+                    "audio_keep_range_count": audio_keep_ranges,
+                    "settings": settings,
+                    "estimated_removed_seconds": sum(l.get("duration_seconds") or 0 for l in lifts),
+                },
+            )
+        blocked = _consume_confirm_token(action="edit_engine.execute_silence_ripple", params=p)
+        if blocked:
+            return blocked
+        source_tl, _src_index = _find_timeline_by_name(proj, plan.get("timeline_name"))
+        if not source_tl:
+            return _err(f"Timeline '{plan.get('timeline_name')}' not found")
+        before = _edit_engine_capture(source_tl)
+        variant_name = f"{plan.get('timeline_name')} — silence ripple {time.strftime('%H%M%S')}"
+        variant = _timeline_create_variant_from_ranges(proj, source_tl, {
+            "ranges": keep_ranges,
+            "name": variant_name,
+        })
+        if not variant.get("success"):
+            return {"success": False, "error": f"variant assembly failed: {variant.get('error')}", "variant": variant}
+        new_tl, _new_index = _find_timeline_by_name(proj, variant.get("name") or variant_name)
+        after = _edit_engine_capture(new_tl) if new_tl else {}
+        structural_diff = None
+        if new_tl is not None:
+            try:
+                structural_diff = _timeline_versioning.compare_usage_snapshots(
+                    _timeline_versioning.capture_timeline_clip_usage(source_tl),
+                    _timeline_versioning.capture_timeline_clip_usage(new_tl),
+                )
+            except Exception as diff_exc:
+                structural_diff = {"error": f"{type(diff_exc).__name__}: {diff_exc}"}
+        run_id = _analysis_runs.current_run_id()
+        try:
+            _brain_edits.log_brain_edit(
+                project_root=project_root,
+                analysis_run_id=run_id or "edit-engine",
+                edit_type="edit_engine.silence_ripple_result",
+                tool_name="edit_engine",
+                action_name="execute_silence_ripple",
+                timeline_before=plan.get("timeline_name"),
+                timeline_after=variant.get("name") or variant_name,
+                target_metric=_brain_edits.METRIC_DURATION_SECONDS,
+                metric_direction="decrease",
+                before_value=before.get("duration_seconds"),
+                after_value=after.get("duration_seconds"),
+                rationale=plan.get("summary"),
+                params={"plan_id": plan.get("plan_id"), "settings": settings},
+                result_summary={"keep_ranges": len(keep_ranges), "lifts": len(lifts)},
+            )
+        except Exception:
+            pass
+        include_details = _media_analysis_bool(
+            p.get("include_details", p.get("includeDetails")), False
+        )
+        _edit_engine_mod.mark_plan_executed(project_root, plan["plan_id"], {
+            "variant_timeline": variant.get("name") or variant_name,
+            "keep_ranges": len(keep_ranges),
+            "lifts": len(lifts),
+            "before": before,
+            "after": after,
+            "structural_diff": structural_diff,
+            "settings": settings,
+        })
+        return {
+            "success": True,
+            "original_timeline": plan.get("timeline_name"),
+            "variant_timeline": variant.get("name") or variant_name,
+            "lifts_applied": len(lifts),
+            "keep_ranges": len(keep_ranges),
+            "settings": settings,
+            "lift_rationales": [
+                {"lift": [l["timeline_start_frame"], l["timeline_end_frame"]], "rationale": l.get("rationale")}
+                for l in lifts
+            ],
+            "readback": {
+                "before": before,
+                "after": after,
+                "removed_seconds": (
+                    round(before["duration_seconds"] - after["duration_seconds"], 2)
+                    if before.get("duration_seconds") is not None and after.get("duration_seconds") is not None
+                    else None
+                ),
+                "structural_diff": (
+                    structural_diff if include_details
+                    else _compact_structural_diff(structural_diff)
+                ),
+                "audio_accounting": {
+                    "planned_audio_ranges": audio_keep_ranges,
+                    "planned_video_ranges": video_keep_ranges,
+                    "variant_audio_items": sum(
+                        1 for it in (variant.get("items") or [])
+                        if (it.get("range") or {}).get("media_type") == 2
+                    ),
+                    "variant_video_items": sum(
+                        1 for it in (variant.get("items") or [])
+                        if (it.get("range") or {}).get("media_type") == 1
+                    ),
+                    "note": (
+                        "Variant carries audio mirrored from the video cuts."
+                        if audio_keep_ranges
+                        else "Variant is VIDEO-ONLY (silent) — re-plan with include_audio=True for sound."
+                    ),
+                },
+            },
+            "plan_id": plan.get("plan_id"),
+        }
+
     if action == "execute_swap":
         _r, proj, project_root, err = _project_context(need_resolve=True)
         if err:
@@ -18930,6 +19092,8 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
         "execute_selects",
         "plan_tighten",
         "execute_tighten",
+        "plan_silence_ripple",
+        "execute_silence_ripple",
         "plan_swap",
         "execute_swap",
         "list_plans",

--- a/src/utils/destructive_hook.py
+++ b/src/utils/destructive_hook.py
@@ -70,6 +70,7 @@ DESTRUCTIVE_ACTIONS_BY_TOOL: Dict[str, FrozenSet[str]] = {
     "edit_engine": frozenset({
         "execute_selects",
         "execute_tighten",
+        "execute_silence_ripple",
         "execute_swap",
     }),
     "timeline": frozenset({

--- a/src/utils/edit_engine.py
+++ b/src/utils/edit_engine.py
@@ -31,10 +31,15 @@ import uuid
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from src.utils import analysis_memory, analysis_store, timeline_brain_db
+from src.utils import silence_ripple as _silence_ripple_mod
 
 PLAN_DIR_NAME = "edit_plans"
 DEFAULT_HANDLE_SECONDS = 0.25
 DEFAULT_MIN_PAUSE_SECONDS = 1.5
+DEFAULT_SILENCE_THRESHOLD_DB = _silence_ripple_mod.DEFAULT_THRESHOLD_DB
+DEFAULT_SILENCE_MIN_STRIP_FRAMES = _silence_ripple_mod.DEFAULT_MIN_STRIP_FRAMES
+DEFAULT_SILENCE_PRE_HEAD_FRAMES = _silence_ripple_mod.DEFAULT_PRE_HEAD_FRAMES
+DEFAULT_SILENCE_POST_TAIL_FRAMES = _silence_ripple_mod.DEFAULT_POST_TAIL_FRAMES
 
 _SELECT_RANK = {"high": 3, "medium": 2, "low": 1}
 
@@ -589,6 +594,224 @@ def plan_tighten(
                 if include_audio
                 else "include_audio=False: the variant will be VIDEO-ONLY (silent)."
             )
+        ),
+    }
+
+
+# ── E2b: waveform silence ripple (Resolve UI parity) ─────────────────────────
+
+
+def _resolve_media_path(conn, item: Dict[str, Any]) -> Optional[str]:
+    path = item.get("media_path") or item.get("file_path")
+    if path and os.path.isfile(str(path)):
+        return str(path)
+    clip_uuid = analysis_store.resolve_clip_uuid(conn, item.get("media_ref"))
+    if not clip_uuid:
+        clip_uuid = analysis_store.resolve_clip_uuid(conn, item.get("media_path"))
+    if not clip_uuid:
+        return None
+    row = conn.execute("SELECT file_path FROM clips WHERE clip_uuid = ?", (clip_uuid,)).fetchone()
+    if not row or not row["file_path"]:
+        return None
+    fp = str(row["file_path"])
+    return fp if os.path.isfile(fp) else None
+
+
+def plan_silence_ripple(
+    project_root: str,
+    *,
+    items: Sequence[Dict[str, Any]],
+    timeline_name: str,
+    timeline_fps: float,
+    threshold_db: float = DEFAULT_SILENCE_THRESHOLD_DB,
+    min_strip_frames: float = DEFAULT_SILENCE_MIN_STRIP_FRAMES,
+    pre_head_frames: float = DEFAULT_SILENCE_PRE_HEAD_FRAMES,
+    post_tail_frames: float = DEFAULT_SILENCE_POST_TAIL_FRAMES,
+    include_audio: bool = True,
+) -> Dict[str, Any]:
+    """Propose silence strips from waveform detection (ffmpeg silencedetect).
+
+    Mirrors Resolve's *Clip → Audio Operations → Ripple Delete Silence*.
+    Each timeline item is analyzed over its source trim; detected silences
+    become lifts assembled into a tightened VARIANT via keep_ranges.
+    """
+    if not items:
+        return {"success": False, "error": "No timeline items supplied"}
+    fps = float(timeline_fps) if timeline_fps and float(timeline_fps) > 0 else 24.0
+    min_strip_sec = _silence_ripple_mod.frames_to_seconds(min_strip_frames, fps)
+    pre_head_sec = _silence_ripple_mod.frames_to_seconds(pre_head_frames, fps)
+    post_tail_sec = _silence_ripple_mod.frames_to_seconds(post_tail_frames, fps)
+    conn = timeline_brain_db.connect(project_root)
+
+    lifts: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+    item_specs: List[Dict[str, Any]] = []
+    timeline_total_frames = 0
+
+    for item_index, item in enumerate(items):
+        try:
+            tl_start = int(item["timeline_start_frame"])
+            tl_end = int(item["timeline_end_frame"])
+            src_start_frame = int(item.get("source_start_frame") or 0)
+        except (KeyError, TypeError, ValueError):
+            skipped.append({"item": item.get("item_name"), "reason": "missing frame fields"})
+            continue
+        timeline_total_frames += max(0, tl_end - tl_start)
+        media_path = _resolve_media_path(conn, item)
+        if not media_path:
+            skipped.append({"item": item.get("item_name"), "reason": "no readable media file path"})
+            item_specs.append({"item_index": item_index, "missing_path": True, "item": item})
+            continue
+
+        clip_uuid = analysis_store.resolve_clip_uuid(conn, item.get("media_ref"))
+        clip_row = None
+        clip_fps = fps
+        resolve_clip_id = None
+        if clip_uuid:
+            clip_row = conn.execute("SELECT * FROM clips WHERE clip_uuid = ?", (clip_uuid,)).fetchone()
+            if clip_row:
+                clip_fps = _clip_fps(dict(clip_row))
+                resolve_clip_id = dict(clip_row).get("resolve_clip_id")
+
+        src_start_sec = src_start_frame / clip_fps
+        src_end_sec = src_start_sec + (tl_end - tl_start) / fps
+        strip_regions, keep_segments = _silence_ripple_mod.plan_item_silence_strips(
+            media_path,
+            src_start_sec,
+            src_end_sec,
+            threshold_db=float(threshold_db),
+            min_strip_sec=min_strip_sec,
+            pre_head_sec=pre_head_sec,
+            post_tail_sec=post_tail_sec,
+        )
+
+        spec = {
+            "item_index": item_index,
+            "item": item,
+            "clip_uuid": clip_uuid,
+            "clip_fps": clip_fps,
+            "resolve_clip_id": resolve_clip_id or item.get("media_ref"),
+            "src_start_sec": src_start_sec,
+            "src_end_sec": src_end_sec,
+            "keep_segments": keep_segments,
+            "strip_regions": strip_regions,
+        }
+        item_specs.append(spec)
+
+        for strip_start, strip_end in strip_regions:
+            lift_start = tl_start + int(round((strip_start - src_start_sec) * fps))
+            lift_end = tl_start + int(round((strip_end - src_start_sec) * fps))
+            if lift_end <= lift_start:
+                continue
+            lifts.append({
+                "kind": "silence",
+                "action": "ripple_delete",
+                "timeline_start_frame": lift_start,
+                "timeline_end_frame": lift_end,
+                "duration_seconds": round((lift_end - lift_start) / fps, 3),
+                "item_name": item.get("item_name"),
+                "item_index": item_index,
+                "source_lift_seconds": [round(strip_start, 3), round(strip_end, 3)],
+                "rationale": (
+                    f"Waveform silence {round(strip_start, 2)}s–{round(strip_end, 2)}s "
+                    f"(threshold {threshold_db} dB, min {min_strip_frames} frames)."
+                ),
+                "evidence": {
+                    "basis": "ffmpeg_silencedetect",
+                    "threshold_db": threshold_db,
+                    "source_gap_seconds": [round(strip_start, 3), round(strip_end, 3)],
+                },
+            })
+
+    skipped = _dedupe_skipped(skipped)
+    if not lifts:
+        return {
+            "success": False,
+            "error": "No silence regions found above threshold",
+            "skipped": skipped,
+            "note": (
+                f"threshold_db={threshold_db}, min_strip_frames={min_strip_frames}; "
+                "items without readable file paths are skipped."
+            ),
+        }
+
+    lifts.sort(key=lambda l: -l["timeline_start_frame"])
+
+    keep_ranges: List[Dict[str, Any]] = []
+    for spec in item_specs:
+        if spec.get("missing_path") or not spec.get("resolve_clip_id"):
+            continue
+        item = spec["item"]
+        clip_fps = spec["clip_fps"]
+        audio_indices: List[int] = []
+        if include_audio:
+            audio_indices = [int(i) for i in (item.get("audio_track_indices") or []) if int(i) > 0]
+            if not audio_indices:
+                audio_indices = [1]
+        for seg_start, seg_end in spec.get("keep_segments") or []:
+            start_frame = int(round(seg_start * clip_fps))
+            end_frame = max(start_frame + 1, int(round(seg_end * clip_fps)))
+            keep_ranges.append({
+                "clip_id": spec["resolve_clip_id"],
+                "start_frame": start_frame,
+                "end_frame": end_frame,
+                "track_type": "video",
+                "track_index": int(item.get("track_index") or 1),
+            })
+            for audio_index in audio_indices:
+                keep_ranges.append({
+                    "clip_id": spec["resolve_clip_id"],
+                    "start_frame": start_frame,
+                    "end_frame": end_frame,
+                    "track_type": "audio",
+                    "media_type": 2,
+                    "track_index": audio_index,
+                })
+
+    removed_frames = sum(l["timeline_end_frame"] - l["timeline_start_frame"] for l in lifts)
+    audio_keep_range_count = sum(1 for r in keep_ranges if r.get("track_type") == "audio")
+    video_keep_range_count = len(keep_ranges) - audio_keep_range_count
+    plan = save_plan(project_root, {
+        "kind": "silence_ripple",
+        "timeline_name": timeline_name,
+        "timeline_fps": fps,
+        "lifts": lifts,
+        "keep_ranges": keep_ranges,
+        "include_audio": bool(include_audio),
+        "skipped": skipped,
+        "summary": (
+            f"{len(lifts)} silence strips, ~{round(removed_frames / fps, 1)}s removed "
+            f"from '{timeline_name}' (waveform ripple-delete variant"
+            f"{', video + audio' if include_audio else ', video only'})"
+        ),
+        "settings": {
+            "threshold_db": threshold_db,
+            "min_strip_frames": min_strip_frames,
+            "pre_head_frames": pre_head_frames,
+            "post_tail_frames": post_tail_frames,
+            "include_audio": bool(include_audio),
+        },
+    })
+    return {
+        "success": True,
+        "status": "plan_ready",
+        "plan_id": plan["plan_id"],
+        "kind": "silence_ripple",
+        "timeline_name": timeline_name,
+        "lift_count": len(lifts),
+        "estimated_removed_seconds": round(removed_frames / fps, 2),
+        "lifts": lifts,
+        "keep_range_count": len(keep_ranges),
+        "video_keep_range_count": video_keep_range_count,
+        "audio_keep_range_count": audio_keep_range_count,
+        "include_audio": bool(include_audio),
+        "skipped": skipped,
+        "note": (
+            "Dry-run plan. Execute with edit_engine(action='execute_silence_ripple', "
+            "params={plan_id}) — a tightened VARIANT timeline is assembled from "
+            "waveform silence detection; the original timeline is never mutated. "
+            "Tune threshold_db / min_strip_frames to match Resolve's "
+            "Ripple Delete Silence dialog."
         ),
     }
 

--- a/src/utils/silence_ripple.py
+++ b/src/utils/silence_ripple.py
@@ -1,0 +1,144 @@
+"""Waveform silence detection for ripple-delete planning.
+
+Resolve exposes **Clip → Audio Operations → Ripple Delete Silence** in the UI
+but not via scripting. This module approximates that workflow using ffmpeg
+``silencedetect`` plus the edit-engine keep-range assembler (variant timeline).
+
+Settings map to the Resolve dialog:
+  - threshold_db     → Threshold (dB)
+  - min_strip_frames → Minimum strip length (frames)
+  - pre_head_frames  → Pre-head (frames kept before silence)
+  - post_tail_frames → Post-tail (frames kept after silence ends)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from src.utils.media_analysis import _parse_silencedetect
+
+DEFAULT_THRESHOLD_DB = -30.0
+DEFAULT_MIN_STRIP_FRAMES = 10
+DEFAULT_PRE_HEAD_FRAMES = 0
+DEFAULT_POST_TAIL_FRAMES = 1
+
+
+def frames_to_seconds(frames: float, fps: float) -> float:
+    if fps <= 0:
+        fps = 24.0
+    return float(frames) / fps
+
+
+def detect_silence_in_range(
+    media_path: str,
+    start_sec: float,
+    end_sec: float,
+    *,
+    threshold_db: float = DEFAULT_THRESHOLD_DB,
+    min_duration_sec: float,
+) -> List[Tuple[float, float]]:
+    """Return absolute-file silence intervals within [start_sec, end_sec).
+
+    Uses ffmpeg silencedetect on the trimmed slice. Timestamps are converted
+    back to absolute source-file seconds.
+    """
+    if not media_path or not os.path.isfile(media_path):
+        return []
+    if end_sec <= start_sec:
+        return []
+    duration = end_sec - start_sec
+    audio_filter = f"silencedetect=noise={threshold_db}dB:d={min_duration_sec}"
+    from src.utils.media_analysis import _run_command
+
+    args = [
+        "ffmpeg", "-hide_banner", "-nostats",
+        "-ss", str(start_sec),
+        "-i", media_path,
+        "-t", str(duration),
+        "-af", audio_filter,
+        "-f", "null", "-",
+    ]
+    code, _, stderr = _run_command(args)
+    if code != 0:
+        return []
+    parsed = _parse_silencedetect(stderr)
+    out: List[Tuple[float, float]] = []
+    for row in parsed:
+        rel_start = row.get("start")
+        rel_end = row.get("end")
+        if rel_start is None:
+            continue
+        abs_start = start_sec + float(rel_start)
+        abs_end = start_sec + float(rel_end) if rel_end is not None else end_sec
+        abs_end = min(abs_end, end_sec)
+        if abs_end - abs_start >= min_duration_sec * 0.9:
+            out.append((abs_start, abs_end))
+    return out
+
+
+def apply_silence_handles(
+    silences: Sequence[Tuple[float, float]],
+    *,
+    pre_head_sec: float,
+    post_tail_sec: float,
+    range_start: float,
+    range_end: float,
+) -> List[Tuple[float, float]]:
+    """Expand/shrink silence regions per Resolve pre-head / post-tail handles."""
+    strip: List[Tuple[float, float]] = []
+    for s, e in silences:
+        s = max(range_start, s + pre_head_sec)
+        e = min(range_end, e - post_tail_sec)
+        if e > s + 0.001:
+            strip.append((s, e))
+    return strip
+
+
+def silence_to_keep_segments(
+    range_start: float,
+    range_end: float,
+    strip_regions: Sequence[Tuple[float, float]],
+    *,
+    min_keep_sec: float = 0.05,
+) -> List[Tuple[float, float]]:
+    """Complement of strip regions → speech/keep segments in source time."""
+    segments: List[Tuple[float, float]] = []
+    cursor = range_start
+    for s, e in sorted(strip_regions):
+        s, e = max(s, range_start), min(e, range_end)
+        if s - cursor >= min_keep_sec:
+            segments.append((cursor, s))
+        cursor = max(cursor, e)
+    if range_end - cursor >= min_keep_sec:
+        segments.append((cursor, range_end))
+    return segments
+
+
+def plan_item_silence_strips(
+    media_path: str,
+    src_start_sec: float,
+    src_end_sec: float,
+    *,
+    threshold_db: float,
+    min_strip_sec: float,
+    pre_head_sec: float,
+    post_tail_sec: float,
+) -> Tuple[List[Tuple[float, float]], List[Tuple[float, float]]]:
+    """Detect silences and return (strip_regions, keep_segments) in source seconds."""
+    raw = detect_silence_in_range(
+        media_path,
+        src_start_sec,
+        src_end_sec,
+        threshold_db=threshold_db,
+        min_duration_sec=min_strip_sec,
+    )
+    strip = apply_silence_handles(
+        raw,
+        pre_head_sec=pre_head_sec,
+        post_tail_sec=post_tail_sec,
+        range_start=src_start_sec,
+        range_end=src_end_sec,
+    )
+    keep = silence_to_keep_segments(src_start_sec, src_end_sec, strip)
+    return strip, keep

--- a/tests/test_edit_engine.py
+++ b/tests/test_edit_engine.py
@@ -305,6 +305,71 @@ class PlanTightenTests(EditEngineBase):
         self.assertFalse(plan["include_audio"])
 
 
+class PlanSilenceRippleTests(EditEngineBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.clip = self._ingest_deep_clip(
+            clip_id="resolve-clip-s", name="Talk.mp4", path="/media/talk.mp4", clip_dir="s-ssssssssssss",
+            shots=[deep_shot(1, 0.0, 20.0, "medium", "Single take.")],
+        )
+
+    def _item(self, **overrides) -> dict:
+        item = {
+            "timeline_start_frame": 0,
+            "timeline_end_frame": 480,
+            "source_start_frame": 0,
+            "media_ref": "resolve-clip-s",
+            "item_name": "Talk.mp4",
+            "track_index": 1,
+        }
+        item.update(overrides)
+        return item
+
+    def test_plan_proposes_waveform_lifts(self) -> None:
+        from unittest import mock
+
+        strip = [(9.5, 19.75)]
+        keep = [(0.0, 9.5), (19.75, 20.0)]
+        with mock.patch.object(edit_engine, "_resolve_media_path", return_value="/media/talk.mp4"), \
+             mock.patch.object(edit_engine._silence_ripple_mod, "plan_item_silence_strips", return_value=(strip, keep)):
+            plan = edit_engine.plan_silence_ripple(
+                self.root, items=[self._item()], timeline_name="TL", timeline_fps=24.0
+            )
+        self.assertTrue(plan["success"], plan)
+        self.assertEqual(plan["kind"], "silence_ripple")
+        self.assertEqual(plan["lift_count"], 1)
+        lift = plan["lifts"][0]
+        self.assertEqual(lift["evidence"]["basis"], "ffmpeg_silencedetect")
+        self.assertEqual(lift["timeline_start_frame"], 228)
+        self.assertEqual(lift["timeline_end_frame"], 474)
+
+    def test_keep_ranges_half_open_with_audio(self) -> None:
+        from unittest import mock
+
+        strip = [(9.5, 19.75)]
+        keep = [(0.0, 9.5), (19.75, 20.0)]
+        with mock.patch.object(edit_engine, "_resolve_media_path", return_value="/media/talk.mp4"), \
+             mock.patch.object(edit_engine._silence_ripple_mod, "plan_item_silence_strips", return_value=(strip, keep)):
+            plan = edit_engine.plan_silence_ripple(
+                self.root, items=[self._item()], timeline_name="TL", timeline_fps=24.0
+            )
+        loaded = edit_engine.load_plan(self.root, plan["plan_id"])
+        video = [r for r in loaded["keep_ranges"] if r["track_type"] == "video"]
+        audio = [r for r in loaded["keep_ranges"] if r["track_type"] == "audio"]
+        self.assertEqual(len(audio), len(video))
+        ranges = sorted((r["start_frame"], r["end_frame"]) for r in video)
+        self.assertEqual(ranges, [(0, 228), (474, 480)])
+
+    def test_missing_media_path_skipped(self) -> None:
+        plan = edit_engine.plan_silence_ripple(
+            self.root,
+            items=[self._item(media_ref="missing-clip", item_name="Mystery.mp4")],
+            timeline_name="TL", timeline_fps=24.0,
+        )
+        self.assertFalse(plan["success"])
+        self.assertIn("skipped", plan)
+
+
 class PlanSwapTests(EditEngineBase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/test_silence_ripple.py
+++ b/tests/test_silence_ripple.py
@@ -1,0 +1,35 @@
+"""Unit tests for src/utils/silence_ripple.py (waveform ripple-delete helpers)."""
+
+from __future__ import annotations
+
+import unittest
+
+from src.utils import silence_ripple
+
+
+class SilenceRippleLogicTests(unittest.TestCase):
+    def test_apply_handles_shrink_strip_region(self) -> None:
+        silences = [(10.0, 12.0)]
+        strip = silence_ripple.apply_silence_handles(
+            silences,
+            pre_head_sec=0.0,
+            post_tail_sec=1 / 30.0,
+            range_start=0.0,
+            range_end=20.0,
+        )
+        self.assertEqual(len(strip), 1)
+        self.assertAlmostEqual(strip[0][0], 10.0)
+        self.assertAlmostEqual(strip[0][1], 12.0 - 1 / 30.0, places=5)
+
+    def test_silence_to_keep_segments(self) -> None:
+        keep = silence_ripple.silence_to_keep_segments(
+            0.0, 20.0, [(9.5, 19.75)], min_keep_sec=0.05
+        )
+        self.assertEqual(keep, [(0.0, 9.5), (19.75, 20.0)])
+
+    def test_frames_to_seconds(self) -> None:
+        self.assertAlmostEqual(silence_ripple.frames_to_seconds(10, 30.0), 1 / 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `plan_silence_ripple` / `execute_silence_ripple` to the edit engine — waveform dead-air removal via ffmpeg `silencedetect`, mirroring Resolve's **Clip → Audio Operations → Ripple Delete Silence** dialog.
- Defaults match common Resolve settings: **−30 dB** threshold, **10-frame** minimum strip, **0** pre-head, **1** post-tail frame. Tunable via params.
- Execution assembles a **variant timeline** from keep ranges (same safety model as `execute_tighten`: original untouched, confirm-gated, audio mirroring).

## Motivation
Resolve exposes Ripple Delete Silence in the UI but not via scripting. Transcript-based `plan_tighten` targets a different signal (speech gaps) and can cut mid-word when transcripts disagree with waveform pauses. This gives agents a safe, waveform-driven alternative.

## Test plan
- [x] `python -m unittest tests.test_silence_ripple tests.test_edit_engine.PlanSilenceRippleTests`
- [ ] Live: `plan_silence_ripple` on a talking-head A-roll track; compare duration/lifts to manual Ripple Delete Silence
- [ ] Live: `execute_silence_ripple` → verify variant is shorter, audible, no mid-word cuts

## Notes for adopters
- Requires readable **file paths** on timeline items (items without paths are skipped, not silently trimmed).
- Tune `threshold_db` / `min_strip_frames` per voice room tone — same as the Resolve dialog.
- Slides/overlays on other tracks are **not** re-timed; run silence ripple on the base A-roll first, then re-place B-roll.