### PR TITLE
fix: honor RESOLVE_SCRIPT_API/LIB env vars in get_resolve_paths

### DIFF
--- a/src/utils/platform.py
+++ b/src/utils/platform.py
@@ -55,6 +55,16 @@ def get_resolve_paths():
         lib_path = "/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion/fusionscript.so"
         modules_path = os.path.join(api_path, "Modules")
     
+    # An explicit install location wins over the platform default: Resolve is
+    # not always under /Applications (external volume, custom install dir).
+    env_api = os.environ.get("RESOLVE_SCRIPT_API")
+    if env_api and os.path.isdir(env_api):
+        api_path = env_api
+        modules_path = os.path.join(api_path, "Modules")
+    env_lib = os.environ.get("RESOLVE_SCRIPT_LIB")
+    if env_lib and os.path.isfile(env_lib):
+        lib_path = env_lib
+
     return {
         "api_path": api_path,
         "lib_path": lib_path,

--- a/tests/test_platform_paths.py
+++ b/tests/test_platform_paths.py
@@ -1,0 +1,82 @@
+"""Offline tests for src.utils.platform.get_resolve_paths (env-var overrides).
+
+Resolve is not always installed under the platform default location (external
+volume, custom install dir). The installer-style env vars RESOLVE_SCRIPT_API and
+RESOLVE_SCRIPT_LIB must win over the built-in default, but only when they point
+at something that actually exists — a stale env var must not shadow a working
+default install.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.utils import platform as platform_utils  # noqa: E402
+
+ENV_KEYS = ("RESOLVE_SCRIPT_API", "RESOLVE_SCRIPT_LIB")
+
+
+def _env_without_overrides():
+    return {k: v for k, v in os.environ.items() if k not in ENV_KEYS}
+
+
+class ResolvePathEnvOverrideTest(unittest.TestCase):
+    def test_defaults_used_when_env_unset(self):
+        with patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                patch.dict(os.environ, _env_without_overrides(), clear=True):
+            paths = platform_utils.get_resolve_paths()
+        self.assertEqual(
+            paths["lib_path"],
+            "/Applications/DaVinci Resolve/DaVinci Resolve.app"
+            "/Contents/Libraries/Fusion/fusionscript.so",
+        )
+
+    def test_existing_env_lib_overrides_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lib = os.path.join(tmp, "fusionscript.so")
+            with open(lib, "w"):
+                pass
+            env = _env_without_overrides()
+            env["RESOLVE_SCRIPT_LIB"] = lib
+            with patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                    patch.dict(os.environ, env, clear=True):
+                paths = platform_utils.get_resolve_paths()
+            self.assertEqual(paths["lib_path"], lib)
+
+    def test_existing_env_api_also_moves_modules_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _env_without_overrides()
+            env["RESOLVE_SCRIPT_API"] = tmp
+            with patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                    patch.dict(os.environ, env, clear=True):
+                paths = platform_utils.get_resolve_paths()
+            self.assertEqual(paths["api_path"], tmp)
+            self.assertEqual(paths["modules_path"], os.path.join(tmp, "Modules"))
+
+    def test_nonexistent_env_paths_fall_back_to_defaults(self):
+        env = _env_without_overrides()
+        env["RESOLVE_SCRIPT_API"] = "/nope/does/not/exist"
+        env["RESOLVE_SCRIPT_LIB"] = "/nope/does/not/exist/fusionscript.so"
+        with patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                patch.dict(os.environ, env, clear=True):
+            paths = platform_utils.get_resolve_paths()
+        self.assertEqual(
+            paths["api_path"],
+            "/Library/Application Support/Blackmagic Design"
+            "/DaVinci Resolve/Developer/Scripting",
+        )
+        self.assertEqual(
+            paths["lib_path"],
+            "/Applications/DaVinci Resolve/DaVinci Resolve.app"
+            "/Contents/Libraries/Fusion/fusionscript.so",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`get_resolve_paths()` in `src/utils/platform.py` returned only the hardcoded platform defaults. Since `src/server.py` writes those values straight back into `os.environ`:

```python
os.environ["RESOLVE_SCRIPT_API"] = RESOLVE_API_PATH
os.environ["RESOLVE_SCRIPT_LIB"] = RESOLVE_LIB_PATH
```

…any `RESOLVE_SCRIPT_API` / `RESOLVE_SCRIPT_LIB` a client had already set were silently overwritten before the bridge was loaded.

This change lets those env vars win over the platform default — but only when they point at a path that actually exists, so a stale variable can't shadow a working default install. With the vars unset, behavior is unchanged.

## Why

On macOS this breaks every install where `DaVinci Resolve.app` is not under `/Applications` — in my case on an external volume. The result is hard to diagnose, because everything else looks healthy:

- Resolve Studio running, project open
- External scripting set to `Local`
- `fuscript -s` up and listening on 1144

…yet `scriptapp("Resolve")` returns `None`, and passing the correct `RESOLVE_SCRIPT_LIB` into the MCP registration has no effect, since it is overwritten at import time. `scripts/doctor.py` already surfaces the mismatch (`[FAIL] Resolve app: /Applications/...`) but the server itself has no way to act on it.

Verified against DaVinci Resolve Studio 21.0.3 on macOS 15.6 (Apple Silicon): before the change `scriptapp()` returns `None`, after it connects and `doctor.py` reports `[OK] Resolve scripting connection: DaVinci Resolve Studio 21.0.3.7`.

## Notes for the reviewer

- `scripts/doctor.py` already supports an equivalent `RESOLVE_APP` override for its own app-bundle check, so honoring env vars here is consistent with existing behavior rather than a new concept.
- Adds `tests/test_platform_paths.py` — 4 offline tests covering both directions (override applied when the path exists, default kept when the env var is unset or dangling). They fail without the fix and pass with it.
- Full offline suite: `python -m unittest discover -s tests -p "test_*.py"` → 1615 tests. The 2 errors (`test_custom_timeline`, `test_improvements` — loader errors) and 2 failures in `test_script_plugin` are pre-existing on `main` and unrelated; I verified this by running the suite with the change stashed.