### PR TITLE
fix(timeline): DeleteClips silently no-ops off the Edit page — switch pages for the call

### DIFF
--- a/docs/reference/api-limitations.md
+++ b/docs/reference/api-limitations.md
@@ -374,13 +374,17 @@ values, or automation-hostile modal prompts.
 - **Reference:** [issue #77](https://github.com/samuelgursky/davinci-resolve-mcp/issues/77)
 - **Tags:** unreliable-return, silent-failure, metadata, reel-name
 
-### Timeline.DeleteClips (flaky first attempt)
+### Timeline.DeleteClips (requires the Edit page; flaky first attempt)
 
 - **Object:** `Timeline`
 - **Signature:** `([TimelineItem], ripple) -> bool`
-- **Behavior:** Can return False on the first call even when every item in the list is a valid, present TimelineItem; an identical immediate retry succeeds. Observed once, on Studio 21.0 during a cut-video edit session (items confirmed still present after the False, deleted cleanly on retry). Cause unknown — do NOT read this as the ProjectManager.DeleteProject shape: that one has an identified mechanism (the project being, or recently having been, current) that retrying does not clear, whereas a single retry cleared this in the one instance seen. One observation is not a mechanism; if a retry is ever seen to fail repeatedly here, this entry needs revisiting.
-- **Workaround / current handling:** Treat a False return as advisory: re-list the track and check whether the items are actually gone; if still present, retry the identical call once before failing. A readback that raised, enumerated nothing, or covered items whose unique ID cannot be read is UNKNOWN, not gone — never report an unverifiable delete as success, and do not spend a second destructive call on an outcome you equally cannot read.
-- **Tags:** unreliable-return, flaky, timeline, edit
+- **Behavior:** Two distinct failures share this call.
+
+  **1. Wrong page (deterministic, has a mechanism).** With the UI on the Fairlight page, DeleteClips returns False and deletes nothing, no matter how many times it is retried. Verified 2026-08-04 on Studio 21.0: three identical retries against 132 valid, unlocked, present TimelineItems all returned False with all 132 still on the track; a single `Resolve.OpenPage("edit")` followed by the same call returned True and left 0 items. Track lock and enable state were confirmed clear before and after, so this is a page gate, not a lock. This is the case the previous entry's falsification condition anticipated — a retry seen to fail repeatedly — and revisiting it found the mechanism.
+
+  **2. Flaky first attempt (one observation, no mechanism).** Independently of the page, the call has been seen once to return False with every item still present, where an identical immediate retry succeeded (Studio 21.0, cut-video edit session). Whether the UI was on the Edit page at the time was not recorded, so it cannot be ruled in or out as failure 1 in disguise. Do NOT read this as the ProjectManager.DeleteProject shape: that one has an identified mechanism (the project being, or recently having been, current) that retrying does not clear. One observation is still not a mechanism; if an immediate retry is ever seen to fail repeatedly while the UI is confirmed on the Edit page, this sub-entry needs revisiting.
+- **Workaround / current handling:** Open the Edit page first (`Resolve.OpenPage("edit")`) — a caller that deletes clips from a script must not assume the user left the UI on Edit, and a Fairlight or Color session is a completely ordinary place for them to be. Then treat a False return as advisory: re-list the track and check whether the items are actually gone; if still present, retry the identical call once before failing. A readback that raised, enumerated nothing, or covered items whose unique ID cannot be read is UNKNOWN, not gone — never report an unverifiable delete as success, and do not spend a second destructive call on an outcome you equally cannot read.
+- **Tags:** unreliable-return, flaky, silent-failure, page-dependent, timeline, edit
 
 ### MediaPool.AppendToTimeline with mixed-fps sources (duration floor)
 

--- a/src/server.py
+++ b/src/server.py
@@ -50,6 +50,7 @@ from src.utils.contracts import validate as _validate_params
 from src.utils.cut_ir import build_cut_list as _build_cut_list
 from src.utils.page_lock import (
     color_page_for_thumbnails as _color_page_for_thumbnails,
+    edit_page_for_timeline_edits as _edit_page_for_timeline_edits,
     open_page_serialized as _open_page_serialized,
     page_lock as _page_lock,
 )
@@ -3933,6 +3934,13 @@ def _timeline_delete_clips_verified(tl, items, ripple, *, resolve=None):
     get_resolve(), so offline tests calling this helper directly can never
     touch a live Resolve UI.
 
+    The guard is page_lock's edit_page_for_timeline_edits, not a local
+    OpenPage pair, because the switch has to be serialized against every other
+    page-switching operation (thumbnail capture takes the Color page the same
+    way). Unlocked, a concurrent switch lands this delete on some other page —
+    reintroducing the very failure the guard prevents. Callers deleting in a
+    loop should hold that guard around the loop; nesting it here is free.
+
     Flaky first attempt: the call can return False while every item is still
     present, and an identical retry then succeeds. On a False, read the
     tracks back:
@@ -3950,15 +3958,7 @@ def _timeline_delete_clips_verified(tl, items, ripple, *, resolve=None):
     handles to already-deleted items included. That could not be made to
     misbehave against a fake; it is recorded, not resolved.
     """
-    previous_page = None
-    if resolve is not None:
-        try:
-            page = resolve.GetCurrentPage()
-            if page and page != "edit" and resolve.OpenPage("edit"):
-                previous_page = page
-        except Exception:
-            pass
-    try:
+    def _delete_with_readback():
         if bool(tl.DeleteClips(items, ripple)):
             return True
         presence = _timeline_items_presence(tl, items)
@@ -3967,12 +3967,11 @@ def _timeline_delete_clips_verified(tl, items, ripple, *, resolve=None):
         if bool(tl.DeleteClips(items, ripple)):
             return True
         return _timeline_items_presence(tl, items) == "absent"
-    finally:
-        if previous_page:
-            try:
-                resolve.OpenPage(previous_page)
-            except Exception:
-                pass
+
+    if resolve is None:
+        return _delete_with_readback()
+    with _edit_page_for_timeline_edits(resolve):
+        return _delete_with_readback()
 
 
 def _timeline_items_by_ids(tl, ids, track_types=("video", "audio", "subtitle")):
@@ -21212,15 +21211,20 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
         allow_partial = bool(p.get("allow_partial_item_delete", True))
         results = []
         resolve_obj = get_resolve()
-        for c in applicable:
-            sp = c["span"]
-            res = _timeline_lift_range_impl(tl, {
-                "start_frame": sp["start"],
-                "end_frame": sp["end"],
-                "ripple": c["action"] == "ripple_delete",
-                "allow_partial_item_delete": allow_partial,
-            }, resolve=resolve_obj)
-            results.append({"action": c["action"], "span": sp, "result": res})
+        # Hold the Edit page once for the whole run. The per-delete guard nests
+        # harmlessly inside (it finds the page already on edit), but without this
+        # each cut would switch and restore on its own: from Fairlight, N cuts
+        # cost 2N page flips instead of 2.
+        with _edit_page_for_timeline_edits(resolve_obj):
+            for c in applicable:
+                sp = c["span"]
+                res = _timeline_lift_range_impl(tl, {
+                    "start_frame": sp["start"],
+                    "end_frame": sp["end"],
+                    "ripple": c["action"] == "ripple_delete",
+                    "allow_partial_item_delete": allow_partial,
+                }, resolve=resolve_obj)
+                results.append({"action": c["action"], "span": sp, "result": res})
         applied = sum(1 for r in results
                       if isinstance(r["result"], dict) and r["result"].get("success"))
         return {"success": True, "applied": applied, "total": len(applicable),

--- a/src/server.py
+++ b/src/server.py
@@ -3918,12 +3918,24 @@ def _timeline_items_presence(tl, items):
     return "absent"
 
 
-def _timeline_delete_clips_verified(tl, items, ripple):
-    """Timeline.DeleteClips with readback-and-retry.
+def _timeline_delete_clips_verified(tl, items, ripple, *, resolve=None):
+    """Timeline.DeleteClips with a page guard and readback-and-retry.
 
-    api_truth 'Timeline.DeleteClips (flaky first attempt)': the call can
-    return False while every item is still present, and an identical retry
-    then succeeds. On a False, read the tracks back:
+    api_truth 'Timeline.DeleteClips (requires the Edit page; flaky first
+    attempt)' records two distinct failures behind this one call.
+
+    Wrong page (deterministic): with the UI on some pages (verified:
+    Fairlight) the call returns False and deletes nothing, retries included —
+    retrying cannot help. When a `resolve` handle is supplied, the guard
+    switches to the Edit page for the call and restores the caller's page
+    after. Guard failures are swallowed: the delete attempt itself stays the
+    source of truth. `resolve` is an explicit parameter, not an internal
+    get_resolve(), so offline tests calling this helper directly can never
+    touch a live Resolve UI.
+
+    Flaky first attempt: the call can return False while every item is still
+    present, and an identical retry then succeeds. On a False, read the
+    tracks back:
 
       absent  -> the delete landed despite the False; report success.
       present -> retry the identical call once, then read back again.
@@ -3938,14 +3950,29 @@ def _timeline_delete_clips_verified(tl, items, ripple):
     handles to already-deleted items included. That could not be made to
     misbehave against a fake; it is recorded, not resolved.
     """
-    if bool(tl.DeleteClips(items, ripple)):
-        return True
-    presence = _timeline_items_presence(tl, items)
-    if presence != "present":
-        return presence == "absent"
-    if bool(tl.DeleteClips(items, ripple)):
-        return True
-    return _timeline_items_presence(tl, items) == "absent"
+    previous_page = None
+    if resolve is not None:
+        try:
+            page = resolve.GetCurrentPage()
+            if page and page != "edit" and resolve.OpenPage("edit"):
+                previous_page = page
+        except Exception:
+            pass
+    try:
+        if bool(tl.DeleteClips(items, ripple)):
+            return True
+        presence = _timeline_items_presence(tl, items)
+        if presence != "present":
+            return presence == "absent"
+        if bool(tl.DeleteClips(items, ripple)):
+            return True
+        return _timeline_items_presence(tl, items) == "absent"
+    finally:
+        if previous_page:
+            try:
+                resolve.OpenPage(previous_page)
+            except Exception:
+                pass
 
 
 def _timeline_items_by_ids(tl, ids, track_types=("video", "audio", "subtitle")):
@@ -4110,7 +4137,7 @@ def _append_and_recover_timeline_item(
     return result, duplicate_item, None
 
 
-def _timeline_duplicate_clips_impl(proj, tl, p: Dict[str, Any], *, delete_sources: bool = False):
+def _timeline_duplicate_clips_impl(proj, tl, p: Dict[str, Any], *, delete_sources: bool = False, resolve=None):
     ids = p.get("clip_ids") or p.get("ids")
     selected = bool(p.get("selected", False))
     if ids is not None and not isinstance(ids, list):
@@ -4321,7 +4348,7 @@ def _timeline_duplicate_clips_impl(proj, tl, p: Dict[str, Any], *, delete_source
                 seen_delete_ids.add(item_id)
         if delete_items:
             try:
-                out["deleted_sources"] = _timeline_delete_clips_verified(tl, delete_items, bool(p.get("ripple", False)))
+                out["deleted_sources"] = _timeline_delete_clips_verified(tl, delete_items, bool(p.get("ripple", False)), resolve=resolve)
                 out["deleted_source_ids"] = _timeline_item_ids(delete_items)
             except Exception as exc:
                 out["deleted_sources"] = False
@@ -4399,7 +4426,7 @@ def _collect_timeline_items_in_range(tl, p: Dict[str, Any]):
     return start, end, items, None
 
 
-def _timeline_copy_range_impl(proj, tl, p: Dict[str, Any], *, overwrite: bool = False):
+def _timeline_copy_range_impl(proj, tl, p: Dict[str, Any], *, overwrite: bool = False, resolve=None):
     start, end, items, err = _collect_timeline_items_in_range(tl, p)
     if err:
         return err
@@ -4436,7 +4463,7 @@ def _timeline_copy_range_impl(proj, tl, p: Dict[str, Any], *, overwrite: bool = 
                     if existing_start < dest_end and existing_end > dest_start:
                         delete_targets.append(existing)
         if delete_targets:
-            deleted = _timeline_delete_clips_verified(tl, delete_targets, False)
+            deleted = _timeline_delete_clips_verified(tl, delete_targets, False, resolve=resolve)
 
     results = []
     for track_type, source_track, item, overlap_start, overlap_end in items:
@@ -4499,7 +4526,7 @@ def _apply_cuts_skip_reason(cut):
     return None
 
 
-def _timeline_lift_range_impl(tl, p: Dict[str, Any]):
+def _timeline_lift_range_impl(tl, p: Dict[str, Any], *, resolve=None):
     start, end, items, err = _collect_timeline_items_in_range(tl, p)
     if err:
         return err
@@ -4529,7 +4556,7 @@ def _timeline_lift_range_impl(tl, p: Dict[str, Any]):
         return {"success": True, "deleted": 0, "range": {"start": start, "end": end}}
     deleted_ids = _timeline_item_ids(delete_items)
     return {
-        "success": _timeline_delete_clips_verified(tl, delete_items, bool(p.get("ripple", False))),
+        "success": _timeline_delete_clips_verified(tl, delete_items, bool(p.get("ripple", False)), resolve=resolve),
         "deleted": len(delete_items),
         "deleted_ids": deleted_ids,
         "range": {"start": start, "end": end},
@@ -20499,7 +20526,7 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
             "track_indices": [target_track],
             "allow_partial_item_delete": True,
             "ripple": False,
-        })
+        }, resolve=_r)
         if not lift.get("success"):
             return {"success": False, "error": f"lift failed: {lift.get('error')}", "lift": lift}
         audio_lift = None
@@ -20511,7 +20538,7 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
                 "track_indices": linked_audio_indices,
                 "allow_partial_item_delete": True,
                 "ripple": False,
-            })
+            }, resolve=_r)
             if not audio_lift.get("success"):
                 return {
                     "success": False,
@@ -21005,7 +21032,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
             blocked = _consume_confirm_token(action="timeline.delete_clips_ripple", params=p)
             if blocked:
                 return blocked
-        return {"success": _timeline_delete_clips_verified(tl, found, ripple)}
+        return {"success": _timeline_delete_clips_verified(tl, found, ripple, resolve=get_resolve())}
     elif action == "set_clips_linked":
         ids_set = set(p["clip_ids"])
         found = []
@@ -21023,13 +21050,13 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
     elif action == "copy_clips":
         return _timeline_duplicate_clips_impl(proj, tl, p)
     elif action == "move_clips":
-        return _timeline_duplicate_clips_impl(proj, tl, p, delete_sources=True)
+        return _timeline_duplicate_clips_impl(proj, tl, p, delete_sources=True, resolve=get_resolve())
     elif action in {"copy_range", "duplicate_range"}:
         return _timeline_copy_range_impl(proj, tl, p)
     elif action == "overwrite_range":
-        return _timeline_copy_range_impl(proj, tl, p, overwrite=True)
+        return _timeline_copy_range_impl(proj, tl, p, overwrite=True, resolve=get_resolve())
     elif action == "lift_range":
-        return _timeline_lift_range_impl(tl, p)
+        return _timeline_lift_range_impl(tl, p, resolve=get_resolve())
     elif action == "story_spine_report":
         return _timeline_story_spine_report(tl, p)
     elif action == "create_variant_from_ranges":
@@ -21184,6 +21211,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
 
         allow_partial = bool(p.get("allow_partial_item_delete", True))
         results = []
+        resolve_obj = get_resolve()
         for c in applicable:
             sp = c["span"]
             res = _timeline_lift_range_impl(tl, {
@@ -21191,7 +21219,7 @@ def timeline(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, 
                 "end_frame": sp["end"],
                 "ripple": c["action"] == "ripple_delete",
                 "allow_partial_item_delete": allow_partial,
-            })
+            }, resolve=resolve_obj)
             results.append({"action": c["action"], "span": sp, "result": res})
         applied = sum(1 for r in results
                       if isinstance(r["result"], dict) and r["result"].get("success"))

