### PR TITLE
feat: wire the ten remaining 24-Jul-2026 README surfaces (preset lists, user prefs, project attributes)

### DIFF
--- a/docs/reference/api-coverage.md
+++ b/docs/reference/api-coverage.md
@@ -8,8 +8,8 @@ Complete Resolve scripting API coverage, live-test status, and method-by-method 
 |--------|-------|
 | MCP Tools | **34** compound (default) / **341** granular |
 | Kernel Actions | **136** guarded MCP workflow actions across 9 compound tools |
-| API Methods Covered | **351/351** (100%) |
-| Methods Live Tested | **338/351** (96.3%) |
+| API Methods Covered | **361/361** (100%) |
+| Methods Live Tested | **338/361** (93.6%) |
 | Live Test Pass Rate | **338/338** (100%) |
 | API Object Classes | 13 |
 | Tested Against | DaVinci Resolve 19.1.3 Studio + Resolve 20.3.2 Studio + Resolve 21.0.2 Studio + Resolve 21.0.3 **free** (via the in-app bridge) |
@@ -109,7 +109,7 @@ source, these summaries are downstream of it:
 | Phase 5 | 6/6 | 100% | Scene cuts, subtitles from audio, graph node cache/tools/enable |
 | Resolve 20 delta | 12/12 | 100% | Resolve 20.0-20.2.2 scripting additions live-tested on 20.3.2 |
 | Resolve 21 delta | 7/7 | 100% | Resolve 21.0 additions that could be executed, live-tested on Studio 21.0.2.4 (`tests/live_resolve21_validation.py`). The other 6 need an AI Extras pack or are unsafe to run — counted as untested, not as passes |
-| **Total** | **338/338** | **100%** | **96.3% of the 351 covered methods tested live** |
+| **Total** | **338/338** | **100%** | **93.6% of the 361 covered methods tested live** |
 
 #### Resolve 21 delta detail
 
@@ -130,7 +130,7 @@ marked 🔬 rather than ⚠️.
 | `Project.GenerateSpeech` | 🔬 | Requires AI Speech Generator; returned an error **string**, not a MediaPoolItem |
 | `Resolve.DisableBackgroundTasksForCurrentResolveSession` | 🔬 | Present in `dir()`; **not executed** — session-wide, returns None, and has no `Enable...` counterpart, so there is no undo short of restarting Resolve |
 
-### Untested Methods (13 of 351)
+### Untested Methods (23 of 361)
 
 Every ☁️ and 🔬 row from the reference tables, listed here so the count is
 checkable rather than asserted.
@@ -150,12 +150,24 @@ checkable rather than asserted.
 | `Resolve.DisableBackgroundTasksForCurrentResolveSession` | Deliberately not executed: session-wide, returns `None`, and has no `Enable...` counterpart, so there is no undo short of restarting Resolve | No |
 | `MPI.GetTimeline` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
 | `TL.GetSelectedClips` | Requires a Resolve 21.0.4 build; the validation machine runs 19.1.3 | Yes |
+| `Resolve.GetLayoutPresetList` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
+| `Resolve.GetBurnInPresetList` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
+| `Resolve.DeleteBurnInPreset` | Requires a Resolve 21.0.4 build; also, no scripting API creates a burn-in preset to round-trip against | Yes |
+| `Resolve.GetUserPreferencesPresetList` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
+| `Resolve.SaveUserPreferencesPreset` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
+| `Resolve.LoadUserPreferencesPreset` | Deliberately not executed even by the reporter: swaps the user's global preferences session-wide | No |
+| `Resolve.DeleteUserPreferencesPreset` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
+| `Resolve.ImportUserPreferencesPreset` | Requires a Resolve 21.0.4 build and a preset file to import | Yes |
+| `Resolve.ExportUserPreferencesPreset` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
+| `PM.GetProjectAttributesInCurrentFolder` | Requires a Resolve 21.0.4 build; the validation machine runs Studio 19.1.3 and free 21.0.3 | Yes |
 
 The five AI Extras rows are untested for want of a downloadable pack, not because
 the wrappers are suspect — a report from anyone who has the packs installed would
-close them. The two 21.0.4 rows are untested for want of the build: this machine
+close them. The twelve 21.0.4 rows are untested for want of the build: this machine
 runs 19.1.3, so they are guarded and unit-tested against stubs and carry a
-contributor's report rather than a result of ours. The remaining one is a
+contributor's report rather than a result of ours (issue #131 for the first two;
+issues #135–#138 for the ten from the 24 Jul 2026 README refresh, several with
+save→list→delete round-trips on Studio 21.0.4.5). The remaining one is a
 decision rather than a gap: it is reachable, and
 running it during a validation sweep would disable background tasks for every
 project open in that Resolve instance.
@@ -199,6 +211,15 @@ Every method in the DaVinci Resolve Scripting API and its test status. Methods a
 | 21 | `SetKeyframeMode(keyframeMode)` | ⚠️ | API accepts; mode must match valid enum |
 | 22 | `GetFairlightPresets()` | ✅ | Returns a preset map. Live on 20.3.2 Studio and 21.0.3 free; **absent below 20.2.2** — confirmed missing on 19.1.3, so the version floor is verified from both sides |
 | 23 | `DisableBackgroundTasksForCurrentResolveSession()` | 🔬 | Resolve 21.0. Present in `dir()`; **not executed** — session-wide, returns `None`, no `Enable...` counterpart, so no undo short of restarting Resolve |
