### PR TITLE
Support Resolve network scripting connections

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -14,8 +14,14 @@ session — projects, timelines, clips, color grading, Fusion compositions, audi
 render queues, and more — through natural language.
 
 DaVinci Resolve must be running with **Preferences > General > "External scripting
-using"** set to **Local**. The server auto-launches Resolve if it is not running,
-but that first connection can take up to 60 seconds.
+using"** set to **Local**, or set to **Network** with `RESOLVE_SCRIPT_HOST`
+configured to the Resolve host IP (use `127.0.0.1` on the same machine). The
+server auto-launches Resolve if it is not running, but that first connection can
+take up to 60 seconds.
+
+Network scripting permits remote control of Resolve. Use Local mode when remote
+access is unnecessary; otherwise restrict access with host firewall and network
+controls.
 
 **Session-start update note.** The first `resolve_control(action="get_version")`
 of a session returns an `mcp` block with the cached update check

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,9 @@ This guide covers Resolve requirements, the universal installer, supported MCP c
 - **DaVinci Resolve Studio** 18.5+ (macOS, Windows, or Linux) — the free edition does not support external scripting
 - **Python 3.10+** (the MCP SDK requires 3.10). **3.10–3.12 is the lowest-risk
   choice**; 3.13/3.14 also work on recent Resolve builds — see below
-- DaVinci Resolve running with **Preferences > General > "External scripting using"** set to **Local**
+- DaVinci Resolve running with **Preferences > General > "External scripting using"**
+  set to **Local**, or **Network** with `RESOLVE_SCRIPT_HOST` set to the Resolve
+  host IP (`127.0.0.1` when Resolve and the MCP run on the same machine)
 
 > **Python 3.13 / 3.14:** these are **allowed** — setup will use them and warn.
 > Python 3.14 is verified working against DaVinci Resolve Studio 20.3.2. On
