### PR TITLE
fix: kill the whole process tree on _run_command timeout, not just the direct child

### DIFF
--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -17,6 +17,7 @@ import os
 import platform as _platform
 import re
 import shutil
+import signal
 import sqlite3
 import subprocess
 import sys
@@ -2376,23 +2377,57 @@ def build_plan(
     }
 
 
-def _run_command(args: List[str], timeout: int = COMMAND_TIMEOUT_SECONDS) -> Tuple[int, str, str]:
-    try:
-        proc = subprocess.run(
-            args,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
+def _kill_process_tree(pid: int) -> None:
+    """Best-effort: terminate pid and its descendants, not just the direct child.
+
+    Popen.kill() only reaches the immediate child. On Windows a PATH lookup can
+    resolve to a shim (Chocolatey, npm, etc.) that spawns the real work as a
+    grandchild, which survives a plain kill() untouched — confirmed for `ffmpeg`
+    on a Chocolatey-managed machine (davinci-resolve-mcp CONTRIBUTION_NOTES.md,
+    Bug 2b: a 5s timeout had zero effect on an ~82s real ffmpeg pass, because
+    killing the shim's PID left the real ffmpeg.exe grandchild running). Killing
+    the whole tree instead of one PID fixes this regardless of what kind of
+    wrapper sits on PATH.
+    """
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            capture_output=True, check=False,
         )
-    except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
-        stderr_tail = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
-        return 124, stdout, f"Command timed out after {timeout}s. {stderr_tail}".strip()
+        return
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def _run_command(args: List[str], timeout: int = COMMAND_TIMEOUT_SECONDS) -> Tuple[int, str, str]:
+    popen_kwargs: Dict[str, Any] = {}
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kwargs["start_new_session"] = True
+    try:
+        proc = subprocess.Popen(
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **popen_kwargs
+        )
     except OSError as exc:
         return 127, "", str(exc)
-    stdout = proc.stdout.decode("utf-8", errors="replace") if proc.stdout else ""
-    stderr = proc.stderr.decode("utf-8", errors="replace") if proc.stderr else ""
-    return proc.returncode, stdout, stderr
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # subprocess.run's default TimeoutExpired handling only kills the direct
+        # child, which is insufficient when that child is itself a wrapper — see
+        # _kill_process_tree. The follow-up communicate() (no timeout) drains
+        # whatever's left now that the tree is actually gone.
+        _kill_process_tree(proc.pid)
+        stdout, stderr = proc.communicate()
+        stdout_s = stdout.decode("utf-8", errors="replace") if stdout else ""
+        stderr_s = stderr.decode("utf-8", errors="replace") if stderr else ""
+        return 124, stdout_s, f"Command timed out after {timeout}s. {stderr_s}".strip()
+    stdout_s = stdout.decode("utf-8", errors="replace") if stdout else ""
+    stderr_s = stderr.decode("utf-8", errors="replace") if stderr else ""
+    return proc.returncode, stdout_s, stderr_s
 
 
 def _write_json(path: str, payload: Dict[str, Any]) -> None:

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -2,9 +2,12 @@ import asyncio
 import json
 import os
 import shutil
+import signal
 import sqlite3
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 import unittest.mock
 from typing import Any, Dict, Optional