+| 24 | `GetLayoutPresetList()` | 🔬 | Resolve 21.0.4 (24 Jul 2026 README). Not executed here — no 21.0.4 build; reporter's save→list→delete round-trip on Studio 21.0.4.5 in issue #137 |
+| 25 | `GetBurnInPresetList()` | 🔬 | Resolve 21.0.4. Not executed here; reported returning a list on Studio 21.0.4.5 in issue #136 |
+| 26 | `DeleteBurnInPreset(presetName)` | 🔬 | Resolve 21.0.4. `dir()`-present on 21.0.4.5 (issue #136); not executed anywhere — no scripting API creates a burn-in preset to round-trip against |
+| 27 | `GetUserPreferencesPresetList()` | 🔬 | Resolve 21.0.4. Not executed here; reporter's save→list→delete round-trip on Studio 21.0.4.5 in issue #138 |
+| 28 | `SaveUserPreferencesPreset(presetName)` | 🔬 | Resolve 21.0.4. Not executed here; part of the issue #138 round-trip on 21.0.4.5 |
+| 29 | `LoadUserPreferencesPreset(presetName)` | 🔬 | Resolve 21.0.4. `dir()`-present on 21.0.4.5; **not executed** even by the reporter — swaps the user's global preferences session-wide (issue #138) |
+| 30 | `DeleteUserPreferencesPreset(presetName)` | 🔬 | Resolve 21.0.4. Not executed here; part of the issue #138 round-trip on 21.0.4.5 |
+| 31 | `ImportUserPreferencesPreset(presetFilePath, presetName)` | 🔬 | Resolve 21.0.4. `dir()`-present on 21.0.4.5 only (issue #138) — no preset file was on hand. Per the README the imported preset is **not** auto-loaded |
+| 32 | `ExportUserPreferencesPreset(presetName, exportPath)` | 🔬 | Resolve 21.0.4. `dir()`-present on 21.0.4.5 only (issue #138) |
 
 ### ProjectManager
 
@@ -229,6 +250,7 @@ Every method in the DaVinci Resolve Scripting API and its test status. Methods a
 | 23 | `LoadCloudProject({cloudSettings})` | ☁️ | Requires cloud infrastructure |
 | 24 | `ImportCloudProject(filePath, {cloudSettings})` | ☁️ | Requires cloud infrastructure |
 | 25 | `RestoreCloudProject(folderPath, {cloudSettings})` | ☁️ | Requires cloud infrastructure |
+| 26 | `GetProjectAttributesInCurrentFolder()` | 🔬 | Resolve 21.0.4 (24 Jul 2026 README). Not executed here — no 21.0.4 build; reported live on Studio 21.0.4.5 in issue #135, returning `lastModifiedDate` / `creationDate` / `notes` / `liveCollaborationMode` for all 8 projects in the current folder |
 
 ### Project
 

--- a/docs/reference/resolve_scripting_api.txt
+++ b/docs/reference/resolve_scripting_api.txt
@@ -1,4 +1,4 @@
-Last Updated: 26 May 2026
+Last Updated: 24 Jul 2026
 -------------------------
 In this package, you will find a brief introduction to the Scripting API for DaVinci Resolve Studio. Apart from this README.txt file, this package contains folders containing the basic import
 modules for scripting access (DaVinciResolve.py) and some representative examples.
@@ -91,6 +91,7 @@ Resolve
   GetProductName()                                --> string             # Returns product name.
   GetVersion()                                    --> [version fields]   # Returns list of product version fields in [major, minor, patch, build, suffix] format.
   GetVersionString()                              --> string             # Returns product version in "major.minor.patch[suffix].build" format.
+  GetLayoutPresetList()                           --> [presetNames...]   # Returns list of layout preset names.
   LoadLayoutPreset(presetName)                    --> Bool               # Loads UI layout from saved preset named 'presetName'.
   UpdateLayoutPreset(presetName)                  --> Bool               # Overwrites preset named 'presetName' with current UI layout.
   ExportLayoutPreset(presetName, presetFilePath)  --> Bool               # Exports preset named 'presetName' to path 'presetFilePath'.
@@ -100,8 +101,16 @@ Resolve
   Quit()                                          --> None               # Quits the Resolve App.
   ImportRenderPreset(presetPath)                  --> Bool               # Import a preset from presetPath (string) and set it as current preset for rendering.
   ExportRenderPreset(presetName, exportPath)      --> Bool               # Export a preset to a given path (string) if presetName(string) exists.
+  GetBurnInPresetList()                           --> [presetName...]    # Returns a list of data burn in preset names.
+  DeleteBurnInPreset(presetName)                  --> Bool               # Deletes the data burn in preset.
   ImportBurnInPreset(presetPath)                  --> Bool               # Import a data burn in preset from a given presetPath (string)
   ExportBurnInPreset(presetName, exportPath)      --> Bool               # Export a data burn in preset to a given path (string) if presetName (string) exists.
+  GetUserPreferencesPresetList()                  --> [presetNames...]   # Returns a list of user preferences preset names.
+  LoadUserPreferencesPreset(presetName)           --> Bool               # Loads the user preferences preset named 'presetName'.
+  SaveUserPreferencesPreset(presetName)           --> Bool               # Saves the current user preferences as a new preset named 'presetName'.
+  DeleteUserPreferencesPreset(presetName)         --> Bool               # Deletes the user preferences preset named 'presetName'.
+  ImportUserPreferencesPreset(presetFilePath, presetName) --> Bool       # Imports user preferences preset from presetFilePath. Optional presetName argument to name the imported preset. The imported preset is not automatically loaded, use LoadUserPreferencesPreset(..) to load it.
+  ExportUserPreferencesPreset(presetName, exportPath) --> Bool           # Exports the user preferences preset to exportPath.
   GetKeyframeMode()                               --> keyframeMode       # Returns the currently set keyframe mode (int). Refer to section 'Keyframe Mode information' below for details.
   SetKeyframeMode(keyframeMode)                   --> Bool               # Returns True when 'keyframeMode'(enum) is successfully set. Refer to section 'Keyframe Mode information' below for details.
   GetFairlightPresets()                           --> [presetNames...].  # Returns a list of Fairlight presets by name
@@ -122,6 +131,8 @@ ProjectManager
   CreateFolder(folderName)                        --> Bool               # Creates a folder if folderName (string) is unique.
   DeleteFolder(folderName)                        --> Bool               # Deletes the specified folder if it exists. Returns True in case of success.
   GetProjectListInCurrentFolder()                 --> [project names...] # Returns a list of project names in current folder.
+  GetProjectAttributesInCurrentFolder()           --> {project name: {attributes}, ...} # Returns a dictionary of project names in the current folder to project attributes.
+                                                                         # Attributes include "lastModifiedDate", "creationDate", "notes", and "liveCollaborationMode".
   GetFolderListInCurrentFolder()                  --> [folder names...]  # Returns a list of folder names in current folder.
   GotoRootFolder()                                --> Bool               # Opens root folder in database.
   GotoParentFolder()                              --> Bool               # Opens parent folder of current folder in database if current folder has parent.
@@ -295,6 +306,7 @@ MediaPoolItem
                                                                          # If no argument is specified, a dict of all set metadata properties is returned.
   SetMetadata(metadataType, metadataValue)        --> Bool               # Sets the given metadata to metadataValue (string). Returns True if successful.
   SetMetadata({metadata})                         --> Bool               # Sets the item metadata with specified 'metadata' dict. Returns True if successful.
+  GetTimeline()                                   --> TimelineItem       # Returns the timeline object if the mpItem is a timeline clip, or None if not.
   GetThirdPartyMetadata(metadataType=None)        --> string|dict        # Returns the third party metadata value for the key 'metadataType'.
                                                                          # If no argument is specified, a dict of all set third party metadata properties is returned.
   SetThirdPartyMetadata(metadataType, metadataValue) --> Bool            # Sets/Add the given third party metadata to metadataValue (string). Returns True if successful.
@@ -385,6 +397,7 @@ Timeline
   DeleteClips([timelineItems], Bool)              --> Bool               # Deletes specified TimelineItems from the timeline, performing ripple delete if the second argument is True. Second argument is optional (The default for this is False)
   SetClipsLinked([timelineItems], Bool)           --> Bool               # Links or unlinks the specified TimelineItems depending on second argument.
   GetItemListInTrack(trackType, index)            --> [items...]         # Returns a list of timeline items on that track (based on trackType and index). 1 <= index <= GetTrackCount(trackType).
+  GetSelectedClips()                              --> [items...]         # Returns the currently selected timeline items.
   AddMarker(frameId, color, name, note, duration, --> Bool               # Creates a new marker at given frameId position and with given marker information. 'customData' is optional and helps to attach user specific data to the marker.
             customData)
   GetMarkers()                                    --> {markers...}       # Returns a dict (frameId -> {information}) of all markers and dicts with their information.
@@ -693,6 +706,10 @@ Affects:
 Affects:
 • x = Project:GetSetting('timelineFrameRate') and Project:SetSetting('timelineFrameRate', x)
 
+"timelineSampleRate" - the property value is one of the sample rates available to the user in project settings under "Audio sample rate" option in the Fairlight tab.
+Affects:
+• x = Project:GetSetting('timelineSampleRate') and Project:SetSetting('timelineSampleRate', x)
+
 The following Clip properties have specifically enumerated values:
 "Super Scale" - the property value is an enumerated integer between 1 and 4 with these meanings: 1=no scaling, and 2, 3 and 4 represent the Super Scale multipliers 2x, 3x and 4x.
                 for super scale multiplier '2x Enhanced', exactly 4 arguments must be passed as outlined below. If less than 4 arguments are passed, it will default to 2x.
@@ -844,6 +861,9 @@ The parameter setting is a dictionary containing the following keys:
     - "ReplaceExistingFilesInPlace": Bool
     - "ExportSubtitle": Bool
     - "SubtitleFormat": string (options: "BurnIn", "EmbeddedCaptions", "SeparateFile")
+    - "UseFullExtents": Bool
+    - "AddFrameHandles": int (>= 0). Ignored if use full extents is enabled.
+    - "DataBurnIn": string. (example: "Same as project", "None")
 
 Looking up timeline export properties
 -------------------------------------

--- a/src/server.py
+++ b/src/server.py
@@ -13581,6 +13581,16 @@ def resolve_control(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
       get_fairlight_presets() -> {presets}
       set_high_priority() -> {success}
       disable_background_tasks_for_current_session() -> {success}  — Resolve 21+
+      list_user_preferences_presets() -> {presets}  — Resolve 21.0.4+
+      save_user_preferences_preset(name) -> {success}  — Resolve 21.0.4+
+      load_user_preferences_preset(name) -> {success}  — Resolve 21.0.4+.
+        SESSION-WIDE: swaps the user's global Resolve preferences, not a
+        project setting. Only call when the user asked for the switch.
+      delete_user_preferences_preset(name) -> {success}  — Resolve 21.0.4+
+      import_user_preferences_preset(path, name?) -> {success}  — Resolve 21.0.4+.
+        The imported preset is NOT auto-loaded; follow with
+        load_user_preferences_preset to activate it.
+      export_user_preferences_preset(name, path) -> {success}  — Resolve 21.0.4+
       open_control_panel(port?, host?, open_browser?) -> {success, url, pid, port, status}
         — Launches the analysis control panel (src/analysis_dashboard.py) as a background process.
           Idempotent: returns the existing URL if already running.
@@ -13816,7 +13826,56 @@ def resolve_control(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
             return missing
         r.DisableBackgroundTasksForCurrentResolveSession()
         return _ok()
-    return _unknown(action, ["launch","runtime_mode","get_version","api_truth","check_version_support","verification_stats","job_status","list_jobs","mcp_update_status","set_mcp_update_policy","ignore_mcp_update","snooze_mcp_update","clear_mcp_update_preferences","get_page","open_page","get_keyframe_mode","set_keyframe_mode","quit","get_fairlight_presets","set_high_priority","disable_background_tasks_for_current_session","open_control_panel","control_panel_status","close_control_panel","save_state","restore_state"])
+    elif action == "list_user_preferences_presets":
+        missing = _requires_method(r, "GetUserPreferencesPresetList", "21.0.4")
+        if missing:
+            return missing
+        return {"presets": _ser(r.GetUserPreferencesPresetList() or [])}
+    elif action == "save_user_preferences_preset":
+        missing = _requires_method(r, "SaveUserPreferencesPreset", "21.0.4")
+        if missing:
+            return missing
+        if not p.get("name"):
+            return _err("save_user_preferences_preset requires name")
+        return {"success": bool(r.SaveUserPreferencesPreset(p["name"]))}
+    elif action == "load_user_preferences_preset":
+        missing = _requires_method(r, "LoadUserPreferencesPreset", "21.0.4")
+        if missing:
+            return missing
+        if not p.get("name"):
+            return _err("load_user_preferences_preset requires name")
+        return {"success": bool(r.LoadUserPreferencesPreset(p["name"]))}
+    elif action == "delete_user_preferences_preset":
+        missing = _requires_method(r, "DeleteUserPreferencesPreset", "21.0.4")
+        if missing:
+            return missing
+        if not p.get("name"):
+            return _err("delete_user_preferences_preset requires name")
+        return {"success": bool(r.DeleteUserPreferencesPreset(p["name"]))}
+    elif action == "import_user_preferences_preset":
+        missing = _requires_method(r, "ImportUserPreferencesPreset", "21.0.4")
+        if missing:
+            return missing
+        if not p.get("path"):
+            return _err("import_user_preferences_preset requires path")
+        if p.get("name"):
+            ok = bool(r.ImportUserPreferencesPreset(p["path"], p["name"]))
+        else:
+            ok = bool(r.ImportUserPreferencesPreset(p["path"]))
+        return {"success": ok,
+                "note": "The imported preset is not auto-loaded; use load_user_preferences_preset to activate it."}
+    elif action == "export_user_preferences_preset":
+        missing = _requires_method(r, "ExportUserPreferencesPreset", "21.0.4")
+        if missing:
+            return missing
+        err, clean = _validate_params(p, {
+            "name": {"type": str, "required": True, "non_empty": True},
+            "path": {"type": str, "required": True, "non_empty": True},
+        })
+        if err:
+            return _err(err)
+        return {"success": bool(r.ExportUserPreferencesPreset(clean["name"], clean["path"]))}
+    return _unknown(action, ["launch","runtime_mode","get_version","api_truth","check_version_support","verification_stats","job_status","list_jobs","mcp_update_status","set_mcp_update_policy","ignore_mcp_update","snooze_mcp_update","clear_mcp_update_preferences","get_page","open_page","get_keyframe_mode","set_keyframe_mode","quit","get_fairlight_presets","set_high_priority","disable_background_tasks_for_current_session","list_user_preferences_presets","save_user_preferences_preset","load_user_preferences_preset","delete_user_preferences_preset","import_user_preferences_preset","export_user_preferences_preset","open_control_panel","control_panel_status","close_control_panel","save_state","restore_state"])
 
 
 # ─── V2 C4: Per-field corrections with provenance + changelog ────────────────
@@ -14682,6 +14741,7 @@ def layout_presets(action: str, params: Optional[Dict[str, Any]] = None) -> Dict
     """Manage DaVinci Resolve UI layout presets.
 
     Actions:
+      list() -> {presets}  — Resolve 21.0.4+; saved layout preset names
       save(name) -> {success}
       load(name) -> {success}
       update(name) -> {success}
@@ -14694,7 +14754,12 @@ def layout_presets(action: str, params: Optional[Dict[str, Any]] = None) -> Dict
     if r is None:
         return _not_connected_error()
 
-    if action == "save":
+    if action == "list":
+        missing = _requires_method(r, "GetLayoutPresetList", "21.0.4")
+        if missing:
+            return missing
+        return {"presets": _ser(r.GetLayoutPresetList() or [])}
+    elif action == "save":
         if not p.get("name"):
             return _err("save requires name")
         return {"success": bool(r.SaveLayoutPreset(p["name"]))}
@@ -14716,7 +14781,7 @@ def layout_presets(action: str, params: Optional[Dict[str, Any]] = None) -> Dict
         return {"success": bool(r.ImportLayoutPreset(p["path"]))}
     elif action == "delete":
         return {"success": bool(r.DeleteLayoutPreset(p["name"]))}
-    return _unknown(action, ["save","load","update","export","import_preset","delete"])
+    return _unknown(action, ["list","save","load","update","export","import_preset","delete"])
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -14733,6 +14798,10 @@ def render_presets(action: str, params: Optional[Dict[str, Any]] = None) -> Dict
       export_render(name, path) -> {success}
       import_burnin(path) -> {success}
       export_burnin(name, path) -> {success}
+      list_burnin() -> {presets}  — Resolve 21.0.4+; burn-in preset names usable
+        with the render tool's DataBurnIn setting and load_burnin_preset on
+        project_settings / timeline_item
+      delete_burnin(name) -> {success}  — Resolve 21.0.4+
     """
     p = _params(params)
     r = get_resolve()
@@ -14747,7 +14816,19 @@ def render_presets(action: str, params: Optional[Dict[str, Any]] = None) -> Dict
         return {"success": bool(r.ImportBurnInPreset(p["path"]))}
     elif action == "export_burnin":
         return {"success": bool(r.ExportBurnInPreset(p["name"], p["path"]))}
-    return _unknown(action, ["import_render","export_render","import_burnin","export_burnin"])
+    elif action == "list_burnin":
+        missing = _requires_method(r, "GetBurnInPresetList", "21.0.4")
+        if missing:
+            return missing
+        return {"presets": _ser(r.GetBurnInPresetList() or [])}
+    elif action == "delete_burnin":
+        missing = _requires_method(r, "DeleteBurnInPreset", "21.0.4")
+        if missing:
+            return missing
+        if not p.get("name"):
+            return _err("delete_burnin requires name")
+        return {"success": bool(r.DeleteBurnInPreset(p["name"]))}
+    return _unknown(action, ["import_render","export_render","import_burnin","export_burnin","list_burnin","delete_burnin"])
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -14783,6 +14864,7 @@ _PROJECT_MANAGER_METHODS = [
     "CreateFolder",
     "DeleteFolder",
     "GetProjectListInCurrentFolder",
+    "GetProjectAttributesInCurrentFolder",
     "GetFolderListInCurrentFolder",
     "GotoRootFolder",
     "GotoParentFolder",
@@ -14938,6 +15020,7 @@ def _project_capabilities(pm=None, project=None, resolve_obj=None) -> Dict[str, 
         "kernel_actions": list(_PROJECT_KERNEL_ACTIONS),
         "resolve": {
             "layout_presets": {
+                "list": _has_method(resolve_obj, "GetLayoutPresetList") if resolve_obj else True,
                 "save": _has_method(resolve_obj, "SaveLayoutPreset") if resolve_obj else True,
                 "load": _has_method(resolve_obj, "LoadLayoutPreset") if resolve_obj else True,
                 "update": _has_method(resolve_obj, "UpdateLayoutPreset") if resolve_obj else True,
@@ -14950,6 +15033,16 @@ def _project_capabilities(pm=None, project=None, resolve_obj=None) -> Dict[str, 
                 "export_render": _has_method(resolve_obj, "ExportRenderPreset") if resolve_obj else True,
                 "import_burnin": _has_method(resolve_obj, "ImportBurnInPreset") if resolve_obj else True,
                 "export_burnin": _has_method(resolve_obj, "ExportBurnInPreset") if resolve_obj else True,
+                "list_burnin": _has_method(resolve_obj, "GetBurnInPresetList") if resolve_obj else True,
+                "delete_burnin": _has_method(resolve_obj, "DeleteBurnInPreset") if resolve_obj else True,
+            },
+            "user_preferences_presets": {
+                "list": _has_method(resolve_obj, "GetUserPreferencesPresetList") if resolve_obj else True,
+                "save": _has_method(resolve_obj, "SaveUserPreferencesPreset") if resolve_obj else True,
+                "load": _has_method(resolve_obj, "LoadUserPreferencesPreset") if resolve_obj else True,
+                "delete": _has_method(resolve_obj, "DeleteUserPreferencesPreset") if resolve_obj else True,
+                "import": _has_method(resolve_obj, "ImportUserPreferencesPreset") if resolve_obj else True,
+                "export": _has_method(resolve_obj, "ExportUserPreferencesPreset") if resolve_obj else True,
             },
         },
     }
@@ -15248,6 +15341,7 @@ def _preset_lifecycle_probe(resolve_obj, project, p: Dict[str, Any]) -> Dict[str
         "quick_export_presets": {"available": _has_method(project, "GetQuickExportRenderPresets")},
         "fairlight_presets": {"available": _has_method(resolve_obj, "GetFairlightPresets")},
         "layout_presets": {
+            "list": _has_method(resolve_obj, "GetLayoutPresetList"),
             "save": _has_method(resolve_obj, "SaveLayoutPreset"),
             "load": _has_method(resolve_obj, "LoadLayoutPreset"),
             "update": _has_method(resolve_obj, "UpdateLayoutPreset"),
@@ -15260,6 +15354,16 @@ def _preset_lifecycle_probe(resolve_obj, project, p: Dict[str, Any]) -> Dict[str
             "export_render": _has_method(resolve_obj, "ExportRenderPreset"),
             "import_burnin": _has_method(resolve_obj, "ImportBurnInPreset"),
             "export_burnin": _has_method(resolve_obj, "ExportBurnInPreset"),
+            "list_burnin": _has_method(resolve_obj, "GetBurnInPresetList"),
+            "delete_burnin": _has_method(resolve_obj, "DeleteBurnInPreset"),
+        },
+        "user_preferences_presets": {
+            "list": _has_method(resolve_obj, "GetUserPreferencesPresetList"),
+            "save": _has_method(resolve_obj, "SaveUserPreferencesPreset"),
+            "load": _has_method(resolve_obj, "LoadUserPreferencesPreset"),
+            "delete": _has_method(resolve_obj, "DeleteUserPreferencesPreset"),
+            "import": _has_method(resolve_obj, "ImportUserPreferencesPreset"),
+            "export": _has_method(resolve_obj, "ExportUserPreferencesPreset"),
         },
     }
     try:
@@ -15641,6 +15745,9 @@ def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
 
     Actions:
       list() -> {projects}
+      list_attributes() -> {projects: {name: {lastModifiedDate, creationDate, notes, liveCollaborationMode}}}
+        — Resolve 21.0.4+. Per-project attributes for the current folder without
+          loading any project.
       get_current() -> {name, id}
       create(name, media_location_path?) -> {success, name}
       load(name) -> {success}
@@ -15722,6 +15829,11 @@ def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
         return _project_boundary_report(r, pm, proj, p)
     elif action == "list":
         return {"projects": pm.GetProjectListInCurrentFolder()}
+    elif action == "list_attributes":
+        missing = _requires_method(pm, "GetProjectAttributesInCurrentFolder", "21.0.4")
+        if missing:
+            return missing
+        return {"projects": _ser(pm.GetProjectAttributesInCurrentFolder() or {})}
     elif action == "get_current":
         proj = pm.GetCurrentProject()
         return {"name": proj.GetName(), "id": proj.GetUniqueId()} if proj else _err("No project open")
@@ -15776,7 +15888,7 @@ def project_manager(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
         if not p.get("path"):
             return _err("restore requires path")
         return {"success": bool(pm.RestoreProject(p["path"], p.get("name")))}
-    return _unknown(action, ["list","get_current","create","load","save","close","delete","import_project","export_project","archive","restore","lint","diff_to_spec","plan_spec","apply_spec", *_PROJECT_KERNEL_ACTIONS])
+    return _unknown(action, ["list","list_attributes","get_current","create","load","save","close","delete","import_project","export_project","archive","restore","lint","diff_to_spec","plan_spec","apply_spec", *_PROJECT_KERNEL_ACTIONS])
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_resolve2104_preset_actions.py
+++ b/tests/test_resolve2104_preset_actions.py
@@ -1,0 +1,279 @@
+"""Contract tests for the remaining Resolve 21.0.4 README surfaces.
+
+The 24 Jul 2026 README refresh (shipped with 21.0.4) documented ten methods
+beyond the three wired for issue #131:
+
+  - Resolve.GetLayoutPresetList                    -> layout_presets list
+  - Resolve.GetBurnInPresetList / DeleteBurnInPreset -> render_presets
+    list_burnin / delete_burnin
+  - the six user-preferences-preset methods        -> resolve_control
+    *_user_preferences_preset actions
+  - ProjectManager.GetProjectAttributesInCurrentFolder -> project_manager
+    list_attributes
+
+The 21.0.4 methods are unavailable on the 19.1.3 baseline this suite runs
+against, so every case here is a stub contract, not a live result.
+"""
+import unittest
+
+import src.server as compound
+
+
+# ── Stubs ────────────────────────────────────────────────────────────────────
+
+
+class Resolve2104:
+    """A Resolve handle from a 21.0.4+ build: all ten preset surfaces exist."""
+
+    def __init__(self):
+        self.layout_presets = ["Edit Layout", "Grade Layout"]
+        self.burnin_presets = ["Dailies TC"]
+        self.prefs_presets = ["Laptop"]
+        self.calls = []
+
+    def GetLayoutPresetList(self):
+        return list(self.layout_presets)
+
+    def GetBurnInPresetList(self):
+        return list(self.burnin_presets)
+
+    def DeleteBurnInPreset(self, name):
+        self.calls.append(("DeleteBurnInPreset", name))
+        return name in self.burnin_presets
+
+    def GetUserPreferencesPresetList(self):
+        return list(self.prefs_presets)
+
+    def SaveUserPreferencesPreset(self, name):
+        self.calls.append(("SaveUserPreferencesPreset", name))
+        return True
+
+    def LoadUserPreferencesPreset(self, name):
+        self.calls.append(("LoadUserPreferencesPreset", name))
+        return name in self.prefs_presets
+
+    def DeleteUserPreferencesPreset(self, name):
+        self.calls.append(("DeleteUserPreferencesPreset", name))
+        return name in self.prefs_presets
+
+    def ImportUserPreferencesPreset(self, path, name=None):
+        self.calls.append(("ImportUserPreferencesPreset", path, name))
+        return True
+
+    def ExportUserPreferencesPreset(self, name, path):
+        self.calls.append(("ExportUserPreferencesPreset", name, path))
+        return name in self.prefs_presets
+
+
+class LegacyResolve:
+    """A pre-21.0.4 build — none of the new preset surfaces exist."""
+
+
+class ProjectManager2104:
+    def __init__(self, attributes):
+        self._attributes = attributes
+
+    def GetProjectAttributesInCurrentFolder(self):
+        return dict(self._attributes)
+
+
+class LegacyProjectManager:
+    """A pre-21.0.4 ProjectManager — no per-project attributes call."""
+
+
+class ResolveWithPm:
+    def __init__(self, pm):
+        self._pm = pm
+
+    def GetProjectManager(self):
+        return self._pm
+
+
+ATTRS = {
+    "Zenith_Online": {
+        "lastModifiedDate": "2026-08-05T22:30:00-04:00",
+        "creationDate": "2026-07-01T09:00:00-04:00",
+        "notes": "",
+        "liveCollaborationMode": "multi_user",
+    }
+}
+
+
+class _ResolveStubTest(unittest.TestCase):
+    """Common get_resolve stubbing."""
+
+    resolve_factory = Resolve2104
+
+    def setUp(self):
+        self.resolve = self.resolve_factory()
+        self._orig = compound.get_resolve
+        compound.get_resolve = lambda: self.resolve
+
+    def tearDown(self):
+        compound.get_resolve = self._orig
+
+
+# ── layout_presets list ──────────────────────────────────────────────────────
+
+
+class LayoutPresetListTest(_ResolveStubTest):
+    def test_list_returns_the_saved_preset_names(self):
+        out = compound.layout_presets("list", {})
+        self.assertEqual(out["presets"], ["Edit Layout", "Grade Layout"])
+
+    def test_pre_2104_build_is_version_guarded(self):
+        compound.get_resolve = lambda: LegacyResolve()
+        out = compound.layout_presets("list", {})
+        self.assertIn("error", out)
+        self.assertIn("21.0.4", str(out))
+
+    def test_list_is_a_known_action(self):
+        out = compound.layout_presets("no_such_action", {})
+        self.assertIn("list", str(out))
+
+
+# ── render_presets list_burnin / delete_burnin ───────────────────────────────
+
+
+class BurnInPresetTest(_ResolveStubTest):
+    def test_list_burnin_returns_the_preset_names(self):
+        out = compound.render_presets("list_burnin", {})
+        self.assertEqual(out["presets"], ["Dailies TC"])
+
+    def test_delete_burnin_deletes_by_name(self):
+        out = compound.render_presets("delete_burnin", {"name": "Dailies TC"})
+        self.assertTrue(out["success"])
+        self.assertIn(("DeleteBurnInPreset", "Dailies TC"), self.resolve.calls)
+
+    def test_delete_burnin_requires_a_name(self):
+        out = compound.render_presets("delete_burnin", {})
+        self.assertIn("error", out)
+        self.assertNotIn(("DeleteBurnInPreset", None), self.resolve.calls)
+
+    def test_pre_2104_build_is_version_guarded(self):
+        compound.get_resolve = lambda: LegacyResolve()
+        for action in ("list_burnin", "delete_burnin"):
+            out = compound.render_presets(action, {"name": "x"})
+            self.assertIn("error", out)
+            self.assertIn("21.0.4", str(out))
+
+    def test_new_actions_are_listed_as_known(self):
+        out = compound.render_presets("no_such_action", {})
+        self.assertIn("list_burnin", str(out))
+        self.assertIn("delete_burnin", str(out))
+
+
+# ── resolve_control user preferences presets ─────────────────────────────────
+
+
+class UserPreferencesPresetTest(_ResolveStubTest):
+    def test_list_returns_the_preset_names(self):
+        out = compound.resolve_control("list_user_preferences_presets", {})
+        self.assertEqual(out["presets"], ["Laptop"])
+
+    def test_save_load_delete_round_trip_by_name(self):
+        self.assertTrue(
+            compound.resolve_control("save_user_preferences_preset", {"name": "Laptop"})["success"])
+        self.assertTrue(
+            compound.resolve_control("load_user_preferences_preset", {"name": "Laptop"})["success"])
+        self.assertTrue(
+            compound.resolve_control("delete_user_preferences_preset", {"name": "Laptop"})["success"])
+        self.assertEqual(
+            [c[0] for c in self.resolve.calls],
+            ["SaveUserPreferencesPreset", "LoadUserPreferencesPreset",
+             "DeleteUserPreferencesPreset"])
+
+    def test_name_is_required_for_the_named_actions(self):
+        for action in ("save_user_preferences_preset", "load_user_preferences_preset",
+                       "delete_user_preferences_preset"):
+            out = compound.resolve_control(action, {})
+            self.assertIn("error", out)
+        self.assertEqual(self.resolve.calls, [])
+
+    def test_import_without_a_name_uses_the_single_arg_form(self):
+        out = compound.resolve_control("import_user_preferences_preset",
+                                       {"path": "/tmp/prefs.zip"})
+        self.assertTrue(out["success"])
+        self.assertIn(("ImportUserPreferencesPreset", "/tmp/prefs.zip", None),
+                      self.resolve.calls)
+
+    def test_import_notes_that_the_preset_is_not_auto_loaded(self):
+        # The README is explicit that import does not activate the preset;
+        # the answer carries that forward so a caller doesn't stop early.
+        out = compound.resolve_control("import_user_preferences_preset",
+                                       {"path": "/tmp/prefs.zip", "name": "Studio"})
+        self.assertIn("not auto-loaded", out["note"])
+        self.assertIn(("ImportUserPreferencesPreset", "/tmp/prefs.zip", "Studio"),
+                      self.resolve.calls)
+
+    def test_export_requires_name_and_path(self):
+        out = compound.resolve_control("export_user_preferences_preset", {"name": "Laptop"})
+        self.assertIn("error", out)
+        out = compound.resolve_control("export_user_preferences_preset",
+                                       {"name": "Laptop", "path": "/tmp/prefs.zip"})
+        self.assertTrue(out["success"])
+
+    def test_pre_2104_build_is_version_guarded(self):
+        compound.get_resolve = lambda: LegacyResolve()
+        out = compound.resolve_control("list_user_preferences_presets", {})
+        self.assertIn("error", out)
+        self.assertIn("21.0.4", str(out))
+
+    def test_new_actions_are_listed_as_known(self):
+        out = compound.resolve_control("no_such_action", {})
+        self.assertIn("list_user_preferences_presets", str(out))
+        self.assertIn("export_user_preferences_preset", str(out))
+
+
+# ── project_manager list_attributes ──────────────────────────────────────────
+
+
+class ListProjectAttributesTest(unittest.TestCase):
+    def setUp(self):
+        self._orig = compound.get_resolve
+        compound.get_resolve = lambda: ResolveWithPm(ProjectManager2104(ATTRS))
+
+    def tearDown(self):
+        compound.get_resolve = self._orig
+
+    def test_attributes_come_back_keyed_by_project_name(self):
+        out = compound.project_manager("list_attributes", {})
+        self.assertEqual(out["projects"], ATTRS)
+
+    def test_pre_2104_build_is_version_guarded(self):
+        compound.get_resolve = lambda: ResolveWithPm(LegacyProjectManager())
+        out = compound.project_manager("list_attributes", {})
+        self.assertIn("error", out)
+        self.assertIn("21.0.4", str(out))
+
+    def test_list_attributes_is_a_known_action(self):
+        out = compound.project_manager("no_such_action", {})
+        self.assertIn("list_attributes", str(out))
+
+
+# ── capability advertisement ─────────────────────────────────────────────────
+
+
+class CapabilityAdvertisementTest(unittest.TestCase):
+    def test_project_capabilities_advertise_the_new_surfaces(self):
+        caps = compound._project_capabilities(None, None, Resolve2104())["resolve"]
+
+        self.assertTrue(caps["layout_presets"]["list"])
+        self.assertTrue(caps["render_presets"]["list_burnin"])
+        self.assertTrue(caps["render_presets"]["delete_burnin"])
+        self.assertEqual(
+            sorted(caps["user_preferences_presets"]),
+            ["delete", "export", "import", "list", "load", "save"])
+        self.assertTrue(all(caps["user_preferences_presets"].values()))
+
+    def test_legacy_build_reports_the_new_surfaces_absent(self):
+        caps = compound._project_capabilities(None, None, LegacyResolve())["resolve"]
+
+        self.assertFalse(caps["layout_presets"]["list"])
+        self.assertFalse(caps["render_presets"]["list_burnin"])
+        self.assertFalse(caps["render_presets"]["delete_burnin"])
+        self.assertFalse(any(caps["user_preferences_presets"].values()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #135, closes #136, closes #137, closes #138.

The 24 Jul 2026 refresh of the shipped scripting README (the one that came with 21.0.4) documented ten methods beyond the three #131 caught. This wires all ten, in the #133 mold: thin wrappers, `_requires_method` guards at 21.0.4, capability advertisement, stub contract tests, and coverage-doc rows that carry my 21.0.4.5 evidence as a contributor report rather than claiming your validation machine ran them.

## What's wired

| Surface | MCP shape |
|---|---|
| `Resolve.GetLayoutPresetList` | `layout_presets` → `list` |
| `Resolve.GetBurnInPresetList` / `DeleteBurnInPreset` | `render_presets` → `list_burnin` / `delete_burnin` |
| six `*UserPreferencesPreset` methods | `resolve_control` → `list/save/load/delete/import/export_user_preferences_preset` |
| `ProjectManager.GetProjectAttributesInCurrentFolder` | `project_manager` → `list_attributes` |

Notes carried into docstrings/answers rather than left to be discovered: `load_user_preferences_preset` is flagged SESSION-WIDE (it swaps the user's global preferences), and `import_user_preferences_preset` answers with the README's own not-auto-loaded caveat so a caller follows with `load` instead of stopping early.

## Docs

- `docs/reference/resolve_scripting_api.txt` was the **26 May 2026** README — which is how this delta went unnoticed. Refreshed to the 24 Jul 2026 text.
- `api-coverage.md`: ten new rows (Resolve 24–32, ProjectManager 26), 351 → 361 methods, Untested 13 → 23. All ten marked 🔬 per your counting convention; `LoadUserPreferencesPreset` recorded as deliberately unexecuted even by me (same class as `DisableBackgroundTasksForCurrentResolveSession`).

## Evidence (Studio 21.0.4.5, macOS)

Live-verified **through the MCP actions themselves**, not just the raw API:

```
layout_presets list                      -> {"presets": []}
layout_presets save  ("MCP_PR_VERIFY")   -> {"success": true}
layout_presets list                      -> {"presets": ["MCP_PR_VERIFY"]}
layout_presets delete("MCP_PR_VERIFY")   -> {"success": true}
layout_presets list                      -> {"presets": []}
render_presets list_burnin               -> {"presets": []}
resolve_control list_user_preferences_presets -> {"presets": []}
project_manager list_attributes          -> 8 projects, each with
  lastModifiedDate / creationDate / notes / liveCollaborationMode
```

The same save→list→delete round-trip was run for the user-prefs family via the raw API (issue #138). `LoadUserPreferencesPreset` and `DeleteBurnInPreset` were not executed — reasons in the issues and the coverage rows.

## Tests

`tests/test_resolve2104_preset_actions.py` — 21 stub contract cases: the answers, the name-required errors, the pre-21.0.4 guards, `_unknown` listings, and capability advertisement on both a 21.0.4 stub and a legacy stub.

Full suite: **2532 tests OK, 27 skipped**, via `venv/bin/python -m unittest discover -s tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)