### PR TITLE
docs: record Linux validation of the free-edition in-app bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ Validated on free 21.0.3.7 and Studio 19.1.3.7, both macOS. The Windows paths
 added in v2.70.1 (issue #106) shipped unverified; reports on free 21.0.1.11
 (issue #109) and free 21.0.3.7 (issue #112) have since shown the bridge
 installing, listing and serving from **both** `%PROGRAMDATA%` and `%APPDATA%` on
-Windows 11, so those paths are now confirmed rather than assumed.
+Windows 11, so those paths are now confirmed rather than assumed. Linux is
+confirmed as well: a report on free 20.3.2.9 (issue #129, Fedora 43) shows the
+bridge installing to `~/.local/share/DaVinciResolve/Fusion/Scripts/Utility`,
+listing against the system Python — no framework-Python requirement on Linux —
+and serving end-to-end, so all three platforms now rest on reports rather than
+assumptions.
 
 Note that the bridge holds its port for as long as it serves. Before v2.70.3 a
 Windows bridge could outlive Resolve and block the next session's listener; if


### PR DESCRIPTION
The README's bridge section tracks per-platform validation status: macOS validated at launch, Windows confirmed via #109/#112, Linux silent. #129 now provides a Linux report — free 20.3.2.9 on Fedora 43, bridge installing to `~/.local/share/DaVinciResolve/Fusion/Scripts/Utility`, listing against the system Python (3.14), and serving end-to-end through `DAVINCI_RESOLVE_BRIDGE=1` with live reads of the open project.

This PR adds one sentence to the validation paragraph so all three platforms' status is on record, matching the pattern used when the Windows paths were confirmed. Probe JSON and environment details are in #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)