### PR TITLE
fix(media-pool): error on unresolvable folder addresses instead of silently using the current bin

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -2579,6 +2579,54 @@ def _find_clip_with_parent(folder, clip_id, _parent=None):
             return found_clip, found_parent
     return None, None
 
+def _find_folder_by_id(folder, folder_id):
+    if folder.GetUniqueId() == folder_id:
+        return folder
+    for sub in (folder.GetSubFolderList() or []):
+        found = _find_folder_by_id(sub, folder_id)
+        if found:
+            return found
+    return None
+
+
+def _folder_from_params(mp, p, *path_keys, no_address="current"):
+    """Resolve the folder an action was aimed at. Returns (folder, error).
+
+    Naming no folder falls back to the action's documented default (see
+    `no_address`). What must never happen is the middle case: an addressing argument was
+    supplied, did not resolve, and the action answered about the current bin
+    anyway. That reports success for a different question than the caller asked,
+    and it is indistinguishable from the tool working. It cost one session an
+    afternoon: `folder_id` is not a key any action read, so it was dropped, the
+    current bin's clips came back, and the tools were written off as broken.
+
+    So: unresolvable-but-supplied is an error, and the id that `get_subfolders`
+    hands out is accepted as an address, since being given an id and having no
+    way to use it is what invited the guess.
+
+    `no_address` preserves each action's historical no-argument default: "current"
+    for the folder tool, "root" for the media_pool actions (whose old code hit
+    `_navigate_folder(mp, "")`, which returns root). This fix must not also
+    change what omitting the address means.
+    """
+    remediation = ("List folders with folder get_subfolders (walking down from "
+                   "path=\"Master\") and address by exact path or folder_id.")
+    path = _first_param(p, *path_keys)
+    if path:
+        f = _navigate_folder(mp, path)
+        return (f, None) if f else (None, _err(
+            f"Folder not found: {path}", code="FOLDER_NOT_FOUND",
+            category="invalid_input", remediation=remediation))
+    folder_id = _first_param(p, "folder_id", "folderId")
+    if folder_id:
+        f = _find_folder_by_id(mp.GetRootFolder(), str(folder_id))
+        return (f, None) if f else (None, _err(
+            f"Folder not found: {folder_id}", code="FOLDER_NOT_FOUND",
+            category="invalid_input", remediation=remediation))
+    f = mp.GetRootFolder() if no_address == "root" else mp.GetCurrentFolder()
+    return (f, None) if f else (None, _err("No current Media Pool folder"))
+
+
 def _navigate_folder(mp, path):
     root = mp.GetRootFolder()
     if not path or path in ("Master", "/", ""):
@@ -16666,7 +16714,9 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
             return _err(f"Folder not found: {p.get('path')}")
         return {"success": bool(mp.SetCurrentFolder(f))}
     elif action == "add_subfolder":
-        parent = _navigate_folder(mp, p.get("parent_path", "")) or mp.GetCurrentFolder()
+        parent, folder_err = _folder_from_params(mp, p, "parent_path", "parentPath", no_address="root")
+        if folder_err:
+            return folder_err
         f = mp.AddSubFolder(parent, p["name"])
         return _ok(name=f.GetName(), id=f.GetUniqueId()) if f else _err("Failed to create subfolder")
     elif action == "delete_folders":
@@ -16973,7 +17023,9 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
         clip = _find_clip(root, p["clip_id"])
         return {"mattes": mp.GetClipMatteList(clip)} if clip else _err("Clip not found")
     elif action == "get_timeline_mattes":
-        folder = _navigate_folder(mp, p.get("folder_path", "")) or mp.GetCurrentFolder()
+        folder, folder_err = _folder_from_params(mp, p, "folder_path", "folderPath", no_address="root")
+        if folder_err:
+            return folder_err
         result = mp.GetTimelineMatteList(folder)
         return {"mattes": len(result) if result else 0}
     elif action == "delete_clip_mattes":
