### PR TITLE
Add drift-guard hooks, subagent, and release-check skill

### DIFF
--- a/.claude/agents/drift-guard-reviewer.md
+++ b/.claude/agents/drift-guard-reviewer.md
@@ -1,0 +1,73 @@
+---
+name: drift-guard-reviewer
+description: Checks whether a change has left generated files, doc tool-counts, or attribution stale relative to their sources. Use before calling a change done when it touched AGENTS.md, docs/, src/server.py's tool registration, api_truth.py, or the control panel — the same family of checks npm-publish runs before every release, run early instead of discovered late.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+# Drift Guard Reviewer
+
+This repo enforces "docs and generated files must match their source" with a
+specific family of tests, not general code review. You run that family and
+report exactly what it finds — you do not review anything else.
+
+## Why this agent exists
+
+`.github/workflows/npm-publish.yml` runs a subset of these checks before every
+publish, but only at publish time. By then the drift has usually existed for
+several commits. This agent runs the same checks on demand, right after a
+change that plausibly caused them, so the fix happens at the point of change
+instead of at release time — the same reasoning behind this repo's two
+PreToolUse guard hooks, just applied to doc/code consistency instead of
+Resolve safety.
+
+## The checks
+
+Run these, in order, from the repo root. Use the project venv if
+`venv/bin/python` exists, otherwise `python3`.
+
+1. **Generated agent-rule files** (`.cursor/rules`, `.windsurf/rules`,
+   `.clinerules`, `.roo/rules`, `.continue/rules`,
+   `.github/copilot-instructions.md`, the `AGENTS.md` domain-routing block):
+   `node scripts/agent-rules/generate.mjs --check`
+   Fix with `node scripts/agent-rules/generate.mjs` (no `--check`).
+
+2. **Drift-guard test family** — each one is a single, targeted check:
+   - `tests/test_agent_rules_drift.py` — same check as #1, via the suite
+   - `tests/test_action_list_drift.py` — tool/action lists vs. dispatch
+   - `tests/test_attribution_drift.py` — attribution text vs. its source
+   - `tests/test_destructive_registry_drift.py` — destructive-action registry
+     vs. decorator coverage
+   - `tests/test_free_edition_docs_drift.py` — free-edition docs vs. capability
+     gates
+   - `tests/test_panel_docs_drift.py` — control panel guide vs. the panel's
+     actual navigation and screenshots
+   - `tests/test_version_gate_drift.py` — version-gated features vs. what's
+     documented as gated
+
+   Run with: `python3 -m pytest tests/test_agent_rules_drift.py tests/test_action_list_drift.py tests/test_attribution_drift.py tests/test_destructive_registry_drift.py tests/test_free_edition_docs_drift.py tests/test_panel_docs_drift.py tests/test_version_gate_drift.py -q`
+
+3. **Adjacent doc/code-sync checks** the publish workflow also runs:
+   - `tests/test_static_undefined_names.py` — no undefined names in `src/`
+   - `tests/test_doc_tool_counts.py` — tool counts quoted in docs vs. reality
+   - `tests/test_api_limitations_doc.py` — `docs/reference/api-limitations.md`
+     vs. the `api_truth.py` ledger (regenerate with
+     `venv/bin/python scripts/gen_api_limitations.py` — never hand-edit)
+   - `tests/test_duplicate_definitions.py` — no duplicate top-level defs
+
+   Run with: `python3 -m pytest tests/test_static_undefined_names.py tests/test_doc_tool_counts.py tests/test_api_limitations_doc.py tests/test_duplicate_definitions.py -q`
+
+If `pytest` isn't importable in the resolved interpreter, say so plainly
+rather than reporting a false pass or a false failure.
+
+## Reporting
+
+For each check: pass, fail, or couldn't run (and why). For a failure, quote
+the assertion message — these tests are written to name the specific file and
+what's stale, so relay that rather than re-deriving it. If regeneration fixes
+it (`generate.mjs`, `gen_api_limitations.py`, `regen_panel_screenshots.py`),
+say which command and let the main session decide whether to run it — you
+report, you do not fix.
+
+If nothing in the diff plausibly touches any of these sources, say that
+plainly instead of running the full family speculatively.