@@ -58,6 +61,8 @@ from src.utils.media_analysis import (
     execute_plan,
     execute_plan_async,
     executing_clips,
+    _kill_process_tree,
+    _run_command,
     plan_requires_capabilities,
     load_report,
     mark_registry_stale_for_clip,
@@ -4760,6 +4765,57 @@ class InventoryCacheReuseTests(unittest.TestCase):
                 self.dash._current_resolve_project_id = original
             self.assertTrue(payload["resolve_available"])
             self.assertEqual(payload["counts"]["total"], 2)
+
+
+class RunCommandTimeoutKillsProcessTreeTests(unittest.TestCase):
+    """Bug 2b: a timeout must actually cut the wait short, not just relabel a
+    normally-completing (or genuinely stalled) child as 'timed out' after
+    waiting for its full natural runtime — see davinci-resolve-mcp
+    CONTRIBUTION_NOTES.md, Bug 2b. Popen.kill() alone only reaches the direct
+    child; on Windows a PATH lookup can resolve to a shim whose real work
+    happens in a grandchild that survives untouched."""
+
+    def test_timeout_returns_well_before_natural_completion(self):
+        # sys.executable, not an external binary — no shim/wrapper can sit on
+        # PATH in front of it, so this isolates the kill-tree mechanism itself
+        # from the shim-specific scenario in the original repro.
+        natural_runtime = 5
+        args = [sys.executable, "-c", f"import time; time.sleep({natural_runtime})"]
+        start = time.monotonic()
+        code, _stdout, stderr = _run_command(args, timeout=1)
+        elapsed = time.monotonic() - start
+        self.assertEqual(code, 124)
+        self.assertIn("timed out", stderr)
+        # Generous bound, not a tight one: proves the kill actually cut the wait
+        # short (vs. the pre-fix behavior of waiting out the full natural
+        # runtime) without flaking on a slow/loaded CI runner.
+        self.assertLess(elapsed, natural_runtime - 1)
+
+    def test_normal_completion_is_unaffected(self):
+        code, stdout, _stderr = _run_command(
+            [sys.executable, "-c", "print('ok')"], timeout=10
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("ok", stdout)
+
+
+@unittest.skipIf(os.name == "nt", "POSIX-only branch of _kill_process_tree")
+class KillProcessTreePosixTests(unittest.TestCase):
+    def test_uses_killpg_with_sigkill(self):
+        with unittest.mock.patch("os.killpg") as mock_killpg:
+            _kill_process_tree(12345)
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+
+
+@unittest.skipUnless(os.name == "nt", "Windows-only branch of _kill_process_tree")
+class KillProcessTreeWindowsTests(unittest.TestCase):
+    def test_uses_taskkill_with_tree_flag(self):
+        with unittest.mock.patch("subprocess.run") as mock_run:
+            _kill_process_tree(12345)
+        mock_run.assert_called_once_with(
+            ["taskkill", "/F", "/T", "/PID", "12345"],
+            capture_output=True, check=False,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`subprocess.run(timeout=...)`'s default `TimeoutExpired` handling calls `proc.kill()` on the direct child only. On Windows, a bare-name PATH lookup (e.g. `ffmpeg`) can resolve to a package-manager shim (Chocolatey's ShimGen shims, npm shims, etc.) rather than the real binary — the shim spawns the actual work as its own child, i.e. a grandchild of this process. Killing the shim's PID leaves that grandchild running untouched, and because it inherited the shim's stdout/stderr pipe handles, the fallback `communicate()` (which `subprocess.run` calls with no timeout after a kill) blocks until the grandchild exits on its own — a normally-completing pass just returns late with a misleadingly-labeled "timed out" result; a genuinely-stalled one hangs forever.

Confirmed empirically on a Chocolatey-managed machine: `ffmpeg` on PATH resolved to a 392KB ShimGen shim, not the real ~101MB binary. A 5s timeout against an ~82s real `ffmpeg` pass had zero effect — the call returned after the full 82s with a "timed out after 5s" message attached to what was actually the complete, correct output.

## Fix

`_run_command` now spawns via `Popen` (new process group on Windows via `CREATE_NEW_PROCESS_GROUP`, new session on POSIX via `start_new_session`) and uses `communicate(timeout=...)` directly, so a timeout can be handled with a real tree-kill instead of trusting a single-PID `kill()`. The new `_kill_process_tree(pid)` helper uses `taskkill /F /T /PID` on Windows and `os.killpg(pid, SIGKILL)` on POSIX — the same platform-branch idiom already used elsewhere in this codebase for process termination (`src/utils/app_control.py`).

This fixes every `_run_command` caller at once (the whisper CLI call and all `ffmpeg` passes in `_readthrough_analysis`) without any call-site changes; the function's signature and `Tuple[int, str, str]` return contract are unchanged. No new dependency — `taskkill`/`killpg` are both stdlib-reachable.

## Testing

Re-ran the original repro against this fix: the same `timeout=5` call that previously took 82.2s (kill had no effect) now returns in ~5s with the process tree actually gone.

Added `RunCommandTimeoutKillsProcessTreeTests` (proves the kill actually cuts the wait short using a `sys.executable` child with no shim involved, and that ordinary non-timeout completion is unaffected) and `KillProcessTreeWindowsTests`/`KillProcessTreePosixTests` (platform-branch dispatch, mocked, whichever applies to the CI runner's OS).

Full existing test suite passes (pre-existing, unrelated Windows tempdir-cleanup flakiness in a handful of `MediaAnalysisPlanningTests` confirmed present on unmodified `main` too, not a regression from this change).