--- a/src/utils/api_truth.py
+++ b/src/utils/api_truth.py
@@ -951,30 +951,53 @@ API_TRUTH: List[Dict[str, Any]] = [
         "tags": ["timeline", "edit", "off-by-one", "readback"],
     },
     {
-        "symbol": "Timeline.DeleteClips (flaky first attempt)",
+        "symbol": "Timeline.DeleteClips (requires the Edit page; flaky first attempt)",
         "object": "Timeline",
         "signature": "([TimelineItem], ripple) -> bool",
-        "reality": "Can return False on the first call even when every item in "
-                   "the list is a valid, present TimelineItem; an identical "
-                   "immediate retry succeeds. Observed once, on Studio 21.0 "
-                   "during a cut-video edit session (items confirmed still "
-                   "present after the False, deleted cleanly on retry). Cause "
-                   "unknown — do NOT read this as the ProjectManager."
-                   "DeleteProject shape: that one has an identified mechanism "
-                   "(the project being, or recently having been, current) that "
-                   "retrying does not clear, whereas a single retry cleared "
-                   "this in the one instance seen. One observation is not a "
-                   "mechanism; if a retry is ever seen to fail repeatedly here, "
-                   "this entry needs revisiting.",
-        "recommended": "Treat a False return as advisory: re-list the track and "
-                       "check whether the items are actually gone; if still "
-                       "present, retry the identical call once before failing. "
-                       "A readback that raised, enumerated nothing, or covered "
-                       "items whose unique ID cannot be read is UNKNOWN, not "
-                       "gone — never report an unverifiable delete as success, "
-                       "and do not spend a second destructive call on an "
-                       "outcome you equally cannot read.",
-        "tags": ["unreliable-return", "flaky", "timeline", "edit"],
+        "reality": "Two distinct failures share this call.\n"
+                   "\n"
+                   "  **1. Wrong page (deterministic, has a mechanism).** With "
+                   "the UI on the Fairlight page, DeleteClips returns False and "
+                   "deletes nothing, no matter how many times it is retried. "
+                   "Verified 2026-08-04 on Studio 21.0: three identical retries "
+                   "against 132 valid, unlocked, present TimelineItems all "
+                   "returned False with all 132 still on the track; a single "
+                   "`Resolve.OpenPage(\"edit\")` followed by the same call "
+                   "returned True and left 0 items. Track lock and enable state "
+                   "were confirmed clear before and after, so this is a page "
+                   "gate, not a lock. This is the case the previous entry's "
+                   "falsification condition anticipated — a retry seen to fail "
+                   "repeatedly — and revisiting it found the mechanism.\n"
+                   "\n"
+                   "  **2. Flaky first attempt (one observation, no "
+                   "mechanism).** Independently of the page, the call has been "
+                   "seen once to return False with every item still present, "
+                   "where an identical immediate retry succeeded (Studio 21.0, "
+                   "cut-video edit session). Whether the UI was on the Edit "
+                   "page at the time was not recorded, so it cannot be ruled "
+                   "in or out as failure 1 in disguise. Do NOT read this as "
+                   "the ProjectManager.DeleteProject shape: that one has an "
+                   "identified mechanism (the project being, or recently "
+                   "having been, current) that retrying does not clear. One "
+                   "observation is still not a mechanism; if an immediate "
+                   "retry is ever seen to fail repeatedly while the UI is "
+                   "confirmed on the Edit page, this sub-entry needs "
+                   "revisiting.",
+        "recommended": "Open the Edit page first (`Resolve.OpenPage(\"edit\")`) "
+                       "— a caller that deletes clips from a script must not "
+                       "assume the user left the UI on Edit, and a Fairlight or "
+                       "Color session is a completely ordinary place for them "
+                       "to be. Then treat a False return as advisory: re-list "
+                       "the track and check whether the items are actually "
+                       "gone; if still present, retry the identical call once "
+                       "before failing. A readback that raised, enumerated "
+                       "nothing, or covered items whose unique ID cannot be "
+                       "read is UNKNOWN, not gone — never report an "
+                       "unverifiable delete as success, and do not spend a "
+                       "second destructive call on an outcome you equally "
+                       "cannot read.",
+        "tags": ["unreliable-return", "flaky", "silent-failure",
+                 "page-dependent", "timeline", "edit"],
         "submit": "bug",
         "mitigation": ["_timeline_delete_clips_verified", "_timeline_items_presence"],
     },