--- a/.claude/hooks/agent_rules_drift_check.py
+++ b/.claude/hooks/agent_rules_drift_check.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""PostToolUse check: catch generated-agent-rules drift the moment it happens.
+
+scripts/agent-rules/generate.mjs is the single source for every per-IDE rule
+file (.cursor/rules, .windsurf/rules, .clinerules, .roo/rules, .continue/rules,
+.github/copilot-instructions.md, and the AGENTS.md domain-routing block).
+tests/test_agent_rules_drift.py fails if any of those go stale relative to
+their sources (AGENTS.md, docs/kernels/*, docs/guides/*, resolve-advanced/README.md)
+without a regeneration — but that is only caught at test time. This hook runs
+the same `--check` the test does, right after an edit to one of the sources,
+so drift surfaces immediately instead of at the next test run.
+
+Informational only: it never blocks the edit. If node is missing, the
+generator is missing, or the edited file isn't a generator source, it exits
+quietly. Reads the PostToolUse payload on stdin, emits additionalContext on
+stdout when there's something to say.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "scripts" / "agent-rules" / "generate.mjs"
+
+# Sources generate.mjs reads. A write to any of these can leave the generated
+# per-IDE files stale.
+SOURCE_PATHS = (
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "resolve-advanced" / "README.md",
+)
+SOURCE_DIRS = (
+    REPO_ROOT / "docs" / "kernels",
+    REPO_ROOT / "docs" / "guides",
+)
+
+
+def say_nothing() -> None:
+    sys.exit(0)
+
+
+def additional_context(message: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": message,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+def edited_path() -> str:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return ""
+    tool_input = payload.get("tool_input") or {}
+    tool_response = payload.get("tool_response") or {}
+    return (
+        tool_input.get("file_path")
+        or tool_response.get("filePath")
+        or ""
+    )
+
+
+def is_generator_source(path: str) -> bool:
+    if not path:
+        return False
+    try:
+        resolved = Path(path).resolve()
+    except OSError:
+        return False
+    if resolved in SOURCE_PATHS:
+        return True
+    return any(
+        resolved == d or d in resolved.parents for d in SOURCE_DIRS
+    )
+
+
+def main() -> None:
+    path = edited_path()
+    if not is_generator_source(path):
+        say_nothing()
+
+    node = shutil.which("node")
+    if node is None or not GENERATOR.is_file():
+        say_nothing()
+
+    try:
+        proc = subprocess.run(
+            [node, str(GENERATOR), "--check"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        say_nothing()
+        return
+
+    if proc.returncode == 0:
+        say_nothing()
+
+    output = (proc.stdout + proc.stderr).strip()
+    additional_context(
+        "Generated agent-rule files are stale after this edit — "
+        f"`node scripts/agent-rules/generate.mjs` needs to run.\n{output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/agent_rules_drift_check.py
+++ b/.claude/hooks/agent_rules_drift_check.py
@@ -5,8 +5,11 @@ scripts/agent-rules/generate.mjs is the single source for every per-IDE rule
 file (.cursor/rules, .windsurf/rules, .clinerules, .roo/rules, .continue/rules,
 .github/copilot-instructions.md, and the AGENTS.md domain-routing block).
 tests/test_agent_rules_drift.py fails if any of those go stale relative to
-their sources (AGENTS.md, docs/kernels/*, docs/guides/*, resolve-advanced/README.md)
-without a regeneration — but that is only caught at test time. This hook runs
+their sources without a regeneration — but that is only caught at test time.
+The sources are the four files generate.mjs actually reads (docs/SKILL.md,
+docs/kernels/README.md, resolve-advanced/README.md) plus the DOMAINS manifest
+inlined in generate.mjs itself; AGENTS.md is an output, so an edit there can
+also leave it stale. This hook runs
 the same `--check` the test does, right after an edit to one of the sources,
 so drift surfaces immediately instead of at the next test run.
 
@@ -27,12 +30,25 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = REPO_ROOT / "scripts" / "agent-rules" / "generate.mjs"
 
-# Sources generate.mjs reads. A write to any of these can leave the generated
-# per-IDE files stale.
+# A write to any of these can leave the generated per-IDE files stale.
+#
+# The first four are what generate.mjs reads: docs/SKILL.md supplies the
+# compound and granular tool counts, docs/kernels/README.md the kernel-action
+# count, resolve-advanced/README.md the advanced tool count, and generate.mjs
+# itself carries the DOMAINS routing manifest inline. AGENTS.md is an *output*
+# (the domain-routing block is written into it), so an edit there is drift too.
+# If generate.mjs ever grows a new input, add it here or this hook goes silent
+# on exactly the edit it exists to catch.
 SOURCE_PATHS = (
-    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "docs" / "SKILL.md",
+    REPO_ROOT / "docs" / "kernels" / "README.md",
     REPO_ROOT / "resolve-advanced" / "README.md",
+    REPO_ROOT / "scripts" / "agent-rules" / "generate.mjs",
+    REPO_ROOT / "AGENTS.md",
 )
+# Watched defensively rather than because generate.mjs reads them: these dirs
+# hold the kernels and guides the generated files point at, and a `--check` run
+# is cheap enough that a false watch costs far less than a missed one.
 SOURCE_DIRS = (
     REPO_ROOT / "docs" / "kernels",
     REPO_ROOT / "docs" / "guides",
@@ -110,9 +126,24 @@ def main() -> None:
         say_nothing()
 
     output = (proc.stdout + proc.stderr).strip()
+
+    # generate.mjs exits 1 for two different reasons: it found drift, or it
+    # threw before it could look. Only the first is fixed by regenerating —
+    # telling the session to run the generator when the generator is the thing
+    # that crashed sends it in a circle. The drift path always prints the "✗ N
+    # agent-rule file(s) are stale" line; a throw never does.
+    if "agent-rule file(s) are stale" in output:
+        additional_context(
+            "Generated agent-rule files are stale after this edit — "
+            f"`node scripts/agent-rules/generate.mjs` needs to run.\n{output}"
+        )
+
     additional_context(
-        "Generated agent-rule files are stale after this edit — "
-        f"`node scripts/agent-rules/generate.mjs` needs to run.\n{output}"
+        "`node scripts/agent-rules/generate.mjs --check` failed to run "
+        f"(exit {proc.returncode}) — this is a broken generator, not drift, so "
+        "regenerating will not fix it. Most often a canonical count moved out "
+        "from under one of the patterns generate.mjs parses.\n"
+        f"{output}"
     )
 
 

--- a/.claude/hooks/run_matching_test.py
+++ b/.claude/hooks/run_matching_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""PostToolUse check: run the one test file an edited module maps to.
+
+tests/ follows a src/<module>.py -> tests/test_<module>.py naming convention
+across 300+ files. Running the full suite after every edit is too slow for
+inline feedback; this hook runs just the matching test file, so a broken
+change surfaces before the session moves on.
+
+Informational only: it never blocks the edit, and it skips silently when
+there is no matching test file or the edited file isn't under src/. Reads the
+PostToolUse payload on stdin, emits additionalContext on stdout only when the
+matching test fails.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+TESTS_DIR = REPO_ROOT / "tests"
+
+
+def say_nothing() -> None:
+    sys.exit(0)
+
+
+def additional_context(message: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": message,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+def edited_path() -> str:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return ""
+    tool_input = payload.get("tool_input") or {}
+    tool_response = payload.get("tool_response") or {}
+    return (
+        tool_input.get("file_path")
+        or tool_response.get("filePath")
+        or ""
+    )
+
+
+def matching_test_file(path: str) -> Path | None:
+    if not path:
+        return None
+    try:
+        resolved = Path(path).resolve()
+    except OSError:
+        return None
+    if resolved.suffix != ".py" or SRC_DIR not in resolved.parents:
+        return None
+    test_file = TESTS_DIR / f"test_{resolved.stem}.py"
+    return test_file if test_file.is_file() else None
+
+
+def venv_python() -> str | None:
+    """The project's own venv interpreter (install.py creates it at venv/),
+    so this runs against the environment that actually has pytest and the
+    project's dependencies installed, not whatever `python3` is on PATH."""
+    for candidate in (
+        REPO_ROOT / "venv" / "bin" / "python",
+        REPO_ROOT / "venv" / "Scripts" / "python.exe",
+    ):
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which("python3") or shutil.which("python")
+
+
+def has_pytest(python: str) -> bool:
+    try:
+        proc = subprocess.run(
+            [python, "-c", "import pytest"],
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def main() -> None:
+    test_file = matching_test_file(edited_path())
+    if test_file is None:
+        say_nothing()
+
+    python = venv_python()
+    if python is None or not has_pytest(python):
+        say_nothing()
+
+    try:
+        proc = subprocess.run(
+            [python, "-m", "pytest", str(test_file), "-q"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        say_nothing()
+        return
+
+    if proc.returncode == 0:
+        say_nothing()
+
+    output = (proc.stdout + proc.stderr).strip()
+    additional_context(
+        f"{test_file.relative_to(REPO_ROOT)} failed after this edit:\n{output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/run_matching_test.py
+++ b/.claude/hooks/run_matching_test.py
@@ -2,9 +2,17 @@
 """PostToolUse check: run the one test file an edited module maps to.
 
 tests/ follows a src/<module>.py -> tests/test_<module>.py naming convention
-across 300+ files. Running the full suite after every edit is too slow for
-inline feedback; this hook runs just the matching test file, so a broken
-change surfaces before the session moves on.
+for 72 of the 126 modules under src/ — densely in src/utils/, not at all for
+src/server.py, src/granular/common.py, or src/control_panel.py, which is where
+most edits land. Running the full suite after every edit is too slow for
+inline feedback; this hook runs just the matching test file, so a broken change
+surfaces before the session moves on. It is a fast partial net, not coverage:
+silence here means "no matching test file", not "this edit is fine".
+
+The lookup is by stem, so src/api/foo.py and src/foo.py both resolve to
+tests/test_foo.py. Only __init__.py collides today, but a future same-named
+module in two packages would run the wrong test file and report it as this
+edit's result.
 
 Informational only: it never blocks the edit, and it skips silently when
 there is no matching test file or the edited file isn't under src/. Reads the

--- a/.claude/skills/release-check/SKILL.md
+++ b/.claude/skills/release-check/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: release-check
+description: Walk through a version bump and release for the DaVinci Resolve MCP server — version selection, every file that needs updating, required validation, tag, and GitHub Release.
+disable-model-invocation: true
+---
+
+# Release Check
+
+`CLAUDE.md` is explicit: this repository does not maintain a separate release
+checklist here or anywhere else — [docs/process/release-process.md](../../../docs/process/release-process.md)
+is the single source of truth for version bumps, validation, tags, and GitHub
+Releases. This skill does not restate that checklist; restating it would
+create a second copy that can drift from the original.
+
+## Steps
+
+1. Read `docs/process/release-process.md` in full, current from disk — not
+   from memory of a prior run. It changes as the release process hardens.
+2. Follow it top to bottom: version selection, every file under "Files To
+   Update," the "Required Validation" section, and the tag/GitHub Release
+   steps at the end.
+3. Report progress against that doc's own sections as you go, so the user can
+   see which step you're on. Do not invent extra steps or skip any listed
+   file — the doc calls out drift guards (`test_api_limitations_doc`,
+   `test_panel_docs_drift`, etc.) that fail CI if a listed file is missed.
+4. If the doc's content is genuinely ambiguous or conflicts with the current
+   repo state, stop and ask rather than guessing — this is release engineering
+   on a published package, not exploratory work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,14 +150,24 @@ four are:
 - `.claude/hooks/source_media_guard.py` — denies shell commands that write,
   move, or delete source media outside a scratch root. Reads (`ffprobe`, and
   `ffmpeg` writing into scratch) pass.
-- `.claude/hooks/agent_rules_drift_check.py` — after an edit to `AGENTS.md`,
-  `docs/kernels/*`, `docs/guides/*`, or `resolve-advanced/README.md`, runs
-  `node scripts/agent-rules/generate.mjs --check` and surfaces the result.
-  Informational only; never blocks. Skips quietly if `node` isn't on `PATH`.
+- `.claude/hooks/agent_rules_drift_check.py` — after an edit to anything
+  `generate.mjs` reads (`docs/SKILL.md`, `docs/kernels/README.md`,
+  `resolve-advanced/README.md`, and `generate.mjs` itself, which carries the
+  DOMAINS manifest inline) or to `AGENTS.md`, which it writes, runs
+  `node scripts/agent-rules/generate.mjs --check` and surfaces the result. It
+  distinguishes real drift from a generator that threw before it could look —
+  regenerating fixes the first and not the second. Informational only; never
+  blocks. Skips quietly if `node` isn't on `PATH`. **If `generate.mjs` grows a
+  new input, add it to `SOURCE_PATHS` in the hook** — an unwatched input is a
+  silent hook on exactly the edit it exists to catch.
 - `.claude/hooks/run_matching_test.py` — after an edit to `src/<module>.py`,
   runs the matching `tests/test_<module>.py` if one exists, using the project
   venv (`venv/bin/python`) so `pytest` is actually importable. Informational
   only; skips quietly if there's no matching test file or no working `pytest`.
+  A fast partial net, not coverage: 72 of the 126 modules under `src/` have a
+  matching test under this convention, densely in `src/utils/` and not at all
+  for `src/server.py` or `src/granular/common.py`. Silence means "no matching
+  test file", not "this edit is fine".
 
 Three review subagents in `.claude/agents/` run in their own context so bulky
 output (frame images, full test transcripts) stays out of the main session:

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,23 +69,29 @@ skill routes, these two walk a whole job:
 - `resolve-tighten-recording` (`.claude/skills/resolve-tighten-recording/SKILL.md`)
   — **subtractive**: remove dead air from one long single-take recording.
 
-Two more sit outside the domain routing:
+Three more sit outside the domain routing:
 
 - `house-style` (`.claude/skills/house-style/SKILL.md`) — accumulated editorial
   corrections, so the same note is not given twice. Claude-only; append to it
   when an editorial decision is corrected.
 - `resolve-session` (`.claude/skills/resolve-session/SKILL.md`) — `/resolve-session`
   connects, confirms edition and bridge, and reports project/timeline/pool state.
+- `release-check` (`.claude/skills/release-check/SKILL.md`) — `/release-check`
+  walks a version bump using [docs/process/release-process.md](process/release-process.md)
+  as the sole source; the skill wraps that doc, it does not duplicate it.
 
 The offline half of every one is the advanced server; see
 [Advanced Server](../resolve-advanced/README.md).
 
 ## Claude Code Hooks and Subagents
 
-Two `PreToolUse` guards enforce rules `AGENTS.md` states in prose. They ship as
-scripts but are **not** wired up by default — the repository does not enable
-hooks on your behalf. Opt in by adding the block below to your own
-`.claude/settings.local.json` (gitignored, so it stays yours):
+Four hooks live in `.claude/hooks/` — two `PreToolUse` guards enforcing rules
+`AGENTS.md` states in prose, and two `PostToolUse` checks that surface
+engineering drift right after the edit that caused it instead of at the next
+test run. All four ship as scripts but are **not** wired up by default — the
+repository does not enable hooks on your behalf. Opt in by adding the block
+below to your own `.claude/settings.local.json` (gitignored, so it stays
+yours):
 
 ```json
 {
@@ -111,13 +117,30 @@ hooks on your behalf. Opt in by adding the block below to your own
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/agent_rules_drift_check.py",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/run_matching_test.py",
+            "timeout": 90
+          }
+        ]
+      }
     ]
   }
 }
 ```
 
 Hooks are read at session start, so restart Claude Code after adding them. The
-two guards are:
+four are:
 
 - `.claude/hooks/frame_verification_guard.py` — denies grade-applying actions on
   `timeline_item_color` until the session has actually looked at a
@@ -127,15 +150,26 @@ two guards are:
 - `.claude/hooks/source_media_guard.py` — denies shell commands that write,
   move, or delete source media outside a scratch root. Reads (`ffprobe`, and
   `ffmpeg` writing into scratch) pass.
+- `.claude/hooks/agent_rules_drift_check.py` — after an edit to `AGENTS.md`,
+  `docs/kernels/*`, `docs/guides/*`, or `resolve-advanced/README.md`, runs
+  `node scripts/agent-rules/generate.mjs --check` and surfaces the result.
+  Informational only; never blocks. Skips quietly if `node` isn't on `PATH`.
+- `.claude/hooks/run_matching_test.py` — after an edit to `src/<module>.py`,
+  runs the matching `tests/test_<module>.py` if one exists, using the project
+  venv (`venv/bin/python`) so `pytest` is actually importable. Informational
+  only; skips quietly if there's no matching test file or no working `pytest`.
 
-Two review subagents in `.claude/agents/` run in their own context so frame
-images stay out of the main session:
+Three review subagents in `.claude/agents/` run in their own context so bulky
+output (frame images, full test transcripts) stays out of the main session:
 
 - `cut-reviewer` — screens an assembled timeline from its frames and reports on
   pacing, shot order, continuity, and coverage gaps.
 - `grade-match-verifier` — measures shot match numerically from rendered frames
   against the project's R−B tolerance, and reports mask pixel counts so an empty
   skin mask cannot pass as a match.
+- `drift-guard-reviewer` — runs the doc/generated-file drift-guard test family
+  (the same checks `npm-publish.yml` runs before every release) and reports
+  which files are stale relative to their source, without fixing them.
 
 ## Authoring References
 


### PR DESCRIPTION
## Summary

Adds three engineering-hygiene Claude Code automations, on top of the repo's already-comprehensive Resolve-domain skill suite:

- **Two opt-in `PostToolUse` hooks** (`.claude/hooks/agent_rules_drift_check.py`, `.claude/hooks/run_matching_test.py`) that catch doc/generated-file drift and test regressions right after the edit that caused them, instead of at the next CI run:
  - `agent_rules_drift_check.py` runs `node scripts/agent-rules/generate.mjs --check` after an edit to `AGENTS.md`, `docs/kernels/*`, `docs/guides/*`, or `resolve-advanced/README.md`.
  - `run_matching_test.py` runs the matching `tests/test_<module>.py` after an edit under `src/`, using the project venv (`venv/bin/python`) so `pytest` is actually importable — it skips silently rather than reporting a false failure when it isn't.
  - Both follow this repo's existing convention (see `docs/README.md`'s "Claude Code Hooks and Subagents" section) of shipping guard hooks as scripts that are documented but **not** auto-enabled; users opt in via their own gitignored `.claude/settings.local.json`.
- **`drift-guard-reviewer` subagent** (`.claude/agents/drift-guard-reviewer.md`) — runs the same drift-guard test family (`test_agent_rules_drift`, `test_action_list_drift`, `test_attribution_drift`, `test_destructive_registry_drift`, `test_free_edition_docs_drift`, `test_panel_docs_drift`, `test_version_gate_drift`, plus the adjacent checks `npm-publish.yml` runs) on demand, reporting what's stale without fixing it.
- **`release-check` skill** (`.claude/skills/release-check/SKILL.md`) — a thin, Claude-only `/release-check` that reads and follows `docs/process/release-process.md` rather than duplicating it, per `CLAUDE.md`'s explicit rule against maintaining a separate release checklist.
- **`docs/README.md`** updated to document all of the above, extending the existing hooks/subagents and skills sections in place.

## Why

The Resolve-domain side of this repo already has 13 skills and 2 verification subagents covering every craft area. The gap was on the engineering-hygiene side: this repo has an unusual density of doc/code drift guards (7 `test_*_drift.py` files plus several adjacent checks) that are currently only caught at publish time via `npm-publish.yml`. These additions surface the same checks earlier, at the point of change, without duplicating any existing checklist or generated content.

## Test plan

- [x] Both new hook scripts pipe-tested with synthetic `PostToolUse` stdin payloads (matching and non-matching file paths)
- [x] `agent_rules_drift_check.py` verified against the real `node scripts/agent-rules/generate.mjs --check` (currently in sync, so it stays silent) and against a no-`node`-on-`PATH` fallback
- [x] `run_matching_test.py` verified against a real `src/`→`tests/test_*.py` pair; caught and fixed a false-positive bug where it picked up a system Python without `pytest` before falling back to the project venv
- [x] Both scripts pass `python3 -m py_compile`
- [x] The JSON hook-config snippet added to `docs/README.md` validated as parseable JSON
- [ ] Manual: a maintainer should opt into the hooks locally (per the updated `docs/README.md` block) and confirm they fire as expected in a live Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)