@@ -169,6 +171,26 @@ If you prefer to set things up yourself, add to your MCP client config:
 ```
 
 On Windows, installer-generated configs also include `PYTHONHOME`. That scopes Resolve's Python binding to the selected interpreter and avoids the Resolve 20.3 multi-Python crash reported in [Issue #26](https://github.com/samuelgursky/davinci-resolve-mcp/issues/26).
+
+For Resolve's **Network** scripting mode, add
+`"RESOLVE_SCRIPT_HOST": "127.0.0.1"` to the `env` object above, replacing the
+address when Resolve runs on another host. When this variable is present, the
+server uses Resolve's explicit IP-targeted `scriptapp` call with a bounded
+connection timeout. Set `RESOLVE_SCRIPT_TIMEOUT` to override the default
+five-second timeout with a positive finite number of seconds. The installer
+includes both values in generated client configs when they are present in its
+environment.
+
+Network scripting permits remote control of Resolve. Prefer Local mode when
+remote access is unnecessary; otherwise restrict access with host firewall and
+network controls.
+
+Run the read-only doctor against Network mode explicitly:
+
+```bash
+python3 scripts/doctor.py --resolve-host 127.0.0.1
+python3 scripts/doctor.py --resolve-host resolve.example.test --resolve-timeout 12.5
+```
 
 When the compound server is running, `resolve_control(action="get_version")`
 includes the local MCP version, the last update-check status, and the current

--- a/install.py
+++ b/install.py
@@ -474,6 +474,13 @@ def build_server_env(python_path, api_path, lib_path, system=SYSTEM, python_home
     if system == "Windows":
         env["PYTHONHOME"] = str(python_home or get_python_base_install(python_path))
 
+    host = os.environ.get("RESOLVE_SCRIPT_HOST")
+    if host:
+        env["RESOLVE_SCRIPT_HOST"] = host
+        timeout = os.environ.get("RESOLVE_SCRIPT_TIMEOUT")
+        if timeout:
+            env["RESOLVE_SCRIPT_TIMEOUT"] = timeout
+
     return env
 
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -7,16 +7,19 @@ mutating anything. Prints OK/WARN/FAIL lines (or JSON with --json) and exits
 nonzero only when a FAIL is present.
 
 Run: `python3 scripts/doctor.py`
+Network mode: `python3 scripts/doctor.py --resolve-host 127.0.0.1`
 
 Overridable via environment: DAVINCI_MCP_REPO, DAVINCI_MCP_PYTHON,
 CODEX_HOME, CLAUDE_DESKTOP_CONFIG, RESOLVE_APP, RESOLVE_SCRIPT_API,
-RESOLVE_SCRIPT_MODULES, RESOLVE_SCRIPT_LIB.
+RESOLVE_SCRIPT_MODULES, RESOLVE_SCRIPT_LIB, RESOLVE_SCRIPT_HOST,
+RESOLVE_SCRIPT_TIMEOUT.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import subprocess
@@ -128,26 +131,41 @@ def git_head() -> str:
     return head["stdout"] or head["stderr"] or "git describe produced no output"
 
 
-def resolve_probe() -> dict[str, Any]:
+def resolve_probe(
+    resolve_host: str | None = None,
+    resolve_timeout: float | None = None,
+) -> dict[str, Any]:
     if not PYTHON.exists():
         return {"import_ok": False, "error": f"{PYTHON} is missing"}
 
     code = f"""
 import json
 import sys
+sys.path.insert(0, {str(REPO)!r})
 sys.path.insert(0, {str(RESOLVE_MODULES)!r})
 try:
     import DaVinciResolveScript as dvr
-    resolve = dvr.scriptapp("Resolve")
-    payload = {{
-        "import_ok": True,
-        "module": getattr(dvr, "__file__", None),
-        "resolve_connected": bool(resolve),
-        "product": resolve.GetProductName() if resolve else None,
-        "version": resolve.GetVersionString() if resolve else None,
-    }}
+    from src.utils.resolve_connection import connect_resolve
 except Exception as exc:
     payload = {{"import_ok": False, "error": repr(exc)}}
+else:
+    try:
+        resolve = connect_resolve(dvr)
+    except Exception as exc:
+        payload = {{
+            "import_ok": True,
+            "module": getattr(dvr, "__file__", None),
+            "resolve_connected": False,
+            "connection_error": repr(exc),
+        }}
+    else:
+        payload = {{
+            "import_ok": True,
+            "module": getattr(dvr, "__file__", None),
+            "resolve_connected": bool(resolve),
+            "product": resolve.GetProductName() if resolve else None,
+            "version": resolve.GetVersionString() if resolve else None,
+        }}
 print(json.dumps(payload))
 """
     env = {
@@ -156,7 +174,26 @@ print(json.dumps(payload))
         "RESOLVE_SCRIPT_LIB": str(RESOLVE_LIB),
         "PYTHONPATH": str(RESOLVE_MODULES),
     }
-    proc = subprocess.run([str(PYTHON), "-c", code], capture_output=True, text=True, timeout=12, env=env)
+    if resolve_host is not None:
+        env["RESOLVE_SCRIPT_HOST"] = resolve_host
+    if resolve_timeout is not None:
+        env["RESOLVE_SCRIPT_TIMEOUT"] = str(resolve_timeout)
+    process_timeout = 12.0
+    configured_timeout = env.get("RESOLVE_SCRIPT_TIMEOUT")
+    if configured_timeout:
+        try:
+            network_timeout = float(configured_timeout)
+            if math.isfinite(network_timeout) and network_timeout > 0:
+                process_timeout = max(process_timeout, network_timeout + 2)
+        except ValueError:
+            pass
+    proc = subprocess.run(
+        [str(PYTHON), "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=process_timeout,
+        env=env,
+    )
     output = (proc.stdout or proc.stderr).strip()
     try:
         payload = json.loads(output)
@@ -166,7 +203,10 @@ print(json.dumps(payload))
     return payload
 
 
-def collect() -> list[dict[str, str]]:
+def collect(
+    resolve_host: str | None = None,
+    resolve_timeout: float | None = None,
+) -> list[dict[str, str]]:
     results: list[dict[str, str]] = []
 
     check(results, "OK" if REPO.exists() else "FAIL", "MCP checkout", str(REPO))
@@ -186,18 +226,27 @@ def collect() -> list[dict[str, str]]:
     pyver = run([str(PYTHON), "--version"]) if PYTHON.exists() else {"ok": False, "stdout": "", "stderr": "missing"}
     check(results, "OK" if pyver["ok"] else "FAIL", "Python version", pyver["stdout"] or pyver["stderr"])
 
-    probe = resolve_probe()
+    probe = resolve_probe(resolve_host, resolve_timeout)
     if probe.get("import_ok"):
         check(results, "OK", "DaVinciResolveScript import", str(probe.get("module")))
         if probe.get("resolve_connected"):
             detail = f"{probe.get('product')} {probe.get('version')}"
             check(results, "OK", "Resolve scripting connection", detail)
+        elif probe.get("connection_error"):
+            check(
+                results,
+                "FAIL",
+                "Resolve scripting connection",
+                str(probe["connection_error"]),
+            )
         else:
             check(
                 results,
                 "WARN",
                 "Resolve scripting connection",
-                'Module import worked, but scriptapp("Resolve") returned no object. Open DaVinci Resolve Studio, set Preferences > General > External scripting using = Local, and restart Resolve.',
+                "Module import worked, but scriptapp returned no object. Use "
+                "External scripting = Local, or Network with --resolve-host "
+                "set to the Resolve host IP, then restart Resolve.",
             )
     else:
         check(results, "FAIL", "DaVinciResolveScript import", str(probe.get("error")))
@@ -211,9 +260,18 @@ def collect() -> list[dict[str, str]]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument(
+        "--resolve-host",
+        help="Resolve host IP for Network scripting mode",
+    )
+    parser.add_argument(
+        "--resolve-timeout",
+        type=float,
+        help="Network connection timeout in seconds (default: 5)",
+    )
     args = parser.parse_args()
 
-    results = collect()
+    results = collect(args.resolve_host, args.resolve_timeout)
     if args.json:
         print(json.dumps({"checks": results}, indent=2))
     else:

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -44,6 +44,7 @@ from src.utils.layout_presets import (
 )
 from src.utils.object_inspection import inspect_object, print_object_help
 from src.utils.platform import get_platform, get_resolve_paths
+from src.utils.resolve_connection import connect_resolve
 from src.utils.project_properties import (
     get_all_project_properties,
     get_color_settings,
@@ -233,7 +234,7 @@ dvr_script = None
 try:
     import DaVinciResolveScript as dvr_script  # type: ignore
 
-    resolve = dvr_script.scriptapp("Resolve")
+    resolve = connect_resolve(dvr_script)
     if resolve:
         logger.info(
             f"Connected to DaVinci Resolve: {resolve.GetProductName()} {resolve.GetVersionString()}"
@@ -311,7 +312,7 @@ def _try_connect():
     """Attempt to connect to Resolve once. Returns resolve object or None."""
     global resolve
     try:
-        candidate = dvr_script.scriptapp("Resolve")
+        candidate = connect_resolve(dvr_script)
         if candidate and _is_resolve_handle_live(candidate):
             resolve = candidate
             logger.info(f"Connected: {resolve.GetProductName()} {resolve.GetVersionString()}")

--- a/src/server.py
+++ b/src/server.py
@@ -97,6 +97,7 @@ from src.utils.media_analysis_jobs import (
     run_batch_job_slice as run_media_analysis_batch_job_slice,
 )
 from src.utils.platform import get_resolve_paths, get_resolve_plugin_paths
+from src.utils.resolve_connection import connect_resolve
 from src.utils.lut_paths import master_lut_dir, ensure_lut_in_master
 from src.utils import fuse_templates, dctl_templates, script_templates
 from src.utils.timeline_title_text import (
@@ -804,7 +805,7 @@ def _try_connect():
         if dvr_script is None:
             return None
         try:
-            candidate = dvr_script.scriptapp("Resolve")
+            candidate = connect_resolve(dvr_script)
             if candidate and _is_resolve_handle_live(candidate):
                 resolve = candidate
                 logger.info(f"Connected: {resolve.GetProductName()} {resolve.GetVersionString()}")

--- a/src/utils/resolve_connection.py
+++ b/src/utils/resolve_connection.py
@@ -3,35 +3,66 @@
 DaVinci Resolve Connection Utilities
 """
 
-import os
 import logging
+import math
+import os
+
 from .platform import get_platform, get_resolve_paths, setup_environment
 
 logger = logging.getLogger("davinci-resolve-mcp.connection")
+
+DEFAULT_RESOLVE_SCRIPT_TIMEOUT = 5.0
+
+
+def _network_timeout():
+    value = os.environ.get(
+        "RESOLVE_SCRIPT_TIMEOUT",
+        str(DEFAULT_RESOLVE_SCRIPT_TIMEOUT),
+    )
+    try:
+        timeout = float(value)
+    except ValueError as exc:
+        raise ValueError(
+            "RESOLVE_SCRIPT_TIMEOUT must be a positive finite number"
+        ) from exc
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError(
+            "RESOLVE_SCRIPT_TIMEOUT must be a positive finite number"
+        )
+    return timeout
+
+
+def connect_resolve(dvr_script):
+    """Create a Resolve handle, optionally targeting an explicit network host."""
+    host = os.environ.get("RESOLVE_SCRIPT_HOST")
+    if host:
+        return dvr_script.scriptapp("Resolve", host, _network_timeout())
+    return dvr_script.scriptapp("Resolve")
+
 
 def initialize_resolve():
     """Initialize connection to DaVinci Resolve application."""
     try:
         # Import the DaVinci Resolve scripting module
         import DaVinciResolveScript as dvr_script
-        
+
         # Get the resolve object
-        resolve = dvr_script.scriptapp("Resolve")
-        
+        resolve = connect_resolve(dvr_script)
+
         if resolve is None:
             logger.error("Failed to get Resolve object. Is DaVinci Resolve running?")
             return None
-        
+
         logger.info(f"Connected to DaVinci Resolve: {resolve.GetProductName()} {resolve.GetVersionString()}")
         return resolve
-    
+
     except ImportError:
         platform_name = get_platform()
         paths = get_resolve_paths()
-        
+
         logger.error("Failed to import DaVinciResolveScript. Check environment variables.")
         logger.error("RESOLVE_SCRIPT_API, RESOLVE_SCRIPT_LIB, and PYTHONPATH must be set correctly.")
-        
+
         if platform_name == 'darwin':
             logger.error("On macOS, typically:")
             logger.error(f'export RESOLVE_SCRIPT_API="{paths["api_path"]}"')
@@ -47,24 +78,25 @@ def initialize_resolve():
             logger.error(f'export RESOLVE_SCRIPT_API="{paths["api_path"]}"')
             logger.error(f'export RESOLVE_SCRIPT_LIB="{paths["lib_path"]}"')
             logger.error(f'export PYTHONPATH="$PYTHONPATH:{paths["modules_path"]}"')
-        
+
         return None
-    
+
     except Exception as e:
         logger.error(f"Unexpected error initializing Resolve: {str(e)}")
         return None
+
 
 def check_environment_variables():
     """Check if the required environment variables are set."""
     resolve_script_api = os.environ.get("RESOLVE_SCRIPT_API")
     resolve_script_lib = os.environ.get("RESOLVE_SCRIPT_LIB")
-    
+
     missing_vars = []
     if not resolve_script_api:
         missing_vars.append("RESOLVE_SCRIPT_API")
     if not resolve_script_lib:
         missing_vars.append("RESOLVE_SCRIPT_LIB")
-    
+
     return {
         "all_set": len(missing_vars) == 0,
         "missing": missing_vars,
@@ -72,6 +104,7 @@ def check_environment_variables():
         "resolve_script_lib": resolve_script_lib
     }
 
+
 def set_default_environment_variables():
     """Set the default environment variables based on platform."""
-    return setup_environment() 
+    return setup_environment()

--- a/tests/test_cdl_and_install_config.py
+++ b/tests/test_cdl_and_install_config.py
@@ -58,13 +58,14 @@ class NormalizeCDLTests(unittest.TestCase):
 
 class InstallConfigTests(unittest.TestCase):
     def test_build_server_entry_includes_env(self):
-        entry = install.build_server_entry(
-            Path("/tmp/python"),
-            Path("/tmp/server.py"),
-            "/Resolve/Scripting",
-            "/Resolve/fusionscript.so",
-            system="Linux",
-        )
+        with patch.dict(os.environ, {}, clear=True):
+            entry = install.build_server_entry(
+                Path("/tmp/python"),
+                Path("/tmp/server.py"),
+                "/Resolve/Scripting",
+                "/Resolve/fusionscript.so",
+                system="Linux",
+            )
 
         self.assertEqual(entry["command"], "/tmp/python")
         self.assertEqual(entry["args"], ["/tmp/server.py"])
@@ -73,6 +74,34 @@ class InstallConfigTests(unittest.TestCase):
             {
                 "RESOLVE_SCRIPT_API": "/Resolve/Scripting",
                 "RESOLVE_SCRIPT_LIB": "/Resolve/fusionscript.so",
+                "PYTHONPATH": "/Resolve/Scripting/Modules",
+            },
+        )
+
+    def test_build_server_entry_includes_explicit_network_env(self):
+        with patch.dict(
+            os.environ,
+            {
+                "RESOLVE_SCRIPT_HOST": "resolve.example.test",
+                "RESOLVE_SCRIPT_TIMEOUT": "12.5",
+            },
+            clear=True,
+        ):
+            entry = install.build_server_entry(
+                Path("/tmp/python"),
+                Path("/tmp/server.py"),
+                "/Resolve/Scripting",
+                "/Resolve/fusionscript.so",
+                system="Linux",
+            )
+
+        self.assertEqual(
+            entry["env"],
+            {
+                "RESOLVE_SCRIPT_API": "/Resolve/Scripting",
+                "RESOLVE_SCRIPT_LIB": "/Resolve/fusionscript.so",
+                "RESOLVE_SCRIPT_HOST": "resolve.example.test",
+                "RESOLVE_SCRIPT_TIMEOUT": "12.5",
                 "PYTHONPATH": "/Resolve/Scripting/Modules",
             },
         )

--- a/tests/test_resolve_connection.py
+++ b/tests/test_resolve_connection.py
@@ -1,0 +1,70 @@
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from src.utils.resolve_connection import connect_resolve
+
+
+class ResolveConnectionTests(unittest.TestCase):
+    def test_uses_default_discovery_without_host(self):
+        dvr_script = Mock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            connect_resolve(dvr_script)
+
+        dvr_script.scriptapp.assert_called_once_with("Resolve")
+
+    def test_uses_explicit_host_with_bounded_timeout(self):
+        dvr_script = Mock()
+
+        with patch.dict(
+            os.environ,
+            {"RESOLVE_SCRIPT_HOST": "127.0.0.1"},
+            clear=True,
+        ):
+            connect_resolve(dvr_script)
+
+        dvr_script.scriptapp.assert_called_once_with("Resolve", "127.0.0.1", 5.0)
+
+    def test_uses_configured_network_timeout(self):
+        dvr_script = Mock()
+
+        with patch.dict(
+            os.environ,
+            {
+                "RESOLVE_SCRIPT_HOST": "resolve.example.test",
+                "RESOLVE_SCRIPT_TIMEOUT": "12.5",
+            },
+            clear=True,
+        ):
+            connect_resolve(dvr_script)
+
+        dvr_script.scriptapp.assert_called_once_with(
+            "Resolve",
+            "resolve.example.test",
+            12.5,
+        )
+
+    def test_rejects_invalid_network_timeout(self):
+        for value in ("forever", "0", "-1", "nan", "inf"):
+            with self.subTest(value=value):
+                dvr_script = Mock()
+                with patch.dict(
+                    os.environ,
+                    {
+                        "RESOLVE_SCRIPT_HOST": "resolve.example.test",
+                        "RESOLVE_SCRIPT_TIMEOUT": value,
+                    },
+                    clear=True,
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "RESOLVE_SCRIPT_TIMEOUT must be a positive finite number",
+                    ):
+                        connect_resolve(dvr_script)
+
+                dvr_script.scriptapp.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a shared Resolve connection helper that supports explicit Network scripting hosts and bounded timeouts
- route compound, granular, installer-generated, and doctor connections through the same behavior
- document Network mode security considerations and add regression coverage for Local and Network configurations

## Root cause

Resolve's one-argument `scriptapp("Resolve")` discovery is appropriate for Local scripting mode, but Network mode requires the explicit host overload. Without a configurable host, the MCP can return no Resolve object or wait on discovery even when Resolve is running on the same machine.

## Behavior

Local mode remains unchanged when `RESOLVE_SCRIPT_HOST` is absent. Network mode is opt-in through `RESOLVE_SCRIPT_HOST`, with `RESOLVE_SCRIPT_TIMEOUT` accepting a positive finite timeout in seconds and defaulting to five seconds.

## Validation

- `venv/bin/python -m unittest tests.test_resolve_connection tests.test_cdl_and_install_config tests.test_static_undefined_names tests.test_action_list_drift tests.test_panel_docs_drift tests.test_api_limitations_doc tests.test_doc_tool_counts tests.test_tool_registration tests.test_mcp_resources` (59 tests passed, 1 conditional skip)
- `venv/bin/python -m compileall -q src scripts tests`
- `git diff --check`
- live Python API connection to DaVinci Resolve Studio 20.3.2.9 in Network mode
- live MCP stdio initialization using protocol 2025-11-25, 34 registered tools, and successful `resolve_control(get_version)`