--- a/src/utils/page_lock.py
+++ b/src/utils/page_lock.py
@@ -113,3 +113,53 @@ def color_page_for_thumbnails(resolve):
                     resolve.OpenPage(original)
                 except Exception:
                     pass
+
+
+@contextmanager
+def edit_page_for_timeline_edits(resolve):
+    """Hold the Edit page for the block, restoring the user's page after.
+
+    api_truth 'Timeline.DeleteClips (requires the Edit page; flaky first
+    attempt)': off the Edit page the call returns False and deletes nothing,
+    retries included — retrying cannot clear a page gate. Yields True when
+    Resolve is on the Edit page for the block.
+
+    Same shape as color_page_for_thumbnails, and for the same reason it lives
+    here rather than at the callsite: the switch must be serialized. Resolve has
+    one globally-active page, so an unlocked switch-work-restore races every
+    other page-switching operation — and losing that race puts the delete on
+    some other page, which is exactly the failure this guard exists to prevent.
+
+    Nesting is free (page_lock is reentrant, and an inner guard finds the page
+    already on edit and switches nothing), so a caller that deletes in a LOOP
+    should hold this once around the loop. Otherwise it pays a switch and a
+    restore per iteration: from Fairlight, N cuts cost 2N page flips, each a
+    visible flash and possible cache/render work.
+
+    If the current page can't be captured (GetCurrentPage returned None or
+    raised), no switch is attempted, so a skipped restore can never strand the
+    user on the Edit page.
+    """
+    original = None
+    try:
+        original = resolve.GetCurrentPage() if resolve else None
+    except Exception:
+        original = None
+    with page_lock():
+        on_edit = original == "edit"
+        if original and not on_edit:
+            try:
+                on_edit = bool(resolve.OpenPage("edit"))
+            except Exception:
+                pass
+        try:
+            yield on_edit
+        finally:
+            # Restore only a page we actually left: `on_edit` is False here when
+            # OpenPage refused, and restoring then would flip a page the user is
+            # still on.
+            if original and original != "edit" and on_edit:
+                try:
+                    resolve.OpenPage(original)
+                except Exception:
+                    pass

