### PR TITLE
feat(skills): add rough-cut skill and contact-sheet tool

### DIFF
--- a/.claude/skills/rough-cut.md
+++ b/.claude/skills/rough-cut.md
@@ -1,0 +1,111 @@
+---
+name: resolve-rough-cut
+description: Assembling a short-form social rough cut from raw behind-the-scenes or vlog footage in the DaVinci Resolve MCP. Apply when asked for a rough cut, first cut, assembly, or "make me a timeline" from a folder of footage — day-in-the-life, BTS, process, or product-shoot material destined for Reels, TikTok, or Shorts. Covers ingest, shot finding at scale, vertical timeline setup, and gapless assembly.
+---
+
+# Resolve Rough Cut — Claude Code Skill
+
+Turns a folder of raw footage into an assembled, gapless timeline. **The
+timeline is the deliverable, not a finished video.**
+
+For editorial craft (why a cut works) see `docs/guides/editorial-decision-guide.md`.
+For the analysis layer see the `resolve-media-analysis` skill. This skill is the
+assembly recipe and the traps between them.
+
+## The deliverable contract
+
+Deliver an assembled timeline. Do **not** add titles, captions, text cards,
+effects, transitions, music, or grading unless explicitly asked. Editors who ask
+for a rough cut want shot selection and pacing; styling is theirs. Adding
+graphics is work that gets thrown away — and see the Fusion trap below for why
+it also silently fails.
+
+Render an mp4 only to preview the cut, and say that is what it is.
+
+## Workflow
+
+1. **Probe before importing.** `ffprobe` every clip for `r_frame_rate`,
+   `avg_frame_rate`, and `rotation`. Two things routinely differ from what the
+   filenames and Resolve suggest — see Verified traps.
+2. **Set project settings before any timeline exists.** `timelineFrameRate` is
+   locked once a timeline is created. Use
+   `project_manager safe_set_project_settings`.
+3. **Import into a named bin**, then `media_pool set_current_folder` to it.
+4. **Analyse** — `media_analysis analyze_bin`, `sampling_mode="adaptive_capped"`.
+   Complete the `commit_vision` loop for every clip; leaving one in
+   `pending_host_vision_analysis` is a failure, not a partial success (AGENTS.md).
+5. **Find shots via contact sheets**, not one frame at a time:
+   `python3 scripts/contact_sheet.py <clip_dir> <out_dir>` — see Shot finding.
+6. **Assemble in one call** — `media_pool create_timeline_from_clips` with
+   positioned `clip_infos`.
+7. **Verify** — `timeline detect_gaps_overlaps` must return zero of both, and
+   check the total duration against the target.
+
+## Shot finding at scale
+
+`media_analysis` extracts frames at **full source resolution**. A 35-minute 4K
+clip yields 80 frames at 2160x3840. Reading those individually to satisfy
+`commit_vision` costs ~1,100 tokens each — a four-clip shoot exceeds 250 frames.
+
+Tile them instead. `scripts/contact_sheet.py` burns frame index, timestamp and
+`selection_reason` onto each tile, so per-frame findings stay reportable by
+index. Roughly a 15x saving with no loss of coverage.
+
+Ask for **short clips per subject** rather than 20-35 minute takes when the
+shooter can choose. `adaptive_capped` tops out at 80 frames per clip, so a
+35-minute take gets sampled only to about its first 16 minutes.
+
+## Verified traps
+
+Confirmed live against Resolve Studio, 2026-07-28. Each one silently produces a
+wrong result rather than an error.
+
+| Trap | Symptom | Fix |
+|---|---|---|
+| `clip_infos` `end_frame` is **exclusive** | 1-frame gap between every clip, and matching audio gaps | `end_frame = start_frame + duration` |
+| `create_timeline_from_clips` needs the current folder | Bare `Failed to create timeline from clip_infos`, valid clip_ids | `media_pool set_current_folder` to the clips' bin first |
+| Phone footage carries a `rotation` flag | Stored 3840x2160, displays 2160x3840 | Check `rotation` in ffprobe; Resolve honours it. **Do not reframe** — it is already vertical |
+| Phone footage is **VFR** | `avg_frame_rate` differs per clip and from `r_frame_rate` | Match the timeline to what Resolve conforms to (its reported clip FPS), not to `r_frame_rate` |
+| `timelinePlaybackFrameRate` is read-only | `set_setting` returns False for every value form | Monitoring only — the render follows `timelineFrameRate`. Tell the user to fix it in Master Settings |
+| Fusion comps built via API never render | Nodes report success and read back correctly; output unchanged | No scripted path to burn text over a clip. Don't attempt it. `delete_comp` also fails — rebuild the timeline to clear one |
+
+Destructive ops auto-archive the timeline, so several edits leave
+`*_archived_vNN` timelines behind. Clean them up before handing over.
+
+## Assembly shape
+
+Build `clip_infos` as a flat list — source `start_frame`/`end_frame` plus a
+cumulative `record_frame`:
+
+```python
+shots = [(clip_id, start_sec, duration_sec), ...]
+infos, record = [], 0
+for clip_id, start, dur in shots:
+    start_f, dur_f = round(start * fps), round(dur * fps)
+    infos.append({
+        "clip_id": clip_id,
+        "start_frame": start_f,
+        "end_frame": start_f + dur_f,   # exclusive
+        "record_frame": record,
+    })
+    record += dur_f
+```
+
+Working in seconds and converting once keeps the shot list readable and makes
+the exclusive-`end_frame` rule impossible to get wrong twice.
+
+## Common mistakes
+
+- Reframing vertical-flagged footage into a vertical timeline — double-rotating
+  or cropping material that already fits.
+- Setting the timeline frame rate after creating the timeline; it is ignored.
+- Trusting `detect_gaps_overlaps` alone — also confirm total duration and
+  inspect representative frames.
+- Reporting a render as the deliverable when the timeline is what was asked for.
+
+## Source-media safety (AGENTS.md)
+
+Assembly references existing Media Pool items and never transcodes, proxies, or
+relinks source media. Analysis frames, contact sheets, and preview renders are
+scratch artifacts — write them to the analysis root or session scratch, never
+beside the source, and never into git.

