### PR TITLE
fix(media-pool): honor list metadata keys, and name delete_timelines' expected param

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -16606,11 +16606,18 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
 
         return _run_maybe_background("media_pool.import_timeline", p, _work)
     elif action == "delete_timelines":
+        ids = p.get("timeline_ids")
+        if not isinstance(ids, list) or not ids:
+            hint = (" ('timeline_names' is not supported — timelines are matched"
+                    " by unique ID, e.g. from timeline.get_unique_id)"
+                    if "timeline_names" in p else "")
+            return _err("delete_timelines requires 'timeline_ids', a non-empty"
+                        " list of timeline unique IDs" + hint)
         count = proj.GetTimelineCount()
         timelines = []
         for i in range(1, count + 1):
             tl = proj.GetTimelineByIndex(i)
-            if tl and tl.GetUniqueId() in p["timeline_ids"]:
+            if tl and tl.GetUniqueId() in ids:
                 timelines.append(tl)
         if not timelines:
             return _err("No timelines found")
@@ -16986,6 +16993,22 @@ def folder(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, An
 # TOOL 13: media_pool_item
 # ═══════════════════════════════════════════════════════════════════════════════
 
+def _keyed_get(getter, key):
+    """Resolve's keyed getters take one string key; passed a list they silently
+    ignore it and return the full dict. Subset it ourselves instead.
+
+    Returns (value, error) — exactly one is non-None unless value is legitimately
+    empty."""
+    if isinstance(key, list):
+        if not key or not all(isinstance(k, str) for k in key):
+            return None, _err("'key' must be a string or a non-empty list of strings")
+        full = getter("")
+        if not isinstance(full, dict):
+            full = {}
+        return {k: full.get(k) for k in key}, None
+    return getter(key), None
+
+
 @mcp.tool()
 @_guard_missing_params
 def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -16994,6 +17017,7 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
     Actions:
       get_name(clip_id) -> {name}
       get_metadata(clip_id, key?) -> {metadata}
+        — key: one string, or a list of strings to get just that subset
       set_metadata(clip_id, key, value) OR set_metadata(clip_id, metadata) -> {success}
       get_third_party_metadata(clip_id, key?) -> {metadata}
       set_third_party_metadata(clip_id, key, value) -> {success}
@@ -17160,7 +17184,10 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
     if action == "get_name":
         return {"name": clip.GetName()}
     elif action == "get_metadata":
-        return {"metadata": _ser(clip.GetMetadata(p.get("key", "")))}
+        value, key_err = _keyed_get(clip.GetMetadata, p.get("key", ""))
+        if key_err:
+            return key_err
+        return {"metadata": _ser(value)}
     elif action == "set_metadata":
         if "metadata" in p:
             ok = bool(clip.SetMetadata(p["metadata"]))
@@ -17176,13 +17203,19 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
                 return silent
         return {"success": ok}
     elif action == "get_third_party_metadata":
-        return {"metadata": _ser(clip.GetThirdPartyMetadata(p.get("key", "")))}
+        value, key_err = _keyed_get(clip.GetThirdPartyMetadata, p.get("key", ""))
+        if key_err:
+            return key_err
+        return {"metadata": _ser(value)}
     elif action == "set_third_party_metadata":
         return {"success": bool(clip.SetThirdPartyMetadata(p["key"], p["value"]))}
     elif action == "get_media_id":
         return {"media_id": clip.GetMediaId()}
     elif action == "get_clip_property":
-        return {"properties": _ser(clip.GetClipProperty(p.get("key", "")))}
+        value, key_err = _keyed_get(clip.GetClipProperty, p.get("key", ""))
+        if key_err:
+            return key_err
+        return {"properties": _ser(value)}
     elif action == "set_clip_property":
         ok = bool(clip.SetClipProperty(p["key"], p["value"]))
         if ok:

--- a/src/server.py
+++ b/src/server.py
@@ -17017,12 +17017,20 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
     Actions:
       get_name(clip_id) -> {name}
       get_metadata(clip_id, key?) -> {metadata}
-        — key: one string, or a list of strings to get just that subset
+        — key: one string, or a list of strings to get just that subset.
+          Missing keys: the list form maps them to null (distinguishing
+          absent from empty); the string form returns Resolve's "".
       set_metadata(clip_id, key, value) OR set_metadata(clip_id, metadata) -> {success}
       get_third_party_metadata(clip_id, key?) -> {metadata}
+        — key: one string, or a list of strings to get just that subset.
+          Missing keys: the list form maps them to null (distinguishing
+          absent from empty); the string form returns Resolve's "".
       set_third_party_metadata(clip_id, key, value) -> {success}
       get_media_id(clip_id) -> {media_id}
       get_clip_property(clip_id, key?) -> {properties}
+        — key: one string, or a list of strings to get just that subset.
+          Missing keys: the list form maps them to null (distinguishing
+          absent from empty); the string form returns Resolve's "".
       set_clip_property(clip_id, key, value) -> {success}
       get_clip_color(clip_id) -> {color}
       set_clip_color(clip_id, color) -> {success}

--- a/tests/live_keyed_param_validation.py
+++ b/tests/live_keyed_param_validation.py
@@ -1,0 +1,86 @@
+"""Live probe for PR #113: list-key get_metadata subset + delete_timelines param error.
+
+Read-only: get_metadata calls only; the delete_timelines calls use bad params
+that must error before any lookup or deletion. No media or project mutation.
+"""
+import os
+import sys
+
+PROJECT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT)
+
+from src.utils.platform import get_resolve_paths  # noqa: E402
+
+paths = get_resolve_paths()
+os.environ["RESOLVE_SCRIPT_API"] = paths["api_path"]
+os.environ["RESOLVE_SCRIPT_LIB"] = paths["lib_path"]
+sys.path.insert(0, paths["modules_path"])
+
+import src.server as s  # noqa: E402
+
+failures = []
+
+
+def check(label, cond, detail=""):
+    print(("PASS " if cond else "FAIL ") + label + (f" — {detail}" if detail else ""))
+    if not cond:
+        failures.append(label)
+
+
+def main():
+    _, proj, mp, err = s._get_mp()
+    if err:
+        print("Cannot reach Resolve media pool:", err)
+        return 2
+    print("Project:", proj.GetName())
+
+    # Find any clip in the media pool (recursive).
+    def first_clip(folder):
+        for c in folder.GetClipList() or []:
+            return c
+        for f in folder.GetSubFolderList() or []:
+            c = first_clip(f)
+            if c:
+                return c
+        return None
+
+    clip = first_clip(mp.GetRootFolder())
+    if clip is None:
+        print("SKIP get_metadata checks — no clips in media pool")
+    else:
+        cid = clip.GetUniqueId()
+        print("Clip:", clip.GetName(), cid)
+
+        full = s.media_pool_item("get_metadata", {"clip_id": cid})
+        check("full dict when key omitted", isinstance(full.get("metadata"), dict),
+              f"{len(full.get('metadata') or {})} keys")
+
+        keys = list((full.get("metadata") or {}).keys())[:2] or ["Description", "Keywords"]
+        sub_out = s.media_pool_item("get_metadata", {"clip_id": cid, "key": keys})
+        md = sub_out.get("metadata")
+        check("list key returns only requested subset",
+              isinstance(md, dict) and sorted(md.keys()) == sorted(keys), str(md)[:120])
+
+        one = s.media_pool_item("get_metadata", {"clip_id": cid, "key": keys[0]})
+        check("string key still returns scalar",
+              "metadata" in one and not isinstance(one["metadata"], dict), str(one)[:120])
+
+        bad = s.media_pool_item("get_metadata", {"clip_id": cid, "key": []})
+        check("empty list rejected", "error" in bad, str(bad.get("error", ""))[:120])
+
+    # delete_timelines param errors — must fail before touching anything.
+    r1 = s.media_pool("delete_timelines", {"timeline_names": ["NoSuchTimeline"]})
+    m1 = (r1.get("error") or {}).get("message", "")
+    check("timeline_names -> clear error naming timeline_ids",
+          "timeline_ids" in m1 and "timeline_names" in m1, m1[:160])
+
+    r2 = s.media_pool("delete_timelines", {})
+    m2 = (r2.get("error") or {}).get("message", "")
+    check("missing param -> clear error naming timeline_ids", "timeline_ids" in m2, m2[:160])
+
+    print("RESULT:", "PASS" if not failures else f"FAIL ({failures})")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_keyed_param_guards.py
+++ b/tests/test_keyed_param_guards.py
@@ -1,0 +1,89 @@
+"""Tests for keyed-param guards found during live cataloguing (2026-08-03).
+
+- media_pool_item get_metadata (and sibling keyed getters): a list-valued `key`
+  was passed straight to Resolve, which silently ignored it and returned the
+  full dict. Now a list key returns just that subset; a bad list is rejected.
+- media_pool delete_timelines: calling with `timeline_names` (or without
+  `timeline_ids`) raised a bare KeyError('timeline_ids'). Now it's a clear
+  error naming the expected parameter.
+"""
+import unittest
+from unittest import mock
+
+import src.server as s
+
+
+class FakeClip:
+    FULL = {"Description": "desc", "Keywords": "kw", "Scene": "s1"}
+
+    def GetMetadata(self, key=""):
+        return self.FULL if key == "" else self.FULL.get(key, "")
+
+
+class GetMetadataListKeyTest(unittest.TestCase):
+    def _call(self, params):
+        mp = mock.Mock()
+        with mock.patch.object(s, "_get_mp", return_value=(None, None, mp, None)), \
+             mock.patch.object(s, "_find_clip", return_value=FakeClip()):
+            return s.media_pool_item("get_metadata", params)
+
+    def test_string_key_unchanged(self):
+        out = self._call({"clip_id": "x", "key": "Description"})
+        self.assertEqual(out["metadata"], "desc")
+
+    def test_omitted_key_returns_full_dict(self):
+        out = self._call({"clip_id": "x"})
+        self.assertEqual(out["metadata"], FakeClip.FULL)
+
+    def test_list_key_returns_subset(self):
+        out = self._call({"clip_id": "x", "key": ["Description", "Scene"]})
+        self.assertEqual(out["metadata"], {"Description": "desc", "Scene": "s1"})
+
+    def test_list_key_missing_field_is_none(self):
+        out = self._call({"clip_id": "x", "key": ["Description", "NoSuch"]})
+        self.assertEqual(out["metadata"], {"Description": "desc", "NoSuch": None})
+
+    def test_empty_list_rejected(self):
+        out = self._call({"clip_id": "x", "key": []})
+        self.assertIn("error", out)
+        self.assertIn("key", out["error"]["message"])
+
+    def test_non_string_list_rejected(self):
+        out = self._call({"clip_id": "x", "key": ["Description", 7]})
+        self.assertIn("error", out)
+
+
+class DeleteTimelinesParamTest(unittest.TestCase):
+    def _call(self, params):
+        proj = mock.Mock()
+        proj.GetTimelineCount.return_value = 0
+        mp = mock.Mock()
+        with mock.patch.object(s, "_get_mp", return_value=(None, proj, mp, None)):
+            return s.media_pool("delete_timelines", params)
+
+    def test_missing_timeline_ids_named_in_error(self):
+        out = self._call({})
+        self.assertIn("error", out)
+        self.assertIn("timeline_ids", out["error"]["message"])
+
+    def test_timeline_names_gets_explicit_hint(self):
+        out = self._call({"timeline_names": ["Timeline 1"]})
+        self.assertIn("error", out)
+        self.assertIn("timeline_ids", out["error"]["message"])
+        self.assertIn("timeline_names", out["error"]["message"])
+
+    def test_non_list_rejected(self):
+        out = self._call({"timeline_ids": "abc"})
+        self.assertIn("error", out)
+        self.assertIn("timeline_ids", out["error"]["message"])
+
+    def test_valid_ids_pass_validation(self):
+        # 0 timelines in the fake project, so passing validation lands on the
+        # "No timelines found" lookup error, not the param error.
+        out = self._call({"timeline_ids": ["some-id"]})
+        self.assertIn("error", out)
+        self.assertNotIn("timeline_ids", out["error"]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two tool-surface bugs found during live cataloguing work:

**media_pool_item get_metadata with a list-valued `key` silently returned the full dict.** Resolve's keyed getters take one string; handed a list they ignore it and return everything — silent misbehavior for callers expecting a subset. A list key now returns exactly that subset (missing keys map to `null`), and an empty or non-string list is a clear error. The same guard covers the identical pattern in `get_third_party_metadata` and `get_clip_property`.

**media_pool delete_timelines called with `timeline_names` leaked a bare `KeyError('timeline_ids')`.** It now returns a proper error naming `timeline_ids` (a non-empty list of timeline unique IDs) and, when `timeline_names` was passed, explicitly says timelines are matched by unique ID, not name.

Offline tests in `tests/test_keyed_param_guards.py` (10 cases); full offline suite passes (2339 tests, 26 skipped). Branched from current main, independent of #107/#108/#110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)