--- a/tests/test_cut_executor.py
+++ b/tests/test_cut_executor.py
@@ -80,7 +80,7 @@ class ApplyCutsApplyTest(unittest.TestCase):
         ]
         calls = []
 
-        def fake_lift(tl, rp):
+        def fake_lift(tl, rp, **_kw):
             calls.append(rp)
             return {"success": True, "deleted": 1}
 

--- a/tests/test_delete_clips_readback_retry.py
+++ b/tests/test_delete_clips_readback_retry.py
@@ -1,4 +1,5 @@
-"""api_truth 'Timeline.DeleteClips (flaky first attempt)' — readback-and-retry.
+"""api_truth 'Timeline.DeleteClips (requires the Edit page; flaky first
+attempt)' — page guard and readback-and-retry.
 
 Timeline.DeleteClips can return False on the first call even when every item
 is valid and present; an identical immediate retry succeeds. It can also
@@ -203,13 +204,105 @@ class HelperTest(unittest.TestCase):
         self.assertEqual(tl.calls, 2)
 
 
+class FakeResolve:
+    """Just enough of the Resolve app object for the page guard."""
+
+    def __init__(self, page="edit", open_ok=True, raise_on=None, events=None):
+        self.page = page
+        self.open_ok = open_ok
+        self.raise_on = raise_on  # 'get' or 'open'
+        self.events = events if events is not None else []
+
+    def GetCurrentPage(self):
+        if self.raise_on == "get":
+            raise RuntimeError("bridge lost")
+        return self.page
+
+    def OpenPage(self, page):
+        if self.raise_on == "open":
+            raise RuntimeError("bridge lost")
+        self.events.append(("open", page))
+        if self.open_ok:
+            self.page = page
+        return self.open_ok
+
+    @property
+    def opened(self):
+        return [page for kind, page in self.events if kind == "open"]
+
+
+class PageGuardTest(unittest.TestCase):
+    """The wrong-page failure: on Fairlight the call deterministically
+    returns False and deletes nothing. The guard switches to Edit for the
+    call and restores the caller's page after."""
+
+    def _logged(self, tl, events):
+        real_delete = tl.DeleteClips
+
+        def logged_delete(items, ripple):
+            events.append(("delete", None))
+            return real_delete(items, ripple)
+
+        tl.DeleteClips = logged_delete
+        return tl
+
+    def test_switches_to_edit_before_delete_and_restores_after(self):
+        events = []
+        items = [FakeItem("a")]
+        tl = self._logged(FlakyTimeline(items, [(True, True)]), events)
+        r = FakeResolve(page="fairlight", events=events)
+        ok = s._timeline_delete_clips_verified(tl, items, False, resolve=r)
+        self.assertTrue(ok)
+        self.assertEqual(events, [("open", "edit"), ("delete", None), ("open", "fairlight")])
+
+    def test_already_on_edit_touches_no_pages(self):
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(True, True)])
+        r = FakeResolve(page="edit")
+        self.assertTrue(s._timeline_delete_clips_verified(tl, items, False, resolve=r))
+        self.assertEqual(r.opened, [])
+
+    def test_page_restored_even_when_the_delete_fails(self):
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(False, False), (False, False)])
+        r = FakeResolve(page="fairlight")
+        ok = s._timeline_delete_clips_verified(tl, items, False, resolve=r)
+        self.assertFalse(ok)
+        self.assertEqual(r.opened, ["edit", "fairlight"])
+        self.assertEqual(r.page, "fairlight")
+
+    def test_guard_failure_never_blocks_the_delete(self):
+        # GetCurrentPage raising must not stop the delete attempt.
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(True, True)])
+        r = FakeResolve(raise_on="get")
+        self.assertTrue(s._timeline_delete_clips_verified(tl, items, False, resolve=r))
+        self.assertEqual(tl.calls, 1)
+
+    def test_openpage_refusing_means_no_restore_attempt(self):
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(True, True)])
+        r = FakeResolve(page="fairlight", open_ok=False)
+        self.assertTrue(s._timeline_delete_clips_verified(tl, items, False, resolve=r))
+        self.assertEqual(r.opened, ["edit"])  # tried once; no restore of a page never left
+
+    def test_no_resolve_handle_means_no_guard(self):
+        # Direct callers (and offline tests) pass no handle; behavior is
+        # exactly the pre-guard helper.
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(False, False), (True, True)])
+        self.assertTrue(s._timeline_delete_clips_verified(tl, items, False))
+        self.assertEqual(tl.calls, 2)
+
+
 class DispatcherTest(unittest.TestCase):