--- a/.claude/skills/rough-cut.md
+++ b/.claude/skills/rough-cut.md
@@ -27,9 +27,17 @@ Render an mp4 only to preview the cut, and say that is what it is.
 1. **Probe before importing.** `ffprobe` every clip for `r_frame_rate`,
    `avg_frame_rate`, and `rotation`. Two things routinely differ from what the
    filenames and Resolve suggest — see Verified traps.
-2. **Set project settings before any timeline exists.** `timelineFrameRate` is
-   locked once a timeline is created. Use
-   `project_manager safe_set_project_settings`.
+2. **Set BOTH frame rates before any timeline exists.** `timelineFrameRate` is
+   locked once a timeline is created — set it via
+   `project_manager safe_set_project_settings`. `timelinePlaybackFrameRate`
+   cannot be set through the API at all, so **ask the user to set it in the UI
+   now**, as a setup step:
+
+   > Project Settings (gear, bottom-right) → Master Settings → Playback frame rate
+
+   Do not defer this to the end or write it off as cosmetic. Confirm both read
+   the shooting frame rate before assembling; a mismatch has been reported to
+   affect playback and output, not just the display.
 3. **Import into a named bin**, then `media_pool set_current_folder` to it.
 4. **Analyse** — `media_analysis analyze_bin`, `sampling_mode="adaptive_capped"`.
    Complete the `commit_vision` loop for every clip; leaving one in
@@ -66,7 +74,7 @@ wrong result rather than an error.
 | `create_timeline_from_clips` needs the current folder | Bare `Failed to create timeline from clip_infos`, valid clip_ids | `media_pool set_current_folder` to the clips' bin first |
 | Phone footage carries a `rotation` flag | Stored 3840x2160, displays 2160x3840 | Check `rotation` in ffprobe; Resolve honours it. **Do not reframe** — it is already vertical |
 | Phone footage is **VFR** | `avg_frame_rate` differs per clip and from `r_frame_rate` | Match the timeline to what Resolve conforms to (its reported clip FPS), not to `r_frame_rate` |
