### PR TITLE
fix: alias background/async_job to prefer_handle for analyze_* actions

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -8049,6 +8049,25 @@ def _media_analysis_bool(value: Any, default: bool = False) -> bool:
     return bool(value)
 
 
+def _media_analysis_wants_batch_job(p: Dict[str, Any]) -> bool:
+    """True when an analyze_* call should divert to the durable batch-job path.
+
+    `prefer_handle` is the documented opt-in; `background`/`async_job` are accepted
+    as aliases. Both previously looked like the async opt-in used by the timeline
+    actions (export/import/create_subtitles_from_audio) but were silently ignored
+    here, leaving callers with no job_id and no way to return early — see
+    davinci-resolve-mcp CONTRIBUTION_NOTES.md, Bug 2a. `dry_run` calls never divert,
+    same as `prefer_handle` alone did before.
+    """
+    if _media_analysis_bool(p.get("dry_run"), False):
+        return False
+    return (
+        _media_analysis_bool(p.get("prefer_handle"), False)
+        or _media_analysis_bool(p.get("background"), False)
+        or _media_analysis_bool(p.get("async_job"), False)
+    )
+
+
 def _media_analysis_target_dict(raw_target: Any, p: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     p = p or {}
     if raw_target is None:
@@ -17728,12 +17747,16 @@ async def media_analysis(action: str, params: Optional[Dict[str, Any]] = None, c
       set_ai_governance(preset?, mode?, overrides?) -> {success, tier, mode, overrides} — set the tier, the mode (advisory|enforce), and/or overrides (deblur_runs, speech_runs, render_bytes, render_wall_clock_ms; int or "unlimited"). In enforce mode a blocked run returns GOVERNANCE_BLOCKED; pass override_governance=true on the op to consciously exceed the tier once.
       resolve_output_root(analysis_root?, source_paths?) -> {project_root}
       plan(target, depth?, analysis_root?, transcription?, vision?, dry_run?) -> {clips, artifacts}
-      analyze_file(path|file_path, dry_run?, session_only?, persist?) -> {clips, manifest}
-      analyze_clip(clip_id|selected, dry_run?, session_only?, persist?) -> {clips, manifest}
-      analyze_bin(path|bin_path, recursive?, dry_run?, session_only?, persist?) -> {clips, manifest}
-      analyze_project(recursive?, dry_run?, session_only?, persist?) -> {clips, manifest}
-      analyze_sequence(timeline_index?, track_types?, dry_run?, session_only?, persist?) -> {clips, manifest}
+      analyze_file(path|file_path, dry_run?, session_only?, persist?, prefer_handle?|background?|async_job?) -> {clips, manifest} | {job_id, status} if handled
+      analyze_clip(clip_id|selected, dry_run?, session_only?, persist?, prefer_handle?|background?|async_job?) -> {clips, manifest} | {job_id, status} if handled
+      analyze_bin(path|bin_path, recursive?, dry_run?, session_only?, persist?, prefer_handle?|background?|async_job?) -> {clips, manifest} | {job_id, status} if handled
+      analyze_project(recursive?, dry_run?, session_only?, persist?, prefer_handle?|background?|async_job?) -> {clips, manifest} | {job_id, status} if handled
+      analyze_sequence(timeline_index?, track_types?, dry_run?, session_only?, persist?, prefer_handle?|background?|async_job?) -> {clips, manifest} | {job_id, status} if handled
       analyze_timeline(...) -> alias for analyze_sequence on the current timeline
+      -- `background`/`async_job` are accepted as aliases for `prefer_handle` on the analyze_* actions
+         above: any of the three reroutes to start_batch_job (job_id, polled via batch_job_status) when
+         not a dry_run. On dry_run=true they're ignored, same as prefer_handle — the call still returns
+         the synchronous plan.
       detect_sync_events(paths?|target?, event_types?, windows?) -> {files, alignment}
       add_sync_event_markers(target?|paths?|detections?, confirm?) -> {added, skipped}
       publish_clip_metadata(target?, fields?, slate_detection?, timed_markers?|write_markers?, dry_run?, confirm?) -> {results}
@@ -18621,15 +18644,17 @@ async def media_analysis(action: str, params: Optional[Dict[str, Any]] = None, c
                 "track_types": p.get("track_types") or p.get("trackTypes") or target.get("track_types") or target.get("trackTypes"),
             })
         p["target"] = target
-        # E3 — `prefer_handle` opt-in. When true AND this isn't a dry-run,
-        # divert to the durable batch-job machinery so the call returns a
-        # job_id immediately instead of blocking on vision/transcription.
-        # Default false: existing blocking semantics are preserved.
+        # E3 — `prefer_handle` opt-in (plus `background`/`async_job` aliases,
+        # see _media_analysis_wants_batch_job). When true AND this isn't a
+        # dry-run, divert to the durable batch-job machinery so the call
+        # returns a job_id immediately instead of blocking on
+        # vision/transcription. Default false: existing blocking semantics
+        # are preserved.
         # The start_batch_job handler lives ABOVE this block in the dispatch
         # chain, so we can't just rewrite `action` and fall through — we
         # re-enter the tool with the rewritten action via await so the
         # handler chain restarts from the top.
-        if _media_analysis_bool(p.get("prefer_handle"), False) and not p.get("dry_run"):
+        if _media_analysis_wants_batch_job(p):
             return await media_analysis("start_batch_job", p, ctx)
         action = "plan"
 

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -25,6 +25,7 @@ from src.server import (
     _media_analysis_provenance_metadata,
     _media_analysis_records_from_target,
     _media_analysis_report_metadata_candidates,
+    _media_analysis_wants_batch_job,
     _publish_clip_metadata_from_analysis,
     setup,
 )
@@ -4760,6 +4761,36 @@ class InventoryCacheReuseTests(unittest.TestCase):
                 self.dash._current_resolve_project_id = original
             self.assertTrue(payload["resolve_available"])
             self.assertEqual(payload["counts"]["total"], 2)
+
+
+class MediaAnalysisWantsBatchJobTests(unittest.TestCase):
+    """Bug 2a: `background`/`async_job` must behave as aliases for `prefer_handle`
+    on analyze_clip/analyze_bin/etc, not be silently ignored (which previously
+    left callers with no job_id and no way to return early — see
+    davinci-resolve-mcp CONTRIBUTION_NOTES.md, Bug 2a)."""
+
+    def test_prefer_handle_true_wants_batch_job(self):
+        self.assertTrue(_media_analysis_wants_batch_job({"prefer_handle": True}))
+
+    def test_background_true_wants_batch_job(self):
+        self.assertTrue(_media_analysis_wants_batch_job({"background": True}))
+
+    def test_async_job_true_wants_batch_job(self):
+        self.assertTrue(_media_analysis_wants_batch_job({"async_job": True}))
+
+    def test_string_true_values_are_coerced(self):
+        self.assertTrue(_media_analysis_wants_batch_job({"background": "true"}))
+
+    def test_no_opt_in_does_not_want_batch_job(self):
+        self.assertFalse(_media_analysis_wants_batch_job({}))
+        self.assertFalse(_media_analysis_wants_batch_job({"prefer_handle": False, "background": False}))
+
+    def test_dry_run_suppresses_all_aliases(self):
+        # Matches prefer_handle's existing dry_run behavior: a dry_run call always
+        # returns the synchronous plan, regardless of the async opt-in used.
+        self.assertFalse(_media_analysis_wants_batch_job({"prefer_handle": True, "dry_run": True}))
+        self.assertFalse(_media_analysis_wants_batch_job({"background": True, "dry_run": True}))
+        self.assertFalse(_media_analysis_wants_batch_job({"async_job": True, "dry_run": True}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`background=true`/`async_job=true` was silently a no-op on `analyze_clip`, `analyze_bin`, `analyze_file`, `analyze_project`, and `analyze_sequence`. `_run_maybe_background` — the only code that actually starts an off-thread `background_jobs` job — is wired to exactly three timeline actions (`export_timeline_checked`, `import_timeline_checked`, `create_subtitles_from_audio`) and never to these. The `analyze_*` actions collapse straight to `action="plan"` and, when not a dry run, run the full analysis synchronously inside the same coroutine the caller is awaiting — no `job_id` is ever returned, and the docstring never documented `background` as a param for them either.

The real async path for analysis work is `prefer_handle=true`, which reroutes to `start_batch_job` (its own durable, slice-runnable job machinery, polled via `batch_job_status`) — a completely different, already-correct code path.

In practice this meant a caller passing `background=true` on `analyze_clip` got no indication anything was wrong — the call just ran to completion (or didn't) with no job_id, indistinguishable from a hang.

## Fix

Rather than build a second job-tracking system, `background`/`async_job` are now aliases for `prefer_handle`: added `_media_analysis_wants_batch_job(p)`, a small pure helper next to `_media_analysis_bool`, and swapped it in at the one dispatch site that used to check `prefer_handle` alone. Same `dry_run` guard as before — a dry_run call still returns the synchronous plan regardless of which alias was used. Docstring updated to document all three params and the `{job_id, status}` return shape.

Extracted as a standalone function (not an inline condition) specifically so it's unit-testable with plain dicts, no Resolve mocking required.

## Testing

Added `MediaAnalysisWantsBatchJobTests` (6 tests) covering all three aliases, string-coerced truthy values, the no-opt-in default, and the `dry_run` interaction.

Full existing test suite passes (pre-existing, unrelated Windows tempdir-cleanup flakiness in a handful of `MediaAnalysisPlanningTests` confirmed present on unmodified `main` too, not a regression from this change).