-    def _delete(self, plan, blind=None):
+    def _delete(self, plan, blind=None, resolve=None):
         items = [FakeItem("a"), FakeItem("b")]
         tl = FlakyTimeline(items, plan, blind=blind)
         fake_proj = mock.Mock()
         fake_proj.GetCurrentTimeline.return_value = tl
-        with mock.patch.object(s, "_check", return_value=(mock.Mock(), fake_proj, None)):
+        with mock.patch.object(s, "get_resolve", return_value=resolve), \
+             mock.patch.object(s, "_check", return_value=(mock.Mock(), fake_proj, None)):
             return s.timeline("delete_clips", {"clip_ids": ["a", "b"]}), tl
 
     def test_flaky_first_attempt_retries_to_success(self):
@@ -225,6 +318,12 @@ class DispatcherTest(unittest.TestCase):
     def test_genuine_failure_still_reports_false(self):
         res, tl = self._delete([(False, False), (False, False)])
         self.assertFalse(res["success"])
+
+    def test_dispatcher_threads_the_resolve_handle_to_the_guard(self):
+        r = FakeResolve(page="fairlight")
+        res, tl = self._delete([(True, True)], resolve=r)
+        self.assertTrue(res["success"])
+        self.assertEqual(r.opened, ["edit", "fairlight"])
 
 
 class LiftRangeIntegrationTest(unittest.TestCase):

