### PR TITLE
fix(test): pass Advanced test files to Node runner

### DIFF
--- a/resolve-advanced/package.json
+++ b/resolve-advanced/package.json
@@ -37,9 +37,9 @@
     "_comment": "audio (split/trim/convert) + conform frame ops need system ffmpeg/ffprobe on PATH (NOT bundled — FFmpeg binaries are GPL; this package stays MIT). Install ffmpeg yourself: brew install ffmpeg."
   },
   "scripts": {
-    "test": "node --test vendor/drp-format/__tests__/ vendor/drt-format/__tests__/ vendor/drx-codec/__tests__/ test/",
-    "test:libs": "node --test vendor/drp-format/__tests__/ vendor/drt-format/__tests__/ vendor/drx-codec/__tests__/",
-    "test:server": "node --test test/"
+    "test": "node --test vendor/drp-format/__tests__/*.test.js vendor/drt-format/__tests__/*.test.js vendor/drx-codec/__tests__/*.test.js test/*.test.mjs",
+    "test:libs": "node --test vendor/drp-format/__tests__/*.test.js vendor/drt-format/__tests__/*.test.js vendor/drx-codec/__tests__/*.test.js",
+    "test:server": "node --test test/*.test.mjs"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- replace directory arguments to node --test with explicit test-file globs
- keep library and server test scripts independently runnable
- avoid MODULE_NOT_FOUND failures on supported Node versions

## Verification
- Node 22.22.3
- npm test --prefix resolve-advanced
- 701 passed, 30 skipped, 0 failed