### PR TITLE
Keep API limitations --help read-only

### DIFF
--- a/scripts/gen_api_limitations.py
+++ b/scripts/gen_api_limitations.py
@@ -17,6 +17,7 @@ Run with ``--check`` to fail (exit 1) when the committed doc is stale.
 """
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -122,9 +123,20 @@ def render() -> str:
     return "\n".join(out).rstrip() + "\n"
 
 
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if the committed report is out of date",
+    )
+    return parser.parse_args(argv)
+
+
 def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
     content = render()
-    if "--check" in argv:
+    if args.check:
         current = DOC_PATH.read_text() if DOC_PATH.exists() else ""
         if current != content:
             print(

--- a/scripts/gen_api_limitations.py
+++ b/scripts/gen_api_limitations.py
@@ -134,6 +134,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str]) -> int:
+    if argv is None:
+        raise TypeError("argv must not be None")
     args = _parse_args(argv)
     content = render()
     if args.check:

--- a/tests/test_api_limitations_doc.py
+++ b/tests/test_api_limitations_doc.py
@@ -10,6 +10,7 @@ import importlib.util
 import contextlib
 import io
 import pathlib
+import sys
 import tempfile
 import unittest
 
@@ -65,6 +66,44 @@ class ApiLimitationsDocTest(unittest.TestCase):
             self.assertEqual(raised.exception.code, 0)
             self.assertIn("usage:", stdout.getvalue().lower())
             self.assertIn("--check", stdout.getvalue())
+            self.assertFalse(gen.DOC_PATH.exists())
+
+    def test_unknown_option_exits_without_writing_report(self):
+        gen = _load_generator()
+        with tempfile.TemporaryDirectory() as tmp:
+            gen.DOC_PATH = pathlib.Path(tmp) / "api-limitations.md"
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as raised:
+                    gen.main(["--unknown-option"])
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("usage:", stderr.getvalue().lower())
+            self.assertIn("unrecognized arguments", stderr.getvalue())
+            self.assertFalse(gen.DOC_PATH.exists())
+
+    def test_tuple_argv_is_accepted_without_writing_report(self):
+        gen = _load_generator()
+        with tempfile.TemporaryDirectory() as tmp:
+            gen.DOC_PATH = pathlib.Path(tmp) / "api-limitations.md"
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                with self.assertRaises(SystemExit) as raised:
+                    gen.main(("--help",))
+            self.assertEqual(raised.exception.code, 0)
+            self.assertIn("usage:", stdout.getvalue().lower())
+            self.assertFalse(gen.DOC_PATH.exists())
+
+    def test_none_argv_fails_before_writing_report(self):
+        gen = _load_generator()
+        original_argv = sys.argv
+        with tempfile.TemporaryDirectory() as tmp:
+            gen.DOC_PATH = pathlib.Path(tmp) / "api-limitations.md"
+            sys.argv = ["gen_api_limitations.py"]
+            try:
+                with self.assertRaises(TypeError):
+                    gen.main(None)
+            finally:
+                sys.argv = original_argv
             self.assertFalse(gen.DOC_PATH.exists())
 
 

--- a/tests/test_api_limitations_doc.py
+++ b/tests/test_api_limitations_doc.py
@@ -7,7 +7,10 @@ adding or editing a ``submit`` entry forces a regenerate. It also asserts the do
 exists, is marked generated, and that every catalogued submit kind is valid.
 """
 import importlib.util
+import contextlib
+import io
 import pathlib
+import tempfile
 import unittest
 
 from src.utils.api_truth import API_TRUTH, submittable_limitations
@@ -50,6 +53,19 @@ class ApiLimitationsDocTest(unittest.TestCase):
         groups = submittable_limitations()
         self.assertTrue(groups["missing"], "expected at least one missing-capability entry")
         self.assertTrue(groups["bug"], "expected at least one bug entry")
+
+    def test_help_prints_usage_without_writing_report(self):
+        gen = _load_generator()
+        with tempfile.TemporaryDirectory() as tmp:
+            gen.DOC_PATH = pathlib.Path(tmp) / "api-limitations.md"
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                with self.assertRaises(SystemExit) as raised:
+                    gen.main(["--help"])
+            self.assertEqual(raised.exception.code, 0)
+            self.assertIn("usage:", stdout.getvalue().lower())
+            self.assertIn("--check", stdout.getvalue())
+            self.assertFalse(gen.DOC_PATH.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- parse generator CLI arguments before rendering or writing the generated API-limitations report
- make `--help` exit successfully without modifying the report
- reject unknown options before any write and add isolated regression coverage for argument handling

## Verification

- `python3 -m unittest tests.test_api_limitations_doc -v` — 8 passed
- `python3 scripts/gen_api_limitations.py --check`
- `git diff --check upstream/main...HEAD`

## Broader-suite note

Full Python discovery was also attempted locally. Five unchanged offline DRT cases could not run because `jszip` was unavailable in the local Node dependency environment; no failure involved the files changed in this PR.