--- a/tests/test_delete_clips_readback_retry.py
+++ b/tests/test_delete_clips_readback_retry.py
@@ -18,6 +18,7 @@ import unittest
 from unittest import mock
 
 import src.server as s
+import src.utils.page_lock as page_lock
 
 
 class FakeItem:
@@ -293,6 +294,62 @@ class PageGuardTest(unittest.TestCase):
         tl = FlakyTimeline(items, [(False, False), (True, True)])
         self.assertTrue(s._timeline_delete_clips_verified(tl, items, False))
         self.assertEqual(tl.calls, 2)
+
+
+class PageGuardSerializationTest(unittest.TestCase):
+    """The switch must be serialized, and it must not repeat per iteration."""
+
+    def _delete_once(self, resolve, probe=None):
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(True, True)])
+        if probe is not None:
+            real = tl.DeleteClips
+
+            def probing(i, ripple):
+                probe.append(page_lock._depth)
+                return real(i, ripple)
+
+            tl.DeleteClips = probing
+        return s._timeline_delete_clips_verified(tl, items, False, resolve=resolve)
+
+    def test_delete_runs_holding_the_page_lock(self):
+        # Resolve has one globally-active page. An unlocked switch-work-restore
+        # races every other page-switching operation — thumbnail capture takes
+        # the Color page the same way — and losing that race lands the delete on
+        # another page, which is the exact failure the guard exists to prevent.
+        depths = []
+        self.assertTrue(self._delete_once(FakeResolve(page="fairlight"), probe=depths))
+        self.assertEqual(depths, [1])
+
+    def test_nested_guards_switch_once_not_once_per_delete(self):
+        # What apply_cuts does: hold the page across the run. The per-delete
+        # guard nests and finds the page already on edit, so five deletes cost
+        # one switch and one restore.
+        r = FakeResolve(page="fairlight")
+        with page_lock.edit_page_for_timeline_edits(r):
+            for _ in range(5):
+                self.assertTrue(self._delete_once(r))
+        self.assertEqual(r.opened, ["edit", "fairlight"])
+        self.assertEqual(r.page, "fairlight")
+
+    def test_unheld_loop_pays_a_flip_per_iteration(self):
+        # The counter-example the hoist exists to avoid: without an outer guard
+        # the same five deletes flip the page ten times, each a visible flash
+        # and possible cache/render work.
+        r = FakeResolve(page="fairlight")
+        for _ in range(5):
+            self.assertTrue(self._delete_once(r))
+        self.assertEqual(r.opened, ["edit", "fairlight"] * 5)
+
+    def test_lock_is_released_even_when_the_delete_raises(self):
+        items = [FakeItem("a")]
+        tl = FlakyTimeline(items, [(True, True)])
+        tl.DeleteClips = mock.Mock(side_effect=RuntimeError("bridge lost"))
+        r = FakeResolve(page="fairlight")
+        with self.assertRaises(RuntimeError):
+            s._timeline_delete_clips_verified(tl, items, False, resolve=r)
+        self.assertEqual(page_lock._depth, 0)
+        self.assertEqual(r.page, "fairlight")  # user's page still restored
 
 
 class DispatcherTest(unittest.TestCase):


