### PR TITLE
fix: scrub PYTHONHOME/PYTHONPATH before spawning the whisper CLI subprocess

### DIFF
--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -2376,13 +2376,18 @@ def build_plan(
     }
 
 
-def _run_command(args: List[str], timeout: int = COMMAND_TIMEOUT_SECONDS) -> Tuple[int, str, str]:
+def _run_command(
+    args: List[str],
+    timeout: int = COMMAND_TIMEOUT_SECONDS,
+    env: Optional[Dict[str, str]] = None,
+) -> Tuple[int, str, str]:
     try:
         proc = subprocess.run(
             args,
             capture_output=True,
             timeout=timeout,
             check=False,
+            env=env,
         )
     except subprocess.TimeoutExpired as exc:
         stdout = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
@@ -4023,7 +4028,21 @@ def _transcribe_with_whisper_cli(path: str, artifacts: Dict[str, Any], transcrip
     ]
     if transcription.get("language"):
         cmd.extend(["--language", str(transcription["language"])])
-    code, _, stderr = _run_command(cmd, timeout=int(transcription.get("timeout", 1800)))
+    # PYTHONHOME/PYTHONPATH are set in this server's own environment to point
+    # at Resolve's bundled Python (for DaVinciResolveScript) — inherited by a
+    # child process, they corrupt a *different* Python interpreter's own
+    # stdlib resolution. whisper's CLI is itself a Python program (frequently
+    # a different interpreter/venv than this server's), so it must not
+    # inherit these. Confirmed by hang: whisper_cli silently stalled
+    # (ffmpeg child pegged at 0% CPU, never exiting) under the inherited
+    # env, and completed normally in under 5 minutes once these were
+    # stripped. PYTHONIOENCODING=utf-8 avoids a separate UnicodeEncodeError
+    # crash in whisper's own argparse help text on non-UTF-8 consoles.
+    whisper_env = dict(os.environ)
+    whisper_env.pop("PYTHONHOME", None)
+    whisper_env.pop("PYTHONPATH", None)
+    whisper_env["PYTHONIOENCODING"] = "utf-8"
+    code, _, stderr = _run_command(cmd, timeout=int(transcription.get("timeout", 1800)), env=whisper_env)
     if code != 0:
         return {"success": False, "backend": "whisper_cli", "error": stderr.strip() or "whisper CLI failed"}
     json_files = sorted(Path(work_dir).glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sqlite3
 import subprocess
+import sys
 import tempfile
 import unittest
 import unittest.mock
@@ -58,6 +59,7 @@ from src.utils.media_analysis import (
     execute_plan,
     execute_plan_async,
     executing_clips,
+    _run_command,
     plan_requires_capabilities,
     load_report,
     mark_registry_stale_for_clip,
@@ -4760,6 +4762,44 @@ class InventoryCacheReuseTests(unittest.TestCase):
                 self.dash._current_resolve_project_id = original
             self.assertTrue(payload["resolve_available"])
             self.assertEqual(payload["counts"]["total"], 2)
+
+
+class RunCommandEnvOverrideTests(unittest.TestCase):
+    """Bug 1: _run_command must let a caller pass a scrubbed env for a subprocess
+    that shouldn't inherit this server's own PYTHONHOME/PYTHONPATH (set for
+    DaVinciResolveScript, but fatal to a *different* Python interpreter such as
+    whisper's CLI — see davinci-resolve-mcp CONTRIBUTION_NOTES.md, Bug 1)."""
+
+    def test_explicit_env_replaces_inherited_environment(self):
+        # Mirrors the real fix's pattern: copy the parent env, pop one key, pass
+        # the result as env=. The child must not see the popped variable, even
+        # though it's set in this test process's own environment.
+        os.environ["_RUN_COMMAND_ENV_TEST_MARKER"] = "should-not-be-seen"
+        try:
+            custom_env = dict(os.environ)
+            custom_env.pop("_RUN_COMMAND_ENV_TEST_MARKER", None)
+            code, stdout, _stderr = _run_command(
+                [sys.executable, "-c",
+                 "import os; print(os.environ.get('_RUN_COMMAND_ENV_TEST_MARKER', 'MISSING'))"],
+                env=custom_env,
+            )
+        finally:
+            del os.environ["_RUN_COMMAND_ENV_TEST_MARKER"]
+        self.assertEqual(code, 0)
+        self.assertIn("MISSING", stdout)
+
+    def test_default_env_none_still_inherits_parent(self):
+        # Backward compatibility: omitting env= must preserve the pre-fix
+        # behavior of inheriting the full parent environment.
+        os.environ["_RUN_COMMAND_ENV_TEST_MARKER"] = "present"
+        try:
+            code, stdout, _stderr = _run_command(
+                [sys.executable, "-c", "import os; print(os.environ.get('_RUN_COMMAND_ENV_TEST_MARKER', 'MISSING'))"]
+            )
+        finally:
+            del os.environ["_RUN_COMMAND_ENV_TEST_MARKER"]
+        self.assertEqual(code, 0)
+        self.assertIn("present", stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`.mcp.json` sets `PYTHONHOME`/`PYTHONPATH` for this server's own process so it can `import DaVinciResolveScript` against Resolve's bundled Python (3.10 in my setup). `_run_command` spawns the `whisper` CLI via `subprocess.run(...)` with no explicit `env=`, so the child inherits that override.

`whisper.exe` is itself a Python program — often a different interpreter/version than the server's own (in my case: whisper installed under Python 3.14's user site-packages). A Python 3.14 interpreter inheriting a Python 3.10 `PYTHONHOME` tries to load 3.10's stdlib against its own compiled C extensions and crashes almost immediately:

```
AssertionError: SRE module mismatch
```

This crash is fast (well under a minute) — on its own it isn't a hang, though it can look like one if something else delays the response (see the two other PRs I'm opening alongside this one).

## Fix

- `_run_command` gains an optional `env: Optional[Dict[str, str]] = None` parameter, passed through to `subprocess.run(..., env=env)`. Default `None` preserves the existing inherit-everything behavior for every other call site.
- `_transcribe_with_whisper_cli` builds a scrubbed env for the `whisper` subprocess specifically: copies `os.environ`, drops `PYTHONHOME`/`PYTHONPATH`, and sets `PYTHONIOENCODING=utf-8` (whisper's own `--help` text includes CJK characters that crash on a non-UTF-8 Windows console).

## Testing

Added `RunCommandEnvOverrideTests` (2 tests) verifying `_run_command` correctly passes through a custom `env=` and doesn't leak parent-only variables, while preserving inherit-all behavior when `env=` is omitted. Confirmed independently: running `python -m whisper <file>` manually outside the server's environment transcribes correctly.

Full existing test suite passes (pre-existing, unrelated Windows tempdir-cleanup flakiness in a handful of `MediaAnalysisPlanningTests` confirmed present on unmodified `main` too, not a regression from this change).