### PR TITLE
source_media_guard: split commands on newlines; never exempt an in-place ffmpeg overwrite

### DIFF
--- a/.claude/hooks/source_media_guard.py
+++ b/.claude/hooks/source_media_guard.py
@@ -137,8 +137,12 @@ def is_media(token: str) -> bool:
 
 
 def split_commands(command: str) -> List[str]:
-    """Split on shell separators so `ffprobe x && rm y` is checked as two."""
-    return [part for part in re.split(r"&&|\|\||;|\|", command) if part.strip()]
+    """Split on shell separators so `ffprobe x && rm y` is checked as two.
+
+    Newlines are separators too: a multi-line block with a harmless first line
+    must not hide the mutating lines after it (fitfam trap row 23, 2026-08-12).
+    """
+    return [part for part in re.split(r"&&|\|\||;|\||\n", command) if part.strip()]
 
 
 def endangered_targets(segment: str) -> List[str]:
@@ -165,9 +169,10 @@ def endangered_targets(segment: str) -> List[str]:
     destructive = argv0 in DESTRUCTIVE
 
     if argv0 in {"ffmpeg", "avconv"}:
-        # ffmpeg reads every -i and writes the trailing operand.
-        inputs = {args[i + 1] for i, a in enumerate(args) if a == "-i" and i + 1 < len(args)}
-        outputs = [a for a in args[-1:] if not a.startswith("-") and a not in inputs]
+        # ffmpeg reads every -i and writes the trailing operand. The output must be
+        # checked even when it equals an input — `ffmpeg -i x.mp4 x.mp4` is the
+        # unrecoverable in-place overwrite, not an operand to exempt (trap row 23b).
+        outputs = [a for a in args[-1:] if not a.startswith("-")]
         return [t for t in outputs if is_media(t) and not is_scratch(t)]
 
     if argv0 == "cp":


### PR DESCRIPTION
Two holes in `.claude/hooks/source_media_guard.py`, both found and verified by executing payloads against the hook (not by reading it):

1. **`split_commands()` does not split on newlines.** It splits on `&&`, `||`, `;` and `|` only, so a multi-line Bash block is parsed as one segment: `argv0` resolves to the first line's command, and if that line is non-mutating the function returns before ever seeing the lines below it. A block like:

   ```
   mkdir -p footage/_superseded
   mv footage/clip.mp4 footage/_superseded/
   ```

   is allowed, while the identical commands joined by `;` are denied. The same shape passes `cd dir` + newline + `rm CLIP.MP4`.

2. **The ffmpeg branch exempts an output that equals an input.** `outputs` was built with `a not in inputs`, which drops the output operand exactly when it matches an `-i` value — i.e. `ffmpeg -i master.mp4 master.mp4`, the in-place source overwrite the guard's own deny message describes as unrecoverable. This one is independent of hole 1: the bare single-line form was also allowed.

**Fix:** add `\n` to the split regex, and drop the input-equality exemption so the trailing output operand is always checked. `ffmpeg` writing into a scratch root still passes, distinct-output transcodes outside scratch still deny (unchanged), and benign multi-line commands (reads, scratch-root writes) still pass — verified with an 11-payload matrix before and after.

(Amusing field note: the first attempt to open this PR was itself blocked by the fixed guard, because the example commands above appeared in the command line's body argument. The fix works.)

Happy to adjust style or add tests wherever you'd like them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