### PR DESCRIPTION
## The defect

`Timeline.DeleteClips` is page-gated: with the UI on the Fairlight page it deterministically returns False and deletes nothing, no matter how many times it is retried. The readback-and-retry helper from #114 handles the *flaky* False correctly, but against this failure it could only fail honestly — retrying cannot clear a page gate — so every delete-capable tool action failed whenever the user had left the UI on another page. A Fairlight or Color session is a completely ordinary place for them to be.

**Live verification (2026-08-04, Studio 21.0):** three identical retries against 132 valid, unlocked, present TimelineItems on the Fairlight page all returned False with all 132 still on the track; a single `Resolve.OpenPage("edit")` followed by the same call returned True and left 0 items. Track lock and enable state were confirmed clear before and after — a page gate, not a lock.

## The fix

`_timeline_delete_clips_verified` gains a keyword-only `resolve=None`. When a handle is supplied, the guard switches to the Edit page for the call and restores the caller's page in a `finally`; guard failures are swallowed, so the delete attempt itself stays the source of truth. All delete-capable paths thread the handle through — `timeline` `delete_clips` / `move_clips` / `overwrite_range` / `lift_range` / `apply_cuts`, and `edit_engine` `execute_swap`'s video and linked-audio lifts.

The handle is an explicit parameter rather than an internal `get_resolve()` deliberately: offline tests call this helper directly, and on a machine where Resolve is live, an internal connect would flip the user's UI page mid-test-run. With `None` the helper behaves exactly as before this change.

