### PR TITLE
fix(rough-cut): reconcile skill with the api_truth ledger (import order, Fusion render claim)

### DIFF
--- a/.claude/skills/rough-cut.md
+++ b/.claude/skills/rough-cut.md
@@ -43,10 +43,14 @@ Render an mp4 only to preview the cut, and say that is what it is.
    Do not defer this to the end or write it off as cosmetic; a mismatch has been
    reported to affect playback and output, not just the display. On an existing
    project, read both back and only raise it if they are wrong.
-4. **Import into a bin named for the episode**, then
-   `media_pool set_current_folder` to it. One bin per episode, not one shared
-   dump — it keeps `analyze_bin` scoped and the Media Pool readable across a
-   long series.
+4. **Create a bin named for the episode, `media_pool set_current_folder` to it,
+   THEN import.** That order is mandatory, not stylistic: `ImportMedia` has no
+   destination parameter and always lands in the *current* folder, so importing
+   first puts the clips wherever the current folder happens to be — see the
+   `MediaPool.ImportMedia (current-folder destination only)` entry in the
+   `api_truth` ledger. Restore the previous current folder afterwards if it
+   matters. One bin per episode, not one shared dump — it keeps `analyze_bin`
+   scoped and the Media Pool readable across a long series.
 5. **Analyse** — `media_analysis analyze_bin`, `sampling_mode="adaptive_capped"`.
    Complete the `commit_vision` loop for every clip; leaving one in
    `pending_host_vision_analysis` is a failure, not a partial success (AGENTS.md).
@@ -82,22 +86,36 @@ done. Don't re-litigate it.
 
 ## Verified traps
 
-Confirmed live against Resolve Studio, 2026-07-28. Each one silently produces a
-wrong result rather than an error.
+Each one silently produces a wrong result rather than an error.
 
-| Trap | Symptom | Fix |
-|---|---|---|
-| `clip_infos` `end_frame` is **exclusive** | 1-frame gap between every clip, and matching audio gaps | `end_frame = start_frame + duration` |
-| `create_timeline_from_clips` needs the current folder | Bare `Failed to create timeline from clip_infos`, valid clip_ids | `media_pool set_current_folder` to the clips' bin first |
-| Phone footage carries a `rotation` flag | Stored 3840x2160, displays 2160x3840 | Check `rotation` in ffprobe; Resolve honours it. **Do not reframe** — it is already vertical |
-| Phone footage is **VFR** | `avg_frame_rate` differs per clip and from `r_frame_rate` | Match the timeline to what Resolve conforms to (its reported clip FPS), not to `r_frame_rate` |
-| `timelinePlaybackFrameRate` is read-only | `set_setting` returns False for every value form, before and after a timeline exists | No API path. Ask the user to set it in Master Settings during setup (step 2), not at handover |
-| A Fusion comp attached to a **media clip** via the API never renders | Every call succeeds and the whole graph reads back correctly — comp count 1, `MediaOut1.Input` wired, `StyledText` returning what you set — while the output is the untouched source | Don't build comps on clips. Fusion **titles** inserted as their own timeline clip DO render, and their `Text+` is settable via `fusion_comp set_text_plus` |
+**Every row states the build it was confirmed on.** A date alone is not
+reproducible — the scripting API changes per patch release, so a trap confirmed
+on one build is only a prior on another. Re-confirm before relying on a row
+whose build is older than yours, and update the stamp when you do.
 