-| `timelinePlaybackFrameRate` is read-only | `set_setting` returns False for every value form | Monitoring only — the render follows `timelineFrameRate`. Tell the user to fix it in Master Settings |
+| `timelinePlaybackFrameRate` is read-only | `set_setting` returns False for every value form, before and after a timeline exists | No API path. Ask the user to set it in Master Settings during setup (step 2), not at handover |
 | Fusion comps built via API never render | Nodes report success and read back correctly; output unchanged | No scripted path to burn text over a clip. Don't attempt it. `delete_comp` also fails — rebuild the timeline to clear one |
 
 Destructive ops auto-archive the timeline, so several edits leave

--- a/.claude/skills/rough-cut.md
+++ b/.claude/skills/rough-cut.md
@@ -27,26 +27,34 @@ Render an mp4 only to preview the cut, and say that is what it is.
 1. **Probe before importing.** `ffprobe` every clip for `r_frame_rate`,
    `avg_frame_rate`, and `rotation`. Two things routinely differ from what the
    filenames and Resolve suggest — see Verified traps.
-2. **Set BOTH frame rates before any timeline exists.** `timelineFrameRate` is
-   locked once a timeline is created — set it via
+2. **For a series, add a timeline to the existing project — don't create a new
+   one.** Check `project_manager list` first. One project per series keeps the
+   bins, analysed clips and settings in one place; one per episode scatters
+   them. Only create a project for a genuinely new series.
+
+3. **On a NEW project, set BOTH frame rates before any timeline exists.**
+   `timelineFrameRate` is locked once a timeline is created — set it via
    `project_manager safe_set_project_settings`. `timelinePlaybackFrameRate`
    cannot be set through the API at all, so **ask the user to set it in the UI
    now**, as a setup step:
 
    > Project Settings (gear, bottom-right) → Master Settings → Playback frame rate
 
-   Do not defer this to the end or write it off as cosmetic. Confirm both read
-   the shooting frame rate before assembling; a mismatch has been reported to
-   affect playback and output, not just the display.
-3. **Import into a named bin**, then `media_pool set_current_folder` to it.
-4. **Analyse** — `media_analysis analyze_bin`, `sampling_mode="adaptive_capped"`.
+   Do not defer this to the end or write it off as cosmetic; a mismatch has been
+   reported to affect playback and output, not just the display. On an existing
+   project, read both back and only raise it if they are wrong.
+4. **Import into a bin named for the episode**, then
+   `media_pool set_current_folder` to it. One bin per episode, not one shared
+   dump — it keeps `analyze_bin` scoped and the Media Pool readable across a
+   long series.
+5. **Analyse** — `media_analysis analyze_bin`, `sampling_mode="adaptive_capped"`.
    Complete the `commit_vision` loop for every clip; leaving one in
    `pending_host_vision_analysis` is a failure, not a partial success (AGENTS.md).
-5. **Find shots via contact sheets**, not one frame at a time:
+6. **Find shots via contact sheets**, not one frame at a time:
    `python3 scripts/contact_sheet.py <clip_dir> <out_dir>` — see Shot finding.
-6. **Assemble in one call** — `media_pool create_timeline_from_clips` with
-   positioned `clip_infos`.
-7. **Verify** — `timeline detect_gaps_overlaps` must return zero of both, and
+7. **Assemble in one call** — `media_pool create_timeline_from_clips` with
+   positioned `clip_infos`. Name the timeline for the episode.
+8. **Verify** — `timeline detect_gaps_overlaps` must return zero of both, and
    check the total duration against the target.
 
 ## Shot finding at scale
@@ -61,7 +69,14 @@ index. Roughly a 15x saving with no loss of coverage.
 
 Ask for **short clips per subject** rather than 20-35 minute takes when the
 shooter can choose. `adaptive_capped` tops out at 80 frames per clip, so a
-35-minute take gets sampled only to about its first 16 minutes.
+35-minute take gets sampled only to about its first 16 minutes — the tail is
+never seen.
+
+**When footage arrives pre-culled** (the shooter has already thrown away the
+unusable takes), scale the effort down: fewer frames per clip, fewer sheets, and
+trust the selection rather than hunting for the good moments. The expensive part
+of shot finding is separating usable from unusable, and that work is already
+done. Don't re-litigate it.
 
 ## Verified traps
 