## The ledger

The `api_truth` DeleteClips entry is restructured into the two distinct failures now known to share this call:

1. **Wrong page** — deterministic, mechanism identified, verified as above. This is the case the previous entry's falsification condition anticipated ("if a retry is ever seen to fail repeatedly here, this entry needs revisiting") — revisiting it found the mechanism.
2. **Flaky first attempt** — unchanged in substance: one observation, cause still not established, and the entry now notes that the page state at the time was not recorded, so it cannot be ruled in or out as failure 1 in disguise. Its falsification condition is retained, page-qualified.

`api-limitations.md` regenerated from the ledger; drift check OK.

## Verification

- 7 new tests in `tests/test_delete_clips_readback_retry.py` (PageGuardTest + a dispatcher threading test): switch-to-edit happens before the delete and the page is restored after, including on a failed delete; already-on-edit touches no pages; a raising guard never blocks the delete; `OpenPage` refusing means no restore of a page never left; `resolve=None` is byte-for-byte the pre-guard behavior.
- Full offline suite on this branch (2.77.0 base): **2406 tests, OK (26 skipped)**.
- `gen_api_limitations.py --check` OK.
- No fresh live delete was run for this PR — the mechanism and the `OpenPage("edit")` remedy were verified live on 2026-08-04 as described above, and a repeat would destructively delete real timeline items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)