### PR TITLE
Pin mcp[cli]<2 so install.py doesn't pull the incompatible SDK 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,9 @@
 # it, AAF preview honest-refuses (it is never faked); live AAF import into Resolve
 # does not need it (Resolve reads AAF natively).
 pyaaf2>=1.7.0
+
+# mcp — pin below 2.0. server.py imports `mcp.server.fastmcp`, which the 1.x SDK
+# provides. The 2.0.0 major restructured the SDK (no fastmcp module, switched to
+# httpx2) and is incompatible. install.py runs `pip install mcp[cli]` UNPINNED
+# first, so it grabs 2.0.0; this constraint (installed second) pins it back.
+mcp[cli]>=1.29,<2


### PR DESCRIPTION
## Problem

A fresh install currently produces a server that crashes on startup:

```
Traceback (most recent call last):
  File ".../src/server.py", line 160, in <module>
    from mcp.server.fastmcp import Context, FastMCP, Image
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`install.py` installs the SDK with an **unpinned** requirement:

```python
# install.py, install_dependencies()
subprocess.run([str(pip), "install", "-q", "mcp[cli]"], check=True, ...)
```

`mcp` has since published **2.0.0**, which `pip install mcp[cli]` now resolves to by default. The 2.0 line restructured the SDK — there is no longer a `mcp.server.fastmcp` module (it depends on `httpx2`, `mcp-types`, etc.) — so `server.py`, which imports `from mcp.server.fastmcp import Context, FastMCP, Image`, fails at import and the MCP client reports only "Server disconnected".

## Fix

Add a constraint to `requirements.txt`, which `install.py` installs **after** `mcp[cli]`:

```
mcp[cli]>=1.29,<2
```

Because it runs second, it pins/downgrades the SDK back to the latest 1.x (which provides `mcp.server.fastmcp`) without changing the installer flow. `1.29.0` is the current newest 1.x release.

## Verification

- `from mcp.server.fastmcp import Context, FastMCP, Image` imports cleanly on `mcp 1.29.0`.
- The server completes an MCP `initialize` handshake and identifies as `DaVinciResolveMCP`.
- End-to-end smoke test against DaVinci Resolve Studio 21.0.3.7: create project → import media → build timeline → render, all via the MCP tools.

## Note (out of scope for this PR)

The other half of a broken fresh install is the Python floor: `mcp[cli]` needs 3.10+, so a venv built on macOS system `python3` (3.9) silently installs none of the MCP stack. `install.py` already checks for this, so this PR only addresses the version-resolution side. Happy to add an explicit floor note in the installer output if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