-The last two rows are recorded in the `api_truth` ledger and
-`docs/reference/api-limitations.md`; query them at runtime with
-`resolve_control api_truth "fusion"`. The ledger is the canonical copy — this
-table is the narrative version.
+| Trap | Confirmed on | Symptom | Fix |
+|---|---|---|---|
+| `clip_infos` `end_frame` is **exclusive** | Studio 21.0 | 1-frame gap between every clip, and matching audio gaps | `end_frame = start_frame + duration` |
+| **Mixed-fps duration floor** — `start_frame`/`end_frame` are **SOURCE** frames | Studio 21.0 (MCP v2.71.1) | Source fps ≠ timeline fps (24.0 or 29.97 source in a 23.976 timeline) → Resolve **floors** the source→timeline conversion, so a range planned to fill an exact record slot lands one frame short | Plan durations in **timeline** frames: `floor(src_frames * timeline_fps / source_fps)`. If the floored duration misses the slot, extend `end_frame` by one source frame and re-check |
+| `create_timeline_from_clips` needs the current folder | Studio 21.0 | Bare `Failed to create timeline from clip_infos`, valid clip_ids | `media_pool set_current_folder` to the clips' bin first |
+| `ImportMedia` has no destination parameter | Studio 21.0 (MCP v2.71.1) | Clips land wherever the current folder happens to be; an unrecognized destination arg is silently ignored | `set_current_folder` **before** importing (step 4) |
+| Phone footage carries a `rotation` flag | Studio 21.0 | Stored 3840x2160, displays 2160x3840 | Check `rotation` in ffprobe; Resolve honours it. **Do not reframe** — it is already vertical |
+| Phone footage is **VFR** | Studio 21.0 | `avg_frame_rate` differs per clip and from `r_frame_rate` | Match the timeline to what Resolve conforms to (its reported clip FPS), not to `r_frame_rate` |
+| `timelinePlaybackFrameRate` is read-only | Studio 21.0.2 | `set_setting` returns False for every value form, before and after a timeline exists | No API path. Ask the user to set it in Master Settings during setup (step 3), not at handover |
+| An API-built Fusion comp on a **media clip** renders **only when MediaOut has a path from MediaIn** | Studio 19.1.3.7, corrected 2026-08-02 | A comp wired `MediaIn → Blur → MediaOut` **does** render. But a `MediaOut` fed by a tool with **no source** does not merely get bypassed — the render job comes back `Failed`. The earlier blanket claim that such comps "never render" was too broad | Wire the graph so `MediaOut` descends from `MediaIn`, and never leave a tool unrooted. For text over picture, insert a Fusion **title** as its own timeline clip and set its `Text+` via `fusion_comp set_text_plus` |
+
+The mixed-fps, `ImportMedia`, playback-frame-rate and Fusion rows are recorded in
+the `api_truth` ledger and `docs/reference/api-limitations.md`; query them at
+runtime with `resolve_control api_truth "fusion"` (or `"timeline"`,
+`"media-pool"`). **The ledger is the canonical copy — this table is the
+narrative version**, so when the two disagree the ledger wins and this table is
+the thing to correct.
+
+⚠️ A **running** MCP process keeps executing the version it started with, so a
+`git pull` does not update the ledger until it restarts. Check
+`resolve_control get_version` → `mcp.version` before trusting an `api_truth`
+miss: on MCP v2.70.4, `api_truth "DeleteClips"` returns zero facts that
+v2.71.1 does carry.
 
 On burning text over picture specifically: the title route above renders, but
 the API cannot choose a destination track (issue #74 — `Insert*IntoTimeline`


### PR DESCRIPTION
Two rows of `.claude/skills/rough-cut.md` contradict the `api_truth` ledger the skill itself points at. Both were found while following the skill against Resolve Studio 21.0.3.7 on MCP v2.71.1.

### 1. Import order is backwards

Step 4 read:

> **Import into a bin named for the episode**, then `media_pool set_current_folder` to it.

`ImportMedia` has no destination parameter and always lands in the **current** folder, so importing first puts the clips wherever the current folder happens to be. The ledger records this as `MediaPool.ImportMedia (current-folder destination only)`, added in v2.71.1 — the new entry invalidates the older skill text.

Reordered to: create bin → `set_current_folder` → import, with a note to restore the previous current folder if it matters.

### 2. The Fusion row states a claim the ledger has retracted

The traps table still asserts a comp attached to a media clip *"never renders"*. The ledger entry was corrected on 2026-08-02 and explicitly calls the blanket form **too broad**: a comp wired `MediaIn → Blur → MediaOut` **does** render, and an unrooted `MediaOut` does not get silently bypassed — it fails the render job outright, which is a different and more dangerous failure than "no effect".

Replaced with the corrected finding, keeping the actionable guidance (use Fusion titles as their own timeline clip for text over picture).

### 3. Version stamps

The table header carried a date (`2026-07-28`) but no build number. The scripting API changes per patch release, so a date alone isn't reproducible. Each row now names the build it was confirmed on, and the header says to re-confirm rows older than your build.

Also adds two rows already in the v2.71.1 ledger but missing from the narrative table:
- **mixed-fps duration floor** — `start/endFrame` are source frames; source fps ≠ timeline fps floors the conversion and the range lands a frame short
- **`ImportMedia` current-folder-only**

### 4. Stale-ledger footgun

Added a note that a **running** MCP process keeps executing the version it started with, so `git pull` does not refresh the ledger until restart. Concretely: on v2.70.4, `api_truth "DeleteClips"` returns zero facts that v2.71.1 carries — which reads as "no known issues" rather than "stale server".

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)