### PR TITLE
Report Whisper timeout as a failed batch clip

### DIFF
--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -200,6 +200,34 @@ def _annotate_clip_vision_failure(clip_result: Dict[str, Any], vision: Any) -> N
         })
 
 
+def _annotate_clip_transcript_failure(clip_result: Dict[str, Any], transcript: Any) -> None:
+    """Mark a clip failed when requested transcription did not complete.
+
+    execute_plan_async writes the analysis JSON and then hard-sets success True.
+    Vision already overwrites that via _annotate_clip_vision_failure; a
+    transcription timeout (or any other transcript.success False) had no
+    equivalent, so batch jobs counted an empty transcript as succeeded.
+    """
+    status = ""
+    reason = ""
+    if isinstance(transcript, dict):
+        status = str(transcript.get("status") or "").strip()
+        reason = str(transcript.get("reason") or transcript.get("error") or "").strip()
+    if status == "wall_clock_timeout":
+        message = "Transcription timed out before a transcript was produced."
+        if reason:
+            message = f"{message} {reason}"
+    elif reason:
+        message = f"Transcription was requested but did not complete: {reason}"
+    else:
+        message = "Transcription was requested but did not complete."
+    clip_result.update({
+        "success": False,
+        "error": message,
+        "transcription": transcript,
+    })
+
+
 def _annotate_partial_success(manifest: Dict[str, Any]) -> None:
     """D3 — Mark batch manifests with explicit completed/failed clip-id lists.
 
@@ -5697,6 +5725,11 @@ async def execute_plan_async(
             and not vision_pending
             and not visual_analysis_completed(vision)
         )
+        transcript_failed = (
+            _coerce_bool((options.get("transcription") or {}).get("enabled"), default=DEFAULT_TRANSCRIPTION_ENABLED)
+            and isinstance(transcript, dict)
+            and not transcript.get("success")
+        )
         frame_count = int(clip_plan.get("analysis_keyframe_budget") or 0)
         marker_plan = _build_clip_marker_plan(
             record,
@@ -5757,6 +5790,8 @@ async def execute_plan_async(
             manifest["vision_pending"] = True
         elif vision_failed:
             _annotate_clip_vision_failure(clip_result, vision)
+        if transcript_failed:
+            _annotate_clip_transcript_failure(clip_result, transcript)
         manifest["clips"].append(clip_result)
 
     manifest["completed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/src/utils/media_analysis_jobs.py
+++ b/src/utils/media_analysis_jobs.py
@@ -745,6 +745,8 @@ def run_batch_job_slice(
                     _event(conn, job_id, "info", f"Clip {row['position'] + 1} {status}", {"clip": clip_result.get("record")})
                 else:
                     error = clip_result.get("error") or manifest.get("error") or "Clip analysis failed"
+                    if not isinstance(error, str):
+                        error = str(error)
                     conn.execute(
                         """
                         UPDATE job_clips
@@ -752,6 +754,10 @@ def run_batch_job_slice(
                         WHERE id = ?
                         """,
                         (error, completed_at, completed_at, row["id"]),
+                    )
+                    conn.execute(
+                        "UPDATE jobs SET last_error = ?, updated_at = ? WHERE job_id = ?",
+                        (error, completed_at, job_id),
                     )
                     processed.append({"position": row["position"], "status": "failed", "error": error})
                     _event(conn, job_id, "error", f"Clip {row['position'] + 1} failed", {"error": error})
@@ -766,6 +772,10 @@ def run_batch_job_slice(
                     (str(exc), completed_at, completed_at, row["id"]),
                 )
                 processed.append({"position": row["position"], "status": "failed", "error": str(exc)})
+                conn.execute(
+                    "UPDATE jobs SET last_error = ?, updated_at = ? WHERE job_id = ?",
+                    (str(exc), completed_at, job_id),
+                )
                 _event(conn, job_id, "error", f"Clip {row['position'] + 1} raised an exception", {"error": str(exc)})
             _sync_job_counts(conn, job_id)
             conn.commit()

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -4072,6 +4072,74 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
             self.assertEqual(index["counts"]["clips"], 2)
             self.assertGreaterEqual(search["result_count"], 1)
 
+    def test_batch_job_slice_reports_whisper_timeout_as_failed_clip(self):
+        """A wall-clock transcription timeout must not count as a succeeded clip."""
+        if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+            self.skipTest("ffmpeg/ffprobe not installed")
+        timeout_payload = {
+            "success": False,
+            "status": "wall_clock_timeout",
+            "backend": "whisper_cli",
+            "reason": "wall-clock timeout after 90s",
+            "elapsed_ms": 90000,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = os.path.join(tmp, "source")
+            analysis_dir = os.path.join(tmp, "analysis")
+            os.makedirs(source_dir)
+            source = os.path.join(source_dir, "job_timeout.mp4")
+            self._write_synthetic_media(source)
+            records = [{
+                "clip_id": "clip-timeout",
+                "clip_name": "job_timeout.mp4",
+                "file_path": source,
+                "media_id": "media-timeout",
+            }]
+            params = {
+                "analysis_root": analysis_dir,
+                "depth": "quick",
+                "transcription": {"enabled": True, "backend": "mock"},
+                "vision": {"enabled": False},
+            }
+            created = create_batch_job(
+                project_name="Example Project",
+                project_id="project-job-timeout",
+                records=records,
+                target={"type": "file_list"},
+                params=params,
+                name="Timeout batch",
+            )
+            self.assertTrue(created["success"])
+            job = created["job"]
+            captured = {}
+            real_execute_plan = execute_plan
+
+            def _capture_execute_plan(*args, **kwargs):
+                manifest = real_execute_plan(*args, **kwargs)
+                captured["manifest"] = manifest
+                return manifest
+
+            with unittest.mock.patch.object(
+                _media_analysis_module, "_transcribe", return_value=timeout_payload
+            ), unittest.mock.patch(
+                "src.utils.media_analysis_jobs.execute_plan",
+                side_effect=_capture_execute_plan,
+            ):
+                slice_result = run_batch_job_slice(job["project_root"], job["job_id"], max_clips=1)
+
+            self.assertIn("manifest", captured)
+            clip_result = (captured["manifest"].get("clips") or [{}])[0]
+            self.assertFalse(
+                clip_result.get("success"),
+                "transcription timeout must not mark clip_result.success True",
+            )
+            self.assertEqual((slice_result.get("processed") or [{}])[0].get("status"), "failed")
+            final = batch_job_status(job["project_root"], job["job_id"])
+            self.assertEqual(final["failed_clips"], 1)
+            self.assertEqual(final["succeeded_clips"], 0)
+            self.assertTrue(final.get("last_error"), "job last_error must be set on transcription timeout")
+            self.assertNotEqual(final["status"], "completed")
+
     def test_batch_job_cancel_and_resume(self):
         with tempfile.TemporaryDirectory() as tmp:
             source_dir = os.path.join(tmp, "source")


### PR DESCRIPTION
A requested Whisper transcription that hits the wall-clock cap already returns `success: False` from `_transcribe`. `execute_plan_async` then overwrote that by hard-coding `clip_result["success"] = True` after writing the analysis JSON, so `run_batch_job_slice` counted the clip as succeeded and closed the job as `completed` with `last_error` unset.

Vision already had `_annotate_clip_vision_failure`. Transcription now follows the same shape: a failed transcript marks the clip failed, the batch job records `failed_clips` and `last_error`, and the job status is no longer `completed`.

This does not raise the 90s cap, add chunking, or change heartbeat behavior.

Reported by @techsolvehq-source.

Fixes #160