@@ -17037,6 +17089,11 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
 def folder(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Operations on Media Pool folders.
 
+    Address a folder with `path` ("Master/SubFolder") or with `folder_id` (the id
+    get_subfolders returns). Omit both for the current folder. An address that is
+    supplied but does not resolve is an error — it never falls back to the current
+    folder.
+
     Actions:
       get_clips(path?) -> {clips}  — path like "Master/SubFolder", omit for current
       get_name(path?) -> {name}
@@ -17057,10 +17114,9 @@ def folder(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, An
     if err:
         return err
 
-    folder_path = p.get("path", "")
-    f = _navigate_folder(mp, folder_path) if folder_path else mp.GetCurrentFolder()
-    if not f:
-        return _err(f"Folder not found: {folder_path}")
+    f, folder_err = _folder_from_params(mp, p, "path", "folder_path", "folderPath")
+    if folder_err:
+        return folder_err
 
     if action == "get_clips":
         clips = f.GetClipList() or []

--- a/tests/test_folder_addressing.py
+++ b/tests/test_folder_addressing.py
@@ -1,0 +1,114 @@
+"""Folder addressing must never silently answer about the current bin.
+
+The defect this pins: an addressing argument the action did not recognise was
+dropped, and the call went on to read (or write to) whatever folder happened to
+be current, returning success. From the caller's side that is identical to the
+tool ignoring its arguments, which is how it was reported.
+"""
+import unittest
+
+from src import server
+
+
+class FakeFolder:
+    def __init__(self, name, uid, subs=None):
+        self._name = name
+        self._uid = uid
+        self._subs = subs or []
+
+    def GetName(self):
+        return self._name
+
+    def GetUniqueId(self):
+        return self._uid
+
+    def GetSubFolderList(self):
+        return list(self._subs)
+
+
+class FakeMP:
+    def __init__(self, root, current):
+        self._root = root
+        self._current = current
+
+    def GetRootFolder(self):
+        return self._root
+
+    def GetCurrentFolder(self):
+        return self._current
+
+
+def _tree():
+    june20 = FakeFolder("2026-06-20", "id-0620")
+    june = FakeFolder("2026-06", "id-06", subs=[june20])
+    august = FakeFolder("2026-08", "id-08")
+    root = FakeFolder("Master", "id-root", subs=[june, august])
+    # Current folder is deliberately NOT the one the tests address.
+    return FakeMP(root, august), june20
+
+
+class FolderAddressingTest(unittest.TestCase):
+    def test_path_wins_over_current_folder(self):
+        mp, june20 = _tree()
+        f, err = server._folder_from_params(mp, {"path": "Master/2026-06/2026-06-20"}, "path")
+        self.assertIsNone(err)
+        self.assertIs(f, june20)
+
+    def test_folder_id_resolves(self):
+        mp, june20 = _tree()
+        f, err = server._folder_from_params(mp, {"folder_id": "id-0620"}, "path")
+        self.assertIsNone(err)
+        self.assertIs(f, june20)
+
+    def _assert_not_found(self, err):
+        # invalid_input, not resolve_api_failed: a bad address is the caller's to
+        # fix, and must not come back marked retryable.
+        self.assertIsNotNone(err)
+        self.assertEqual(err["error"]["code"], "FOLDER_NOT_FOUND")
+        self.assertEqual(err["error"]["category"], "invalid_input")
+        self.assertFalse(err["error"]["retryable"])
+
+    def test_unresolvable_path_errors_instead_of_current(self):
+        mp, _ = _tree()
+        f, err = server._folder_from_params(mp, {"path": "Master/nope"}, "path")
+        self.assertIsNone(f)
+        self._assert_not_found(err)
+
+    def test_unresolvable_id_errors_instead_of_current(self):
+        mp, _ = _tree()
+        f, err = server._folder_from_params(mp, {"folder_id": "id-missing"}, "path")
+        self.assertIsNone(f)
+        self._assert_not_found(err)
+
+    def test_no_address_means_current_folder(self):
+        mp, _ = _tree()
+        f, err = server._folder_from_params(mp, {}, "path")
+        self.assertIsNone(err)
+        self.assertEqual(f.GetName(), "2026-08")
+
+    def test_no_address_root_default_preserved(self):
+        # add_subfolder and get_timeline_mattes historically defaulted to root
+        # (via _navigate_folder(mp, "") returning root), not the current bin.
+        # The fail-loud fix must not change what omitting the address means.
+        mp, _ = _tree()
+        f, err = server._folder_from_params(mp, {}, "parent_path", no_address="root")
+        self.assertIsNone(err)
+        self.assertEqual(f.GetName(), "Master")
+
+    def test_supplied_address_still_errors_under_root_default(self):
+        mp, _ = _tree()
+        f, err = server._folder_from_params(mp, {"parent_path": "Master/nope"}, "parent_path", no_address="root")
+        self.assertIsNone(f)
+        self.assertIsNotNone(err)
+
+    def test_alias_folder_path_is_honoured(self):
+        mp, june20 = _tree()
+        f, err = server._folder_from_params(
+            mp, {"folder_path": "Master/2026-06/2026-06-20"}, "path", "folder_path"
+        )
+        self.assertIsNone(err)
+        self.assertIs(f, june20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

Three actions resolve their folder argument with `_navigate_folder(...) or <fallback>`:

- `folder` (all 13 actions route through one lookup)
- `media_pool add_subfolder`
- `media_pool get_timeline_mattes`

An address that fails to resolve — a typo'd path, or a guessed argument name like `folder_id` that no action reads — is silently dropped, and the action answers about the **current bin** (or root) with a success envelope. For reads, that is a wrong answer indistinguishable from a right one. For `add_subfolder`, it creates the folder in whatever bin the UI happens to have open.

This is how it bites in practice: `folder get_subfolders` returns `id` fields, an agent passes one back as `folder_id`, gets the current bin's clips with `success`, and reasonably concludes the tools ignore their arguments. That exact sequence cost us a session working around a bug that didn't exist.

## The fix

One shared resolver, `_folder_from_params`, used by all three sites:

- **Supplied-but-unresolvable is an error**: `FOLDER_NOT_FOUND`, `invalid_input` (non-retryable — a bad address is the caller's to fix), with remediation naming `get_subfolders`.
- **`folder_id` is accepted as an address** (recursive id walk mirroring `_find_clip`), since `get_subfolders` hands out ids and having no way to use them is what invited the guess.
- **No-address defaults are preserved per action**: current folder for the `folder` tool; root for the two `media_pool` actions, whose old code reached root via `_navigate_folder(mp, "")`. A fail-loud fix must not also change what omitting the address means.

## Verification

- 8 new tests in `tests/test_folder_addressing.py`, each addressing a folder that is deliberately not the current one; the two defaults and the error envelope are pinned.
- Full offline suite on this base: 2399 tests, OK (26 skipped).
- Live against Resolve Studio: path and `folder_id` addressing from a non-current bin, both failure modes returning errors instead of the current bin's contents, and the current folder confirmed unchanged throughout (the resolver never touches bin selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)