--- a/scripts/contact_sheet.py
+++ b/scripts/contact_sheet.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Labelled contact sheets from a media_analysis frames directory.
+
+Solves a concrete cost problem in the host-chat vision loop. `media_analysis`
+extracts sampled frames at FULL source resolution — a 35-minute 4K clip yields
+80 frames at 2160x3840, ~280 KB each. Reading those one at a time to satisfy
+`commit_vision` costs roughly 1,100 tokens per frame; a four-clip shoot runs to
+250+ frames and several hundred thousand tokens.
+
+Tiling them into labelled grids drops that by an order of magnitude while
+keeping every frame visible. Each tile is burned with its frame index, source
+timestamp and the sampler's `selection_reason`, so per-frame findings can still
+be reported by index against the schema.
+
+Source-safe: reads only the analysis scratch directory and the sidecar
+`visual.json`; writes only into `out_dir`. Never touches source media.
+
+Run: `python3 scripts/contact_sheet.py <clip_analysis_dir> <out_dir>`
+where `<clip_analysis_dir>` is the directory holding `visual.json` and
+`frames/` (printed as `artifacts.clip_dir` by `media_analysis`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any, Dict, List, Tuple
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:  # pragma: no cover - guidance only, never auto-installs
+    raise SystemExit(
+        "Pillow is required: pip install Pillow "
+        "(source-safe; used only to tile analysis scratch frames)"
+    )
+
+LABEL_HEIGHT = 26
+FONT_CANDIDATES = (
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/Library/Fonts/Arial.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+)
+
+
+def _load_font(size: int):
+    for path in FONT_CANDIDATES:
+        if os.path.exists(path):
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _timestamp(seconds: Any) -> str:
+    if seconds is None:
+        return "?"
+    minutes, secs = divmod(float(seconds), 60)
+    return "%d:%05.2f" % (int(minutes), secs)
+
+
+def _read_json(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, ValueError):
+        return {}
+
+
+def load_frames(clip_dir: str) -> Tuple[List[str], Dict[int, Dict[str, Any]]]:
+    """Resolve frame paths + per-frame labels across all three artifact states.
+
+    Order matters. While vision is pending, visual.json's `frame_paths` IS the
+    payload `commit_vision` expects findings reported against, so its indices
+    must win — analysis.json holds a larger superset (vision sample plus
+    cut-boundary frames) whose numbering would not line up.
+
+    `commit_vision` then REPLACES visual.json with the committed analysis,
+    dropping `frame_paths`. After that analysis.json's `analysis_keyframes` is
+    the richest surviving source, and index alignment no longer matters because
+    there is no vision payload left to report against.
+    """
+    visual = _read_json(os.path.join(clip_dir, "visual.json"))
+    paths = [p for p in visual.get("frame_paths", []) if os.path.exists(p)]
+    if paths:
+        meta = {
+            m["frame_index"]: m for m in visual.get("frame_metadata", [])
+        }
+        return paths, meta
+
+    keyframes = _read_json(os.path.join(clip_dir, "analysis.json")).get(
+        "analysis_keyframes"
+    )
+    if keyframes:
+        paths, meta = [], {}
+        for position, entry in enumerate(keyframes, start=1):
+            frame_path = entry.get("frame_path")
+            if not frame_path or not os.path.exists(frame_path):
+                continue
+            paths.append(frame_path)
+            meta[len(paths)] = {
+                "time_seconds": entry.get("time_seconds"),
+                "selection_reason": entry.get("selection_reason"),
+                "frame_index": entry.get("index", position),
+            }
+        if paths:
+            return paths, meta
+
+    frames_dir = os.path.join(clip_dir, "frames")
+    if os.path.isdir(frames_dir):
+        listed = sorted(
+            os.path.join(frames_dir, n)
+            for n in os.listdir(frames_dir)
+            if n.lower().endswith((".jpg", ".jpeg", ".png"))
+        )
+        return listed, {}
+
+    return [], {}
+
+
+def build_sheets(
+    clip_dir: str,
+    out_dir: str,
+    tile_width: int = 300,
+    columns: int = 6,
+    rows: int = 3,
+) -> Tuple[List[Tuple[str, int, int]], int]:
+    """Tile every sampled frame into labelled sheets. Returns (sheets, frame_count)."""
+    paths, meta = load_frames(clip_dir)
+    if not paths:
+        return [], 0
+
+    per_sheet = columns * rows
+    os.makedirs(out_dir, exist_ok=True)
+    font = _load_font(17)
+
+    # Derive tile height from a real frame — never assume 16:9. Vertical phone
+    # footage arrives here already rotated to portrait by ffmpeg.
+    with Image.open(paths[0]) as probe:
+        tile_height = max(1, round(tile_width * probe.height / probe.width))
+
+    sheets: List[Tuple[str, int, int]] = []
+    for offset in range(0, len(paths), per_sheet):
+        chunk = paths[offset:offset + per_sheet]
+        used_rows = (len(chunk) + columns - 1) // columns
+        sheet = Image.new(
+            "RGB",
+            (columns * tile_width, used_rows * (tile_height + LABEL_HEIGHT)),
+            (18, 18, 18),
+        )
+        draw = ImageDraw.Draw(sheet)
+
+        for position, frame_path in enumerate(chunk):
+            index = offset + position + 1
+            row, column = divmod(position, columns)
+            x = column * tile_width
+            y = row * (tile_height + LABEL_HEIGHT)
+            with Image.open(frame_path) as frame:
+                frame = frame.convert("RGB").resize(
+                    (tile_width, tile_height), Image.LANCZOS
+                )
+                sheet.paste(frame, (x, y + LABEL_HEIGHT))
+            entry = meta.get(index, {})
+            reason = (entry.get("selection_reason") or "")[:14]
+            draw.text(
+                (x + 5, y + 4),
+                "#%d  %s  %s" % (index, _timestamp(entry.get("time_seconds")), reason),
+                fill=(255, 220, 90),
+                font=font,
+            )
+
+        out_path = os.path.join(out_dir, "sheet_%02d.jpg" % (offset // per_sheet + 1))
+        sheet.save(out_path, quality=82, optimize=True)
+        sheets.append((out_path, offset + 1, offset + len(chunk)))
+
+    return sheets, len(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("clip_dir", help="directory containing visual.json and frames/")
+    parser.add_argument("out_dir", help="where to write the contact sheets")
+    parser.add_argument("--tile-width", type=int, default=300)
+    parser.add_argument("--columns", type=int, default=6)
+    parser.add_argument("--rows", type=int, default=3)
+    args = parser.parse_args()
+
+    sheets, frame_count = build_sheets(
+        args.clip_dir, args.out_dir, args.tile_width, args.columns, args.rows
+    )
+    if not frame_count:
+        print(
+            "no sampled frames found in %s\n"
+            "expected analysis.json, visual.json, or a frames/ directory "
+            "(use the clip_dir printed as artifacts.clip_dir by media_analysis)"
+            % args.clip_dir
+        )
+        return 1
+
+    print("frames=%d sheets=%d" % (frame_count, len(sheets)))
+    for path, first, last in sheets:
+        print("%s  frames %d-%d" % (path, first, last))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a `resolve-rough-cut` skill for assembling short-form social rough cuts
from raw BTS/vlog footage, plus the frame-grid tool it depends on.

Both come out of a real vertical (1080x1920) assembly run against Resolve
Studio. The skill records six behaviours that silently produce a wrong result
rather than erroring:

- create_timeline_from_clips `end_frame` is exclusive, so the obvious
  start+duration-1 leaves a 1-frame gap between every clip
- create_timeline_from_clips fails with a bare error unless the Media Pool
  current folder is set to the clips' bin first
- phone footage carries a rotation flag (stored 3840x2160, displays
  2160x3840) and must not be reframed into a vertical timeline
- phone footage is VFR, so the timeline should match Resolve's conformed
  rate rather than the container's r_frame_rate
- timelinePlaybackFrameRate is read-only via SetSetting; it is monitoring
  only and does not affect the render
- Fusion comps built through the API never reach the render, so there is no
  scripted path to burn text over a clip

scripts/contact_sheet.py tiles media_analysis sampled frames into labelled
grids. Frames are extracted at full source resolution, so reading them
individually to satisfy the commit_vision loop costs roughly 1,100 tokens
each and a four-clip shoot exceeds 250 frames. It resolves frames across all
three artifact states and deliberately prefers visual.json while vision is
pending, because those indices are what commit_vision expects findings to be
reported against; analysis.json holds a larger superset whose numbering does
not align.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
