### PR TITLE
fix(dashboard): honor inventory_limit preference instead of hardcoding a 500 cap

### DIFF
--- a/src/analysis_dashboard.py
+++ b/src/analysis_dashboard.py
@@ -6624,7 +6624,7 @@ HTML = r"""<!doctype html>
         const query = options.silent ? '&probe=0&reuse=1' : '';
         const headers = {};
         if (state.mediaETag) headers['If-None-Match'] = state.mediaETag;
-        const res = await fetch(`/api/resolve/media?limit=500${query}`, { headers, cache: 'no-store' });
+        const res = await fetch(`/api/resolve/media?${query.replace(/^&/, '')}`, { headers, cache: 'no-store' });
         state.mediaLastRefresh = new Date();
         state.resolveMediaStale = false;
         if (res.status === 304) return;


### PR DESCRIPTION
## Bug

The Preferences panel already exposes `media_analysis.inventory_limit` (up to 10000), and `/api/resolve/media` already applies it server-side. But the dashboard's own auto-refresh polling call (`refreshResolveMedia()`) hardcoded `?limit=500`, silently overriding whatever the user had configured.

On a 3015-clip project this truncated the inventory to the first 500 clips and made several real Media Pool bins appear empty in the Overview panel.

## Fix

Drop the hardcoded `limit` param from the polling fetch so the request falls through to the server-applied `inventory_limit` preference instead of overriding it.

## Verification

Reproduced against a live 3015-clip project: before the fix the dashboard reported 500/truncated; after the fix and a control-panel restart it reported all 3015 clips (32 real bins), matching the configured preference.