### PR TITLE
fix(install): find Resolve outside the default install location

### DIFF
--- a/install.py
+++ b/install.py
@@ -284,6 +284,21 @@ def find_resolve_paths():
             lib_path = expanded
             break
 
+    if lib_path is None:
+        # The literal candidates above only cover a default install. An explicit
+        # override wins outright; failing that, ask where Resolve actually is.
+        # Skipping this is what wrote an empty RESOLVE_SCRIPT_LIB into working
+        # configs and left the server importing a DLL that was never there.
+        env_lib = os.environ.get("RESOLVE_SCRIPT_LIB")
+        if env_lib and os.path.isfile(env_lib):
+            lib_path = env_lib
+        else:
+            try:
+                from src.utils.platform import discover_scripting_lib
+                lib_path = discover_scripting_lib()
+            except Exception:
+                lib_path = None
+
     return api_path, lib_path
 
 
@@ -520,7 +535,14 @@ def get_python_base_install(python_path):
 
 
 def build_server_env(python_path, api_path, lib_path, system=SYSTEM, python_home=None):
-    """Build the env block used by all generated stdio MCP configs."""
+    """Build the env block used by all generated stdio MCP configs.
+
+    Keys whose value is empty are omitted rather than written as "". An empty
+    `RESOLVE_SCRIPT_LIB` is worse than an absent one: it reads as configured in
+    the config file, while `DaVinciResolveScript.py` treats it as unset and
+    silently reverts to its own hardcoded install path — so a machine with
+    Resolve elsewhere fails with a DLL-load error that names nothing useful.
+    """
     api_value = str(api_path or "")
     lib_value = str(lib_path or "")
     env = {
@@ -528,6 +550,7 @@ def build_server_env(python_path, api_path, lib_path, system=SYSTEM, python_home
         "RESOLVE_SCRIPT_LIB": lib_value,
         "PYTHONPATH": str(Path(api_value) / "Modules") if api_value else "",
     }
+    env = {key: value for key, value in env.items() if value}
 
     if system == "Windows":
         env["PYTHONHOME"] = str(python_home or get_python_base_install(python_path))
@@ -1921,7 +1944,13 @@ def main():
     if lib_path:
         print(f"  Library:   {green(lib_path)}")
     else:
-        print(f"  Library:   {yellow('Not found')} {dim('(optional — API path is sufficient)')}")
+        # Not optional, whatever this line used to claim: DaVinciResolveScript
+        # is a thin wrapper that loads this binary, so without it every tool
+        # fails at import. Saying "API path is sufficient" here sent people
+        # looking at their Resolve edition and their preferences instead.
+        print(f"  Library:   {red('Not found')} {dim('(required — the scripting API cannot load without it)')}")
+        print(f"  {dim('Set RESOLVE_SCRIPT_LIB to the fusionscript library inside your Resolve install,')}")
+        print(f"  {dim('or start Resolve and re-run setup so its location can be read from the process.')}")
 
     resolve_running = check_resolve_running()
     if resolve_running:
@@ -2122,6 +2151,7 @@ def main():
     if interactive:
         print_step(5, total_steps, "Verification")
 
+    verification_failed = False
     if api_path:
         success, message = verify_resolve_connection(python_path, api_path, lib_path)
         try:
@@ -2171,13 +2201,28 @@ def main():
             else:
                 print(f"  Connected: {green(message)}")
         else:
-            print(f"  Verify:    {yellow(message)}")
+            verification_failed = True
+            print(f"  Verify:    {red(message)}")
+            if "DLL load failed" in message or "cannot open shared object" in message:
+                # This is the shape of a wrong or missing library path, and it
+                # is the one failure the installer can diagnose precisely. Say
+                # so before offering the interpreter theory below — a reader who
+                # is told "try another Python" first will go and do that.
+                print(
+                    f"             The scripting library named by RESOLVE_SCRIPT_LIB did not load. "
+                    f"Current value: {lib_path or dim('(not set)')}"
+                )
+                print(
+                    "             Point RESOLVE_SCRIPT_LIB at the fusionscript library inside your "
+                    "Resolve install, or start Resolve and re-run setup."
+                )
             if py_abi_risk:
                 print(
                     f"             On Python 3.13+ this may be an ABI mismatch with Resolve's "
                     f"scripting library — try Python 3.10-3.12 if it persists."
                 )
     else:
+        verification_failed = True
         print(f"  {yellow('Skipped')} — Resolve API path not detected")
 
     # ══════════════════════════════════════════════════════════════════════
@@ -2185,7 +2230,25 @@ def main():
     # ══════════════════════════════════════════════════════════════════════
 
     print(f"\n  {'═' * 50}")
-    if configured or show_manual:
+    if verification_failed and (configured or show_manual):
+        # Writing the configs is not the job; a working connection is. Reporting
+        # "Setup complete!" over a failed verification is how an install that
+        # never worked gets handed to the user as finished — the error scrolls
+        # past mid-output and the last line says success.
+        print(f"  {yellow(bold('Setup incomplete — the scripting API did not load.'))}")
+        if configured:
+            print(f"  Configured: {', '.join(configured)} {dim('(written, but the server will fail to start)')}")
+        print()
+        print(f"  {bold('Fix the verification error above, then re-run:')}")
+        print(f"    {cyan('python install.py')}")
+        print()
+        print(f"  {dim(f'Server: {server_path}')}")
+        print(f"  {dim(f'Python: {python_path}')}")
+        if api_path:
+            print(f"  {dim(f'API:    {api_path}')}")
+        if lib_path:
+            print(f"  {dim(f'Library: {lib_path}')}")
+    elif configured or show_manual:
         print(f"  {green(bold('Setup complete!'))}")
         if configured:
             print(f"  Configured: {', '.join(configured)}")

--- a/src/utils/platform.py
+++ b/src/utils/platform.py
@@ -64,12 +64,103 @@ def get_resolve_paths():
     env_lib = os.environ.get("RESOLVE_SCRIPT_LIB")
     if env_lib and os.path.isfile(env_lib):
         lib_path = env_lib
+    elif not os.path.isfile(lib_path):
+        # No usable override and nothing at the default: look for the real
+        # install before handing back a path we already know is not there.
+        # The default is kept as the return value when discovery finds nothing,
+        # so the failure message still names the location people expect.
+        lib_path = discover_scripting_lib(platform_name) or lib_path
 
     return {
         "api_path": api_path,
         "lib_path": lib_path,
         "modules_path": modules_path
     }
+
+
+def _windows_lib_candidates():
+    r"""Plausible `fusionscript.dll` locations on this machine.
+
+    `%PROGRAMFILES%` is not a constant — a 64-bit install can sit under
+    `%PROGRAMW6432%` — and Resolve is routinely moved to a second drive
+    because the application and its caches are large. Only fixed drives that
+    exist are probed, two fixed paths each, no directory walk: this runs on
+    every connection attempt and must stay cheap. A: and B: are skipped so a
+    machine with a floppy-mapped letter does not stall on the probe.
+    """
+    relative = os.path.join("Blackmagic Design", "DaVinci Resolve", "fusionscript.dll")
+    candidates = []
+    for variable in ("PROGRAMFILES", "PROGRAMW6432", "PROGRAMFILES(X86)"):
+        base = os.environ.get(variable)
+        if base:
+            candidates.append(os.path.join(base, relative))
+    for letter in "CDEFGHIJKLMNOPQRSTUVWXYZ":
+        drive = f"{letter}:\\"
+        if not os.path.isdir(drive):
+            continue
+        candidates.append(os.path.join(drive, relative))
+        candidates.append(os.path.join(drive, "Program Files", relative))
+    return candidates
+
+
+def _macos_lib_candidates():
+    """The App Store bundle as well as the installer one.
+
+    The default above names `/Applications/DaVinci Resolve/DaVinci Resolve.app`.
+    The App Store build installs to `/Applications/DaVinci Resolve.app` instead —
+    the same class of miss as a Windows install on another drive, and
+    `resolve_runtime.MACOS_RESOLVE_APPS` already records both.
+    """
+    inside_bundle = os.path.join("Contents", "Libraries", "Fusion", "fusionscript.so")
+    bundles = (
+        "/Applications/DaVinci Resolve/DaVinci Resolve.app",
+        "/Applications/DaVinci Resolve.app",
+    )
+    return [os.path.join(bundle, inside_bundle) for bundle in bundles]
+
+
+def _linux_lib_candidates():
+    """The documented /opt layouts, both of which Blackmagic has shipped."""
+    return [
+        "/opt/resolve/libs/Fusion/fusionscript.so",
+        "/opt/resolve/libs/fusionscript.so",
+        "/opt/resolve/bin/fusionscript.so",
+    ]
+
+
+def discover_scripting_lib(platform_name=None):
+    """Locate the scripting library of a Resolve installed outside the default.
+
+    Order: the running Resolve first — its executable path is the install
+    location, so it needs no guessing and covers every platform — then the
+    conventional roots for that platform, for when Resolve is not up at the
+    moment (installer runs, cold starts).
+
+    Returns None when nothing is found, which leaves the caller's default in
+    place rather than substituting a second guess.
+    """
+    if platform_name is None:
+        platform_name = get_platform()
+
+    try:
+        from src.utils.resolve_runtime import running_resolve_lib
+        running = running_resolve_lib()
+    except Exception:
+        running = None
+    if running and os.path.isfile(running):
+        return running
+
+    by_platform = {
+        'windows': _windows_lib_candidates,
+        'darwin': _macos_lib_candidates,
+        'linux': _linux_lib_candidates,
+    }
+    builder = by_platform.get(platform_name)
+    candidates = builder() if builder else []
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
 
 def get_resolve_plugin_paths():
     """Get platform-specific paths for Resolve plugin install dirs.

--- a/src/utils/resolve_runtime.py
+++ b/src/utils/resolve_runtime.py
@@ -122,11 +122,21 @@ def _is_resolve_command(line: str) -> bool:
     the executable is exactly what sits inside the first quoted span; anything
     after the closing quote is arguments, and the flag loop never sees it.
     """
+    return _matches_pattern(_executable_from_line(line))
+
+
+def _executable_from_line(line: str) -> str:
+    """The executable path from a command line, with argument tokens removed.
+
+    Split out of `_is_resolve_command` so the install-location lookup below
+    agrees with the "is this Resolve" test about where the path ends. See that
+    function's docstring for why the quoting and flag-stripping rules are these.
+    """
     text = line.strip()
     if text.startswith('"'):
         close = text.find('"', 1)
         if close > 1:
-            return _matches_pattern(text[1:close])
+            return text[1:close]
     while True:
         stripped = text.rstrip()
         cut = stripped.rfind(" -")
@@ -138,7 +148,7 @@ def _is_resolve_command(line: str) -> bool:
         if not candidate:
             break
         text = candidate
-    return _matches_pattern(text)
+    return text
 
 
 def resolve_processes() -> Optional[List[str]]:
@@ -147,6 +157,52 @@ def resolve_processes() -> Optional[List[str]]:
     if lines is None:
         return None
     return [line for line in lines if _is_resolve_command(line)]
+
+
+#: Where the scripting library sits relative to the Resolve executable. The
+#: library ships *inside* the application, so the running executable's own path
+#: is the only locator that is right by construction — every hardcoded install
+#: root is a guess about where the user chose to put Resolve.
+_LIB_RELATIVE_TO_EXECUTABLE = {
+    "windows": ("fusionscript.dll",),
+    "darwin": ("../Libraries/Fusion/fusionscript.so",),
+    "linux": (
+        "../libs/Fusion/fusionscript.so",
+        "../libs/fusionscript.so",
+        "fusionscript.so",
+    ),
+}
+
+
+def running_resolve_lib() -> Optional[str]:
+    """Scripting library of the *running* Resolve, or None.
+
+    Blackmagic's own `DaVinciResolveScript.py` falls back to one hardcoded
+    install path per platform, and this project's defaults mirror it. A Resolve
+    installed anywhere else — a second drive, an external volume, a custom
+    directory — is therefore invisible to both, and the failure is silent: the
+    module imports, the DLL behind it does not load, and the user is told the
+    edition or the preference is at fault.
+
+    The running process settles it without guessing. Returns None when nothing
+    is running, the process list is unavailable, or the derived path does not
+    exist; callers keep their existing defaults in that case.
+    """
+    processes = resolve_processes()
+    if not processes:
+        return None
+    suffixes = _LIB_RELATIVE_TO_EXECUTABLE.get(platform.system().lower(), ())
+    for line in processes:
+        executable_dir = os.path.dirname(_executable_from_line(line))
+        if not executable_dir:
+            continue
+        for suffix in suffixes:
+            candidate = os.path.normpath(
+                os.path.join(executable_dir, *suffix.split("/"))
+            )
+            if os.path.isfile(candidate):
+                return candidate
+    return None
 
 
 def runtime_mode() -> Dict[str, Any]:

--- a/tests/test_scripting_lib_discovery.py
+++ b/tests/test_scripting_lib_discovery.py
@@ -1,0 +1,273 @@
+"""Finding fusionscript when Resolve is not where the defaults say it is.
+
+Blackmagic's `DaVinciResolveScript.py` hardcodes one install root per platform,
+and this project's defaults mirrored it. A Resolve installed anywhere else — a
+second drive, an external volume, a custom directory — was therefore invisible,
+and the failure was silent in a specific and expensive way:
+
+  1. `find_resolve_paths()` returned `lib_path=None`.
+  2. `build_server_env()` turned that into `"RESOLVE_SCRIPT_LIB": ""`, which
+     reads as configured in the config file but is falsy to the loader, so it
+     reverted to the same hardcoded path that was already known to be wrong.
+  3. The connection check failed with `DLL load failed`, mid-output.
+  4. The installer's last line said `Setup complete!`.
+
+The running Resolve process settles the question without guessing: its image
+path is the install location. These tests pin that discovery, and pin the two
+reporting behaviours that let the failure masquerade as a success.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.utils import platform as platform_utils  # noqa: E402
+from src.utils import resolve_runtime as rr  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "resolve_install", PROJECT_ROOT / "install.py"
+)
+install = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(install)
+
+ENV_KEYS = ("RESOLVE_SCRIPT_API", "RESOLVE_SCRIPT_LIB")
+
+
+def _ps(stdout: str):
+    return mock.Mock(returncode=0, stdout=stdout)
+
+
+def _env_without_overrides():
+    return {k: v for k, v in os.environ.items() if k not in ENV_KEYS}
+
+
+def _resolve_paths_with_api(api_dir: str) -> dict:
+    """A RESOLVE_PATHS stand-in with a real API dir and no findable library.
+
+    Both the host's key and "Linux" are present because `find_resolve_paths`
+    reads `RESOLVE_PATHS.get(SYSTEM, RESOLVE_PATHS["Linux"])`, and Python
+    evaluates that default eagerly — a replacement holding only the host key
+    raises KeyError on any host that is not Linux.
+    """
+    entry = {"api": [api_dir], "lib": ["/nope/fusionscript.dll"], "app": []}
+    return {install.SYSTEM: entry, "Linux": entry}
+
+
+def _windows_install(root: str) -> str:
+    """A Resolve.exe with fusionscript.dll beside it. Returns the exe path."""
+    os.makedirs(root, exist_ok=True)
+    exe = os.path.join(root, "Resolve.exe")
+    for path in (exe, os.path.join(root, "fusionscript.dll")):
+        with open(path, "w"):
+            pass
+    return exe
+
+
+def _macos_install(root: str) -> str:
+    """A Resolve.app laid out the way the installer build is. Returns the exe.
+
+    Joined with "/" on every host, not os.sep: RESOLVE_PROCESS_PATTERNS matches
+    a slash-separated suffix, because that is what `ps` prints. Building this
+    fixture with the host separator made the test pass on POSIX and fail on
+    Windows for a reason that has nothing to do with the code under test.
+    Windows accepts forward slashes in filesystem calls, so the files below are
+    still real on both.
+    """
+    bundle = f"{root}/DaVinci Resolve.app"
+    macos = f"{bundle}/Contents/MacOS"
+    fusion = f"{bundle}/Contents/Libraries/Fusion"
+    os.makedirs(macos, exist_ok=True)
+    os.makedirs(fusion, exist_ok=True)
+    exe = f"{macos}/Resolve"
+    for path in (exe, f"{fusion}/fusionscript.so"):
+        with open(path, "w"):
+            pass
+    return exe
+
+
+class RunningResolveLibTests(unittest.TestCase):
+    def test_windows_install_on_another_drive_is_found(self) -> None:
+        """The reported case: Resolve on F:, the default probing C:."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = _windows_install(os.path.join(tmp, "Blackmagic Design", "DaVinci Resolve"))
+            # WMIC quotes a path containing spaces, and this one does.
+            with mock.patch.object(rr.platform, "system", return_value="Windows"), \
+                    mock.patch.object(rr.subprocess, "run", return_value=_ps(f'"{exe}"  \n')):
+                found = rr.running_resolve_lib()
+            self.assertEqual(found, os.path.join(os.path.dirname(exe), "fusionscript.dll"))
+
+    def test_macos_reads_through_the_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = _macos_install(tmp)
+            with mock.patch.object(rr.platform, "system", return_value="Darwin"), \
+                    mock.patch.object(rr.subprocess, "run", return_value=_ps(f"{exe}\nDock\n")):
+                found = rr.running_resolve_lib()
+            self.assertIsNotNone(found)
+            normalized = found.replace(os.sep, "/")
+            self.assertTrue(normalized.endswith("Libraries/Fusion/fusionscript.so"))
+            self.assertTrue(os.path.isfile(found))
+
+    def test_flags_after_the_executable_do_not_break_the_derivation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = _macos_install(tmp)
+            with mock.patch.object(rr.platform, "system", return_value="Darwin"), \
+                    mock.patch.object(rr.subprocess, "run", return_value=_ps(f"{exe} -nogui\n")):
+                self.assertIsNotNone(rr.running_resolve_lib())
+
+    def test_nothing_running_is_none_not_a_guess(self) -> None:
+        with mock.patch.object(rr.subprocess, "run", return_value=_ps("Dock\nfinder\n")):
+            self.assertIsNone(rr.running_resolve_lib())
+
+    def test_an_unreadable_process_list_is_none(self) -> None:
+        with mock.patch.object(rr.subprocess, "run", side_effect=OSError("no wmic")):
+            self.assertIsNone(rr.running_resolve_lib())
+
+    def test_a_running_resolve_without_the_library_beside_it_is_none(self) -> None:
+        """Derivation must confirm the file, not assume the layout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = os.path.join(tmp, "Resolve.exe")
+            with open(exe, "w"):
+                pass
+            with mock.patch.object(rr.platform, "system", return_value="Windows"), \
+                    mock.patch.object(rr.subprocess, "run", return_value=_ps(f'"{exe}"\n')):
+                self.assertIsNone(rr.running_resolve_lib())
+
+
+class CandidateListTests(unittest.TestCase):
+    """The cold-install lists, for when Resolve is not running.
+
+    These are pure path construction — no filesystem, so they run identically on
+    every host and cover the platforms this developer cannot test on.
+    """
+
+    def test_windows_looks_beyond_the_c_drive(self) -> None:
+        with mock.patch.dict(os.environ, {"PROGRAMFILES": r"C:\Program Files"}, clear=True), \
+                mock.patch.object(platform_utils.os.path, "isdir", lambda p: p in ("C:\\", "F:\\")):
+            candidates = platform_utils._windows_lib_candidates()
+        self.assertTrue(any(c.startswith("F:") for c in candidates))
+        self.assertTrue(any("Program Files" in c for c in candidates))
+        self.assertTrue(all(c.endswith("fusionscript.dll") for c in candidates))
+
+    def test_macos_covers_both_bundle_locations(self) -> None:
+        """The App Store build sits at /Applications/DaVinci Resolve.app, which
+        the platform default does not name."""
+        candidates = platform_utils._macos_lib_candidates()
+        self.assertIn(
+            "/Applications/DaVinci Resolve.app/Contents/Libraries/Fusion/fusionscript.so",
+            [c.replace(os.sep, "/") for c in candidates],
+        )
+        self.assertEqual(len(candidates), 2)
+
+    def test_linux_covers_the_shipped_opt_layouts(self) -> None:
+        candidates = platform_utils._linux_lib_candidates()
+        self.assertTrue(all(c.startswith("/opt/resolve/") for c in candidates))
+        self.assertTrue(all(c.endswith("fusionscript.so") for c in candidates))
+
+    def test_an_unknown_platform_yields_no_candidates_rather_than_an_error(self) -> None:
+        # Patched on resolve_runtime, not on this module: discover_scripting_lib
+        # imports the helper inside the function body, so that is where the
+        # lookup lands. Patching the wrong module leaves the real process probe
+        # running and makes the result depend on whether Resolve happens to be
+        # open on the machine running the tests.
+        with mock.patch.object(rr, "running_resolve_lib", return_value=None):
+            self.assertIsNone(platform_utils.discover_scripting_lib("plan9"))
+
+
+class GetResolvePathsDiscoveryTests(unittest.TestCase):
+    def test_discovery_fills_in_a_missing_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lib = os.path.join(tmp, "fusionscript.so")
+            with open(lib, "w"):
+                pass
+            with mock.patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                    mock.patch.object(platform_utils, "discover_scripting_lib", return_value=lib), \
+                    mock.patch.dict(os.environ, _env_without_overrides(), clear=True):
+                paths = platform_utils.get_resolve_paths()
+            self.assertEqual(paths["lib_path"], lib)
+
+    def test_an_existing_env_override_still_wins_over_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            override = os.path.join(tmp, "override.so")
+            discovered = os.path.join(tmp, "discovered.so")
+            for path in (override, discovered):
+                with open(path, "w"):
+                    pass
+            env = _env_without_overrides()
+            env["RESOLVE_SCRIPT_LIB"] = override
+            with mock.patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                    mock.patch.object(platform_utils, "discover_scripting_lib", return_value=discovered), \
+                    mock.patch.dict(os.environ, env, clear=True):
+                paths = platform_utils.get_resolve_paths()
+            self.assertEqual(paths["lib_path"], override)
+
+    def test_the_platform_default_survives_when_discovery_finds_nothing(self) -> None:
+        """A failed lookup must not replace the expected path with a second guess:
+        the default is what the error message needs to name."""
+        with mock.patch.object(platform_utils, "get_platform", return_value="darwin"), \
+                mock.patch.object(platform_utils, "discover_scripting_lib", return_value=None), \
+                mock.patch.dict(os.environ, _env_without_overrides(), clear=True):
+            paths = platform_utils.get_resolve_paths()
+        self.assertEqual(
+            paths["lib_path"],
+            "/Applications/DaVinci Resolve/DaVinci Resolve.app"
+            "/Contents/Libraries/Fusion/fusionscript.so",
+        )
+
+
+class InstallerEnvTests(unittest.TestCase):
+    def test_an_unfound_library_is_omitted_not_written_empty(self) -> None:
+        """`"RESOLVE_SCRIPT_LIB": ""` is the worst of both worlds: it looks set
+        in the config and is unset to the loader, which then falls back to the
+        hardcoded default that was already missing."""
+        env = install.build_server_env(
+            "/usr/bin/python3", "/api", None, system="Darwin"
+        )
+        self.assertNotIn("RESOLVE_SCRIPT_LIB", env)
+        self.assertEqual(env["RESOLVE_SCRIPT_API"], "/api")
+
+    def test_a_found_library_is_written(self) -> None:
+        env = install.build_server_env(
+            "/usr/bin/python3", "/api", "/Resolve/fusionscript.so", system="Darwin"
+        )
+        self.assertEqual(env["RESOLVE_SCRIPT_LIB"], "/Resolve/fusionscript.so")
+
+    def test_find_resolve_paths_falls_back_to_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lib = os.path.join(tmp, "fusionscript.dll")
+            with open(lib, "w"):
+                pass
+            with mock.patch.object(install, "RESOLVE_PATHS", _resolve_paths_with_api(tmp)), \
+                    mock.patch.object(platform_utils, "discover_scripting_lib", return_value=lib), \
+                    mock.patch.dict(os.environ, _env_without_overrides(), clear=True):
+                api_path, lib_path = install.find_resolve_paths()
+        self.assertEqual(api_path, tmp)
+        self.assertEqual(lib_path, lib)
+
+    def test_an_env_override_is_preferred_over_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            override = os.path.join(tmp, "override.dll")
+            with open(override, "w"):
+                pass
+            env = _env_without_overrides()
+            env["RESOLVE_SCRIPT_LIB"] = override
+            with mock.patch.object(install, "RESOLVE_PATHS", _resolve_paths_with_api(tmp)), \
+                    mock.patch.object(platform_utils, "discover_scripting_lib",
+                                      return_value="/should/not/be/used.dll"), \
+                    mock.patch.dict(os.environ, env, clear=True):
+                _, lib_path = install.find_resolve_paths()
+        self.assertEqual(lib_path, override)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
My DaVinci Resolve Studio 21.0.4 on Windows 11 is installed to F:\Blackmagic Design\DaVinci Resolve. Setup reported success, every tool then failed, and it took me a long time to find that the config contained "RESOLVE_SCRIPT_LIB": "". I fixed it by hand-editing claude_desktop_config.json before digging into why.

## What happens today

On a machine where DaVinci Resolve is not installed at the platform default path, `npx davinci-resolve-mcp setup` finishes with `Setup complete!` and produces a client config that cannot work. Every tool then fails with `SCRIPTING_UNAVAILABLE`, whose remediation text sends the user to check their Resolve edition and their External-scripting preference — both of which may already be correct.

Reported on DaVinci Resolve Studio 21.0.4, Windows 11, Resolve installed to `F:\Blackmagic Design\DaVinci Resolve\`, Claude Desktop (MSIX build), Python 3.14.7.

### The chain

1. `RESOLVE_PATHS["Windows"]["lib"]` (install.py) holds a single literal candidate:

   ```python
   "lib": [ r"C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll" ],
   ```

   It does not consult `%PROGRAMFILES%`, any other drive, or the running process. `find_resolve_paths()` returns `lib_path=None`.

2. `build_server_env()` turns that `None` into an empty string:

   ```python
   lib_value = str(lib_path or "")            # install.py
   env = { ..., "RESOLVE_SCRIPT_LIB": lib_value, ... }
   ```

   The generated config therefore contains `"RESOLVE_SCRIPT_LIB": ""`. This is the worst of both worlds: it reads as *configured* to anyone inspecting the file, and it is falsy to `DaVinciResolveScript.py`, which then falls back to the same hardcoded path that was already known to be absent.

3. Step 1 of the installer prints:

   ```
   Library:   Not found (optional — API path is sufficient)
   ```

   It is not optional. `DaVinciResolveScript` is a thin wrapper around that binary; without it nothing imports.

4. Verification fails, roughly half a screen up from the end of the output:

   ```
   IMPORT_ERROR: DLL load failed while importing fusionscript: The specified module could not be found.
                 On Python 3.13+ this may be an ABI mismatch with Resolve's scripting library —
                 try Python 3.10-3.12 if it persists.
   ```

   The Python-version hint is the first concrete suggestion offered, and it is the wrong lead here — the same message is what Windows emits when the library path simply does not exist.

5. The final line is:

   ```
   Setup complete!   Configured: Claude Desktop
   ```

The reporting user spent several hours on this, tried a second Python installation, and eventually fixed it by hand-editing `claude_desktop_config.json`. With the changes below, step 1 would have named the cause.

### Reproducing

Any machine where Resolve is not at the default path reproduces it. Without moving an installation:

```bash
# macOS/Linux — point the literal candidate at nothing
python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location("i", "install.py")
i = importlib.util.module_from_spec(spec); spec.loader.exec_module(i)
i.RESOLVE_PATHS[i.SYSTEM]["lib"] = ["/nonexistent/fusionscript.so"]
print(i.build_server_env("/usr/bin/python3", "/some/api", i.find_resolve_paths()[1]))
PY
# before: {'RESOLVE_SCRIPT_API': '/some/api', 'RESOLVE_SCRIPT_LIB': '', 'PYTHONPATH': '...'}
```

## What this changes

In the order the failure happens:

**Discovery from the running process** — `resolve_runtime.running_resolve_lib()` derives the scripting library from the running Resolve's own image path. When the application is up, the install location needs no guessing, and this works on all three platforms. `_executable_from_line()` is split out of `_is_resolve_command()` so the "is this Resolve" test and the location lookup agree about where the path ends — including the WMIC quoting fixed in #150.

**Discovery for cold installs** — `platform.discover_scripting_lib()` consults the running process first, then the conventional roots for the platform, for when Resolve is not up:

- Windows: `%PROGRAMFILES%`, `%PROGRAMW6432%`, `%PROGRAMFILES(X86)%`, and existing fixed drives — two fixed paths per drive, no directory walk, A: and B: skipped. This runs on connection attempts and stays cheap.
- macOS: both bundle locations. The default names `/Applications/DaVinci Resolve/DaVinci Resolve.app`; the App Store build installs to `/Applications/DaVinci Resolve.app`, which is the same class of miss as the Windows case. `resolve_runtime.MACOS_RESOLVE_APPS` already recorded both.
- Linux: the `/opt/resolve` layouts already listed in `install.py`'s candidates.

An unknown platform yields no candidates rather than an error.

**Defaults are preserved** — `get_resolve_paths()` calls discovery only when the default is absent *and* no usable env override exists, and keeps the platform default when discovery finds nothing. A failed lookup must not substitute a second guess; the default is what the error message needs to name.

**No more empty env values** — `build_server_env()` omits empty keys rather than writing `""`.

**Honest reporting** — the "optional" line is corrected; a DLL-load failure is diagnosed explicitly, naming the current `RESOLVE_SCRIPT_LIB`, *before* the Python 3.13+ theory; and a failed verification ends in `Setup incomplete — the scripting API did not load.` instead of `Setup complete!`. Configs that were written are still listed, marked as non-functional.

## Tests

New `tests/test_scripting_lib_discovery.py` (17 cases): derivation on Windows and macOS layouts, WMIC-quoted command lines, flags after the executable, the three `None` cases (nothing running, unreadable process list, library not beside the executable), the per-platform candidate lists (pure path construction, so they cover the two platforms I cannot test on), override precedence over discovery, the surviving platform default, the omitted empty key, and `find_resolve_paths()`'s fallback order.

Full offline suite green (2746 passed, 20 skipped) on Linux / Python 3.11. Four pre-existing failures are excluded and are unrelated to this change: `test_live_api` and the two `test_script_plugin` inline-Python cases need a live Resolve, and `test_child_process_text_encoding::test_it_is_searched_first` depends on the interpreter's PATH position.

The new tests were also run on Windows 11 / Python 3.14 — the platform where the bug was found. The first Windows run failed four of them, and both causes were in the tests rather than the code: a `RESOLVE_PATHS` stand-in holding only the host key tripped the eagerly-evaluated `RESOLVE_PATHS["Linux"]` default in `find_resolve_paths()`, and the macOS-layout fixture was built with `os.sep`, so it could not match the slash-separated `RESOLVE_PROCESS_PATTERNS` on a backslash host. Both are fixed; the suite is green on both platforms.

## A separate observation, not addressed here

While running on Windows, 12 pre-existing failures showed up in `tests/test_cdl_and_install_config.py`. They are all the same shape — fixtures built from POSIX literals such as `Path("/tmp/python")`, which `pathlib` renders as `\tmp\python` on Windows — plus one `endswith(".codex/config.toml")`. `docs/contributing.md` already lists Windows testing as help wanted, so this is presumably known; flagging it in case it is not. Happy to open a separate PR making those fixtures separator-agnostic.
