### PR TITLE
fix(resolve): checked returns on SetCurrentTimeline and 28 other discarded mutators

### DIFF
--- a/src/granular/media_pool.py
+++ b/src/granular/media_pool.py
@@ -277,11 +277,18 @@ def setup_multicam_timeline(
     if not switched:
         return {"error": describe_switch_failure(switch_detail, "stacking the angles"),
                 "switch": switch_detail}
+    start_timecode_set = None
     if plan.get("start_timecode"):
+        # A refused start timecode leaves the timeline at 01:00:00:00 while every
+        # recordFrame below was computed against the requested one, so the whole
+        # stack lands at the wrong absolute time. Reported, not swallowed.
         try:
-            timeline.SetStartTimecode(plan["start_timecode"])
-        except Exception:
-            pass
+            start_timecode_set = bool(timeline.SetStartTimecode(plan["start_timecode"]))
+        except Exception as exc:
+            return {"error": f"SetStartTimecode('{plan['start_timecode']}') raised: {exc}"}
+        if not start_timecode_set:
+            return {"error": f"SetStartTimecode('{plan['start_timecode']}') was refused; "
+                             f"the angle stack would land at the wrong absolute time"}
 
     video_tracks = _ensure_timeline_tracks_for_multicam(timeline, "video", plan.get("max_video_track", 0))
     if not video_tracks.get("success"):

--- a/src/granular/media_pool.py
+++ b/src/granular/media_pool.py
@@ -2,6 +2,7 @@
 
 from src.granular.common import *  # noqa: F401,F403
 from src.utils.multicam import build_multicam_setup_plan
+from src.utils.resolve_writes import set_current_timeline, describe_switch_failure
 
 resolve = ResolveProxy()
 
@@ -272,10 +273,10 @@ def setup_multicam_timeline(
     timeline = mp.CreateEmptyTimeline(plan["name"])
     if not timeline:
         return {"error": f"Failed to create multicam setup timeline: {plan['name']}"}
-    try:
-        project.SetCurrentTimeline(timeline)
-    except Exception:
-        pass
+    switched, switch_detail = set_current_timeline(project, timeline)
+    if not switched:
+        return {"error": describe_switch_failure(switch_detail, "stacking the angles"),
+                "switch": switch_detail}
     if plan.get("start_timecode"):
         try:
             timeline.SetStartTimecode(plan["start_timecode"])

--- a/src/granular/timeline.py
+++ b/src/granular/timeline.py
@@ -3,6 +3,7 @@
 from src.granular.common import *  # noqa: F401,F403
 
 from src.utils.page_lock import color_page_for_thumbnails
+from src.utils.resolve_writes import set_current_timeline, describe_switch_failure
 
 resolve = ResolveProxy()
 
@@ -1038,11 +1039,15 @@ def create_timeline_from_clips(
         tl = mp.CreateEmptyTimeline(name)
         if not tl:
             return {"success": False, "error": "Failed to create timeline"}
-        try:
-            if project:
-                project.SetCurrentTimeline(tl)
-        except Exception:
-            logger.debug("Could not set newly created timeline current", exc_info=True)
+        if project:
+            # The appends below go to the CURRENT timeline, so this is a
+            # precondition for the whole build, not a convenience.
+            switched, switch_detail = set_current_timeline(project, tl)
+            if not switched:
+                return {"success": False,
+                        "error": describe_switch_failure(switch_detail,
+                                                         "appending the clip_infos"),
+                        "switch": switch_detail}
         timeline_start = _timeline_start_frame(tl)
         built = []
         for i, ci in enumerate(clip_infos):

--- a/src/granular/timeline_item.py
+++ b/src/granular/timeline_item.py
@@ -978,9 +978,15 @@ def modify_keyframe(timeline_item_id: str, property_name: str, frame: int, new_v
             if new_frame < start_frame or new_frame > end_frame:
                 return f"Error: New frame {new_frame} is outside the item's range ({start_frame} to {end_frame})"
                 
-            # Delete the keyframe at the current frame
+            # Delete the keyframe at the current frame. A discarded False here
+            # leaves the ORIGINAL keyframe in place; the AddKeyframe below then
+            # succeeds at the new frame and the tool reports "moved" for what is
+            # actually a copy.
             current_value = timeline_item.GetPropertyAtKeyframeIndex(property_name, keyframe_index)
-            timeline_item.DeleteKeyframe(property_name, frame)
+            if not timeline_item.DeleteKeyframe(property_name, frame):
+                return (f"Failed to move keyframe for {property_name}: DeleteKeyframe "
+                        f"refused frame {frame}, so the original is still there and "
+                        f"nothing was moved")
             
             # Add a new keyframe at the new frame position with the current value (or new value if specified)
             value = new_value if new_value is not None else current_value
@@ -991,9 +997,13 @@ def modify_keyframe(timeline_item_id: str, property_name: str, frame: int, new_v
             else:
                 return f"Failed to move keyframe for {property_name}"
         else:
-            # Only changing the value, not the frame position
-            # We need to delete and re-add the keyframe with the new value
-            timeline_item.DeleteKeyframe(property_name, frame)
+            # Only changing the value, not the frame position: delete and
+            # re-add. A discarded False leaves the OLD value in place and
+            # AddKeyframe on an occupied frame is not a value update.
+            if not timeline_item.DeleteKeyframe(property_name, frame):
+                return (f"Failed to update keyframe value for {property_name} at frame "
+                        f"{frame}: DeleteKeyframe refused, so the old value is still "
+                        f"there and nothing was changed")
             result = timeline_item.AddKeyframe(property_name, frame, new_value)
             
             if result:
@@ -1171,8 +1181,12 @@ def set_keyframe_interpolation(timeline_item_id: str, property_name: str, frame:
                 value = timeline_item.GetPropertyAtKeyframeIndex(property_name, i)
                 break
         
-        # Delete the old keyframe
-        timeline_item.DeleteKeyframe(property_name, frame)
+        # Delete the old keyframe. A discarded False leaves the original
+        # interpolation in place and the tool still reports success.
+        if not timeline_item.DeleteKeyframe(property_name, frame):
+            return (f"Failed to set interpolation for {property_name} at frame {frame}: "
+                    f"DeleteKeyframe refused, so the original keyframe and its "
+                    f"interpolation are unchanged")
         
         # Add a new keyframe with the same value but different interpolation
         result = timeline_item.AddKeyframe(property_name, frame, value, interpolation_map[interpolation_type])

--- a/src/server.py
+++ b/src/server.py
@@ -6426,10 +6426,24 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
     if switch_err:
         return switch_err
     if p.get("start_timecode"):
+        # A refused start timecode leaves the variant at the default hour while
+        # every record frame below was computed against the requested one, so
+        # the whole build lands at the wrong absolute time.
         try:
-            new_tl.SetStartTimecode(p["start_timecode"])
-        except Exception:
-            pass
+            start_tc_set = bool(new_tl.SetStartTimecode(p["start_timecode"]))
+            start_tc_error = None
+        except Exception as exc:
+            start_tc_set, start_tc_error = False, str(exc)
+        if not start_tc_set:
+            return _err(
+                f"SetStartTimecode({p['start_timecode']!r}) was refused on '{name}'",
+                code="START_TIMECODE_REFUSED", category="api_error", retryable=False,
+                reason=(start_tc_error or
+                        "Resolve returned False. The variant would sit at the default "
+                        "start timecode while its record frames assume the requested one."),
+                remediation="Check the timecode is valid for the timeline's frame rate, "
+                            "or omit start_timecode to build at the default start.",
+            )
     for track_type, needed in max_tracks.items():
         while int(new_tl.GetTrackCount(track_type) or 0) < needed:
             if not new_tl.AddTrack(track_type):
@@ -6676,7 +6690,16 @@ def _timeline_thumbnail_contact_sheet(proj, tl, p: Dict[str, Any]) -> Dict[str, 
                     sampled.append(sample)
                     continue
                 try:
-                    tl.SetCurrentTimecode(timecode)
+                    # A refused playhead move means the thumbnail below is the
+                    # frame the playhead was ALREADY on -- a sheet of the wrong
+                    # frames, labelled with the frames that were asked for.
+                    if not tl.SetCurrentTimecode(timecode):
+                        sample["error"] = (
+                            f"Playhead would not move to {timecode}; no thumbnail was "
+                            "sampled here rather than sampling the wrong frame"
+                        )
+                        sampled.append(sample)
+                        continue
                     thumbnail = tl.GetCurrentClipThumbnailImage()
                     if not thumbnail:
                         sample["error"] = (
@@ -6693,11 +6716,7 @@ def _timeline_thumbnail_contact_sheet(proj, tl, p: Dict[str, Any]) -> Dict[str, 
                     sample["error"] = str(exc)
                 sampled.append(sample)
         finally:
-            if original_timecode:
-                try:
-                    tl.SetCurrentTimecode(original_timecode)
-                except Exception:
-                    pass
+            _restore_playhead(tl, original_timecode, what="the contact sheet")
     sheet_samples = [sample for sample in sampled if sample.get("thumbnail_rgb")]
     if not sheet_samples:
         return {"success": False, "samples": sampled, "error": "No thumbnails could be sampled"}
@@ -8788,10 +8807,24 @@ def _setup_multicam_timeline(proj, mp, p: Dict[str, Any]):
     if switch_err:
         return switch_err
     if plan.get("start_timecode"):
+        # Same as the variant builder: the angle stack's record frames assume
+        # this start, so a refusal puts every angle at the wrong absolute time.
         try:
-            new_tl.SetStartTimecode(plan["start_timecode"])
-        except Exception:
-            pass
+            start_tc_set = bool(new_tl.SetStartTimecode(plan["start_timecode"]))
+            start_tc_error = None
+        except Exception as exc:
+            start_tc_set, start_tc_error = False, str(exc)
+        if not start_tc_set:
+            return _err(
+                f"SetStartTimecode({plan['start_timecode']!r}) was refused on "
+                f"'{plan['name']}'",
+                code="START_TIMECODE_REFUSED", category="api_error", retryable=False,
+                reason=(start_tc_error or
+                        "Resolve returned False. The angle stack would land at the "
+                        "wrong absolute time."),
+                remediation="Check the timecode is valid for the timeline's frame rate, "
+                            "or omit start_timecode.",
+            )
 
     audio_type = str(p.get("audio_type", p.get("audioType", "stereo")) or "stereo")
     video_tracks = _ensure_timeline_tracks(new_tl, "video", plan.get("max_video_track", 0))
@@ -10504,7 +10537,18 @@ def _apply_sync_event_markers(proj, detection: Dict[str, Any], p: Dict[str, Any]
                 skipped.append({"clip_id": clip_id, "frame": marker["frame"], "reason": "Marker already exists", "custom_data": custom_data})
                 continue
             if existing and replace_existing and _has_method(clip, "DeleteMarkerByCustomData"):
-                clip.DeleteMarkerByCustomData(custom_data)
+                # A discarded False leaves the old marker in place, and AddMarker
+                # then refuses the occupied frame -- reported as "add failed"
+                # when the real failure was the delete.
+                if not clip.DeleteMarkerByCustomData(custom_data):
+                    failed.append({
+                        "clip_id": clip_id, "frame": marker["frame"],
+                        "custom_data": custom_data,
+                        "reason": "replace_existing was requested but "
+                                  "DeleteMarkerByCustomData refused; the existing "
+                                  "marker is still there and nothing was replaced",
+                    })
+                    continue
         result = _add_marker(clip, marker)
         if result.get("success"):
             added.append({
@@ -10901,7 +10945,20 @@ def _apply_media_analysis_clip_markers(clip, markers: List[Dict[str, Any]], p: D
                 skipped.append({"frame": marker.get("frame"), "name": marker.get("name"), "reason": "Marker already exists", "custom_data": custom_data})
                 continue
             if existing and replace_existing and _has_method(clip, "DeleteMarkerByCustomData"):
-                clip.DeleteMarkerByCustomData(custom_data)
+                # A discarded False leaves the old marker in place, and AddMarker
+                # then refuses the occupied frame -- reported as "add failed"
+                # when the real failure was the delete.
+                if not clip.DeleteMarkerByCustomData(custom_data):
+                    failed.append({
+                        "marker": marker,
+                        "result": {
+                            "success": False,
+                            "reason": "replace_existing was requested but "
+                                      "DeleteMarkerByCustomData refused; the existing "
+                                      "marker is still there and nothing was replaced",
+                        },
+                    })
+                    continue
         result = _add_marker(clip, marker)
         if result.get("success"):
             added.append({"frame": result.get("frame"), "name": marker.get("name"), "custom_data": custom_data})
@@ -12508,11 +12565,24 @@ def _set_current_folder_temporarily(mp, target_path: Optional[str]):
 
 
 def _restore_current_folder(mp, previous):
-    if previous:
-        try:
-            mp.SetCurrentFolder(previous)
-        except Exception:
-            pass
+    """Put the Media Pool's current folder back. Logged, never raised.
+
+    Fire-and-forget by design: this runs after the real work, the current
+    folder is UI state that nothing downstream reads, and turning a failed
+    teardown into a failed operation would report a successful import as a
+    failure. Logged rather than swallowed, because a bin left open somewhere
+    unexpected is otherwise unexplained.
+    """
+    if not previous:
+        return
+    try:
+        restored = mp.SetCurrentFolder(previous)
+    except Exception as exc:
+        logger.debug("could not restore the current Media Pool folder: %s", exc)
+        return
+    if not restored:
+        logger.debug("could not restore the current Media Pool folder: "
+                     "SetCurrentFolder returned %r", restored)
 
 
 def _ensure_folder_path(mp, path: str):
@@ -13814,11 +13884,7 @@ def _playhead_frame_preview(tl, p: Dict[str, Any]):
                 width, height, raw = _box_downscale_rgb(width, height, raw, int(max_width))
             return Image(data=_rgb_to_png_bytes(width, height, raw), format="png")
         finally:
-            if original_tc:
-                try:
-                    tl.SetCurrentTimecode(original_tc)
-                except Exception:
-                    pass
+            _restore_playhead(tl, original_tc, what="the thumbnail capture")
 
 
 def _playhead_frame_render(proj, tl, p: Dict[str, Any]):
@@ -13969,11 +14035,22 @@ def _playhead_frame_render(proj, tl, p: Dict[str, Any]):
             except Exception:
                 pass
         if original_fc:
+            # A failed restore leaves the Deliver page on the capture's format
+            # and codec, which the user's next render would silently inherit.
+            # This runs in a teardown path, so it is logged rather than raised.
             try:
-                proj.SetCurrentRenderFormatAndCodec(
+                restored_fc = proj.SetCurrentRenderFormatAndCodec(
                     original_fc.get("format"), original_fc.get("codec"))
-            except Exception:
-                pass
+            except Exception as exc:
+                restored_fc, restore_exc = False, exc
+            else:
+                restore_exc = None
+            if not restored_fc:
+                logger.warning(
+                    "frame capture could not restore the render format/codec to %s/%s: %s",
+                    original_fc.get("format"), original_fc.get("codec"),
+                    restore_exc or "SetCurrentRenderFormatAndCodec returned False",
+                )
         # Best-effort, not a restore: without GetRenderSettings there is nothing
         # to restore FROM, so put the mark range back to the whole timeline
         # rather than leaving it pinned to the captured frame.
@@ -13997,11 +14074,7 @@ def _playhead_frame_render(proj, tl, p: Dict[str, Any]):
                 os.rmdir(folder)
         except OSError:
             pass
-        if original_tc:
-            try:
-                tl.SetCurrentTimecode(original_tc)
-            except Exception:
-                pass
+        _restore_playhead(tl, original_tc, what="the render capture")
         if original_page and original_page != "deliver":
             try:
                 _open_page_serialized(resolve, original_page)
@@ -14112,11 +14185,7 @@ def _playhead_frame_full(proj, tl, p: Dict[str, Any]):
                     album.DeleteStills([still])
                 except Exception:
                     pass
-            if original_tc:
-                try:
-                    tl.SetCurrentTimecode(original_tc)
-                except Exception:
-                    pass
+            _restore_playhead(tl, original_tc, what="the still capture")
             try:
                 for name in os.listdir(folder):
                     if name.startswith(prefix):
@@ -14202,6 +14271,29 @@ def _playhead_frame_capture(p: Dict[str, Any]):
                     "frame capture could not restore the current timeline: %s",
                     restore_err["error"]["message"],
                 )
+
+
+def _restore_playhead(tl, timecode, *, what: str) -> None:
+    """Put the playhead back after a capture. Logged, never raised.
+
+    Deliberately fire-and-forget on the CALLER's behalf: every use of this runs
+    in a `finally`, so raising or returning an error would replace the caller's
+    real result -- or its real exception -- with a teardown failure. What it is
+    not is silent. A refused restore leaves the editor's playhead somewhere
+    else, and a support log that says so is the difference between a two-minute
+    diagnosis and an afternoon.
+    """
+    if not timecode:
+        return
+    try:
+        moved = tl.SetCurrentTimecode(timecode)
+    except Exception as exc:
+        logger.warning("could not restore the playhead to %s after %s: %s",
+                       timecode, what, exc)
+        return
+    if not moved:
+        logger.warning("could not restore the playhead to %s after %s: "
+                       "SetCurrentTimecode returned %r", timecode, what, moved)
 
 
 def _set_current_timeline_checked(proj, tl, *, what: str):
@@ -16321,11 +16413,21 @@ def _resolve_restore_state(p: Dict[str, Any]) -> Dict[str, Any]:
                         break
                     restored["current_timeline_id"] = state["current_timeline_id"]
                     if state.get("current_timecode"):
+                        # restored[] is a claim about what was put back. Writing
+                        # it before checking made restore_state report a playhead
+                        # position it had not reached.
                         try:
-                            tl.SetCurrentTimecode(state["current_timecode"])
+                            moved = bool(tl.SetCurrentTimecode(state["current_timecode"]))
+                        except Exception as exc:
+                            moved, restored["current_timecode_error"] = False, str(exc)
+                        if moved:
                             restored["current_timecode"] = state["current_timecode"]
-                        except Exception:
-                            pass
+                        else:
+                            restored.setdefault(
+                                "current_timecode_error",
+                                f"SetCurrentTimecode({state['current_timecode']!r}) "
+                                "returned False; the playhead is elsewhere",
+                            )
                     break
         except Exception as exc:
             restored["timeline_error"] = str(exc)
@@ -16339,9 +16441,20 @@ def _resolve_restore_state(p: Dict[str, Any]) -> Dict[str, Any]:
                 for cid in state["selected_clip_ids"]:
                     found, parent = _find_clip_with_parent(root, cid)
                     if found and parent is not None:
-                        mp.SetCurrentFolder(parent)
-                        mp.SetSelectedClip(found)
-                        restored["selected_clip_id"] = cid
+                        # Both report with a bare bool. Claiming the selection
+                        # was restored when SetSelectedClip refused is the same
+                        # lie as the timeline and timecode above.
+                        folder_ok = bool(mp.SetCurrentFolder(parent))
+                        selected_ok = bool(mp.SetSelectedClip(found))
+                        if selected_ok:
+                            restored["selected_clip_id"] = cid
+                        else:
+                            restored["selection_error"] = (
+                                f"SetSelectedClip({cid!r}) returned False"
+                                + ("" if folder_ok else
+                                   " (SetCurrentFolder also refused, so the bin was "
+                                   "never opened)")
+                            )
                         break  # SetSelectedClip is singular; pick the first
         except Exception as exc:
             restored["selection_error"] = str(exc)
@@ -17202,10 +17315,16 @@ class _SpecLiveExecutor:
             if tl is None:
                 return False
         if fps is not None:
+            # A refused rate is the silent wrong-fps timeline: everything built
+            # on it is laid at a rate nobody asked for and the durations read
+            # back wrong. Resolve only accepts this on an EMPTY project, so the
+            # refusal is common and must not be reported as success.
             try:
-                tl.SetSetting("timelineFrameRate", str(fps))
+                rate_set = bool(tl.SetSetting("timelineFrameRate", str(fps)))
             except Exception:
-                pass
+                rate_set = False
+            if not rate_set:
+                return False
         return True
 
     def set_timeline_setting(self, tl_name: str, key: str, value: Any) -> bool:
@@ -19828,11 +19947,19 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
                     mark_set = {"applied": False, "error": str(exc)}
 
         # Navigate the bin to the clip's folder so the clip is visible to select.
+        # Not fatal on its own (SetSelectedClip may still work), but a discarded
+        # False meant the caller could not tell "the bin did not move" from
+        # "the bin moved and the clip is right there", which is the whole point
+        # of the action.
+        folder_ok: Optional[bool] = None
+        folder_error: Optional[str] = None
         if parent is not None:
             try:
-                mp.SetCurrentFolder(parent)
-            except Exception:
-                pass  # not fatal; SetSelectedClip below may still work
+                folder_ok = bool(mp.SetCurrentFolder(parent))
+            except Exception as exc:
+                folder_ok, folder_error = False, str(exc)
+            if not folder_ok:
+                folder_error = folder_error or "SetCurrentFolder returned False"
         select_ok = bool(mp.SetSelectedClip(clip))
 
         # Bring Resolve to the foreground so the editor doesn't have to
@@ -19857,6 +19984,8 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
             "clip_id": clip.GetUniqueId(),
             "clip_name": clip.GetName(),
             "folder_name": parent.GetName() if parent else None,
+            "bin_opened": folder_ok,
+            "bin_error": folder_error,
             "page": page,
             "mark_set": mark_set,
             "focus": focus_result,
@@ -26642,9 +26771,17 @@ def gallery_stills(action: str, params: Optional[Dict[str, Any]] = None) -> Dict
                 used_format = try_fmt
                 break
             time.sleep(0.3)
-        # Clean up still from gallery
+        # Clean up still from gallery. Cleanup, not the operation: the export
+        # above is what the caller asked for and it has already been verified by
+        # the file listing below. A leftover still is visible in the Gallery
+        # rather than silent, so this is logged, not raised.
         if delete_after:
-            album.DeleteStills([still])
+            try:
+                if not album.DeleteStills([still]):
+                    logger.warning("DeleteStills returned False; a still is left in "
+                                   "the Gallery album after the export")
+            except Exception as exc:
+                logger.warning("DeleteStills raised after the export: %s", exc)
         if not export_ok:
             _discard_still_staging(staging)
             return _err("ExportStills failed — ensure the Gallery panel is open on the Color page (Workspace > Gallery)")
@@ -26797,12 +26934,20 @@ def graph(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
             # not the per-user dir that dctl install writes to. Relocate and retry.
             relocated = _ensure_lut_in_master(lut_path)
             if relocated:
+                # The retry below only works if Resolve re-scanned the master
+                # LUT dir. A discarded False here turns the retry into a second
+                # identical failure with no explanation.
+                refreshed = None
                 try:
                     _, proj, _lut_err = _check()
                     if proj:
-                        proj.RefreshLUTList()
-                except Exception:
-                    pass
+                        refreshed = bool(proj.RefreshLUTList())
+                except Exception as exc:
+                    logger.warning("RefreshLUTList raised before the SetLUT retry: %s", exc)
+                if refreshed is False:
+                    logger.warning(
+                        "RefreshLUTList returned False; the relocated LUT may not be "
+                        "visible to SetLUT yet")
                 ok = bool(g.SetLUT(node_index, relocated))
                 if ok:
                     return {"success": True, "resolved_lut": relocated,
@@ -27070,6 +27215,19 @@ def _fusion_group_settings_load(comp, p: Dict[str, Any]) -> Dict[str, Any]:
         group.SaveSettings(backup_path)
     except Exception as exc:
         return _err(f"backup SaveSettings failed: {exc}")
+    # SaveSettings reports through the Lua bridge and its return is not
+    # reliable, but the file it was asked to write is. This backup is the only
+    # way back from the LoadSettings below, so loading without it would be an
+    # irreversible replacement of the group's graph presented as a reversible one.
+    if not os.path.isfile(backup_path):
+        return _err(
+            f"backup SaveSettings did not create a file at {backup_path!r}",
+            code="FUSION_BACKUP_NOT_WRITTEN", category="api_error", retryable=False,
+            reason="LoadSettings replaces the group's graph. Without the backup on "
+                   "disk there is no way back, so nothing was loaded.",
+            remediation="Check the backup_path directory is writable, or pass an "
+                        "explicit backup_path somewhere that is.",
+        )
 
     undo_name = p.get("undo_name", f"MCP group_settings_load {group_name}")
     undo_started = False
@@ -28215,7 +28373,31 @@ def fusion_comp(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
             except Exception:
                 _already_animated = False
             if not _already_animated:
+                # AddModifier reports through the Lua bridge, which resolves an
+                # unknown attribute to None rather than raising, so the return is
+                # not reliable evidence on its own. The readback below is: if the
+                # input still has no connected output, the assignment on the next
+                # line would set a STATIC value and _ok() would report a keyframe
+                # that does not exist.
                 tool.AddModifier(p["input_name"], p.get("modifier", "BezierSpline"))
+                try:
+                    attached = tool[p["input_name"]].GetConnectedOutput() is not None
+                except Exception:
+                    attached = False
+                if not attached:
+                    return _err(
+                        f"Could not animate '{p['input_name']}' on "
+                        f"'{p['tool_name']}': no spline modifier attached.",
+                        code="FUSION_ADD_MODIFIER_FAILED", category="api_error",
+                        retryable=False,
+                        reason="Without a spline, assigning at a time sets a STATIC "
+                               "value (last write wins) and creates no keyframe. "
+                               "Reporting success here would claim a keyframe that "
+                               "does not exist.",
+                        remediation="Check the input accepts the modifier type "
+                                    f"({p.get('modifier', 'BezierSpline')!r}); Point "
+                                    "inputs take 'Path'.",
+                    )
             tool[p["input_name"]][p["time"]] = p["value"]
             return _ok()
         finally:
@@ -29189,10 +29371,24 @@ def _run_inline_lua(source: str) -> Dict[str, Any]:
     )
 
     # Clear prior slots so we can detect if RunScript silently did nothing.
-    fusion.SetData("__mcp_done__", "")
-    fusion.SetData("__mcp_stdout__", "")
-    fusion.SetData("__mcp_result__", "")
-    fusion.SetData("__mcp_error__", "")
+    # SetData goes through the Lua bridge and returns nil whether or not it
+    # took, so the return is not evidence -- but GetData is. The __mcp_done__
+    # slot is the one that matters: a stale "1" left by the previous run makes
+    # the poll below exit immediately and return the PREVIOUS run's stdout,
+    # result and error as this run's.
+    for slot in ("__mcp_done__", "__mcp_stdout__", "__mcp_result__", "__mcp_error__"):
+        fusion.SetData(slot, "")
+    stale = fusion.GetData("__mcp_done__")
+    if stale not in ("", None):
+        return _err(
+            "Could not clear the Fusion completion sentinel before running.",
+            code="FUSION_SENTINEL_NOT_CLEARED", category="api_error", retryable=True,
+            reason=f"__mcp_done__ still reads {stale!r} after SetData. The poll would "
+                   "exit immediately and hand back the previous run's output as this "
+                   "run's.",
+            remediation="Retry; if it persists, restart Resolve to clear the Fusion "
+                        "app's data slots.",
+        )
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.lua',
                                       prefix='mcp-lua-inline-',

--- a/src/server.py
+++ b/src/server.py
@@ -44,6 +44,7 @@ for p in [current_dir, project_dir]:
 
 # Platform-specific Resolve paths
 from src.utils.cdl import normalize_cdl_payload
+from src.utils import resolve_writes as _resolve_writes
 from src.utils.mcp_stdio import run_fastmcp_stdio
 from src.utils.api_truth import lookup_api_truth, VERIFIED_ON as _API_TRUTH_VERIFIED_ON
 from src.utils import clip_colors as _clip_colors
@@ -6421,7 +6422,9 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
     new_tl = mp.CreateEmptyTimeline(name)
     if not new_tl:
         return _err(f"Failed to create timeline: {name}")
-    proj.SetCurrentTimeline(new_tl)
+    switch_err = _set_current_timeline_checked(proj, new_tl, what="building the variant")
+    if switch_err:
+        return switch_err
     if p.get("start_timecode"):
         try:
             new_tl.SetStartTimecode(p["start_timecode"])
@@ -8781,10 +8784,9 @@ def _setup_multicam_timeline(proj, mp, p: Dict[str, Any]):
     new_tl = mp.CreateEmptyTimeline(plan["name"])
     if not new_tl:
         return _err(f"Failed to create multicam setup timeline: {plan['name']}")
-    try:
-        proj.SetCurrentTimeline(new_tl)
-    except Exception:
-        pass
+    switch_err = _set_current_timeline_checked(proj, new_tl, what="stacking the angles")
+    if switch_err:
+        return switch_err
     if plan.get("start_timecode"):
         try:
             new_tl.SetStartTimecode(plan["start_timecode"])
@@ -14188,10 +14190,48 @@ def _playhead_frame_capture(p: Dict[str, Any]):
         return _playhead_frame_render(proj, tl, p)
     finally:
         if original_tl is not None:
-            try:
-                proj.SetCurrentTimeline(original_tl)
-            except Exception:
-                pass
+            # Best-effort by necessity: this runs in a finally, so raising or
+            # returning here would replace the caller's real result (or its real
+            # exception) with a restore failure. It is still not silent -- a
+            # failed restore leaves the editor on a different timeline, which is
+            # visible immediately, and it is logged.
+            restore_err = _set_current_timeline_checked(
+                proj, original_tl, what="restoring the timeline after the capture")
+            if restore_err:
+                logger.warning(
+                    "frame capture could not restore the current timeline: %s",
+                    restore_err["error"]["message"],
+                )
+
+
+def _set_current_timeline_checked(proj, tl, *, what: str):
+    """Switch the project's current timeline and PROVE it switched.
+
+    Returns None on success, or an error envelope naming what did not happen.
+
+    This is not UI polish. `AppendToTimeline`, `GetCurrentTimeline` and every
+    other "current timeline" call writes to whatever the PROJECT believes is
+    current, not to the handle in scope. A discarded False here sends the
+    assembly to the timeline the editor was looking at while the tool reports
+    the new timeline's name and id, which is the worst possible shape of
+    failure: the work happened, on the wrong timeline, under a success.
+
+    The bare bool is not trusted on its own. A Resolve attached to no database
+    answers version queries normally while every project mutation returns False
+    or None, and a True that did not take has been observed there, so the
+    switch is confirmed by reading the current timeline back.
+    """
+    ok, detail = _resolve_writes.set_current_timeline(proj, tl)
+    if ok:
+        return None
+    return _err(
+        _resolve_writes.describe_switch_failure(detail, what),
+        code="TIMELINE_SWITCH_FAILED", category="api_error", retryable=False,
+        reason="A discarded False here writes the work to the wrong timeline.",
+        remediation="Quit and restart Resolve if it came up with no database attached "
+                    "(resolve_control runtime_mode reports that), then retry.",
+        state=detail,
+    )
 
 
 def _unknown(action, valid):
@@ -16271,7 +16311,14 @@ def _resolve_restore_state(p: Dict[str, Any]) -> Dict[str, Any]:
             for i in range(1, count + 1):
                 tl = proj.GetTimelineByIndex(i)
                 if tl and tl.GetUniqueId() == state["current_timeline_id"]:
-                    proj.SetCurrentTimeline(tl)
+                    # The one function whose whole job is putting things back
+                    # must not claim it did. restored[] is written only on a
+                    # verified switch; a failure is reported, not swallowed.
+                    switch_err = _set_current_timeline_checked(
+                        proj, tl, what="restoring the saved state")
+                    if switch_err:
+                        restored["current_timeline_error"] = switch_err["error"]["message"]
+                        break
                     restored["current_timeline_id"] = state["current_timeline_id"]
                     if state.get("current_timecode"):
                         try:
@@ -19165,10 +19212,10 @@ def media_pool(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str
             tl = mp.CreateEmptyTimeline(create_name)
             if not tl:
                 return _err("Failed to create timeline from clip_infos")
-            try:
-                proj.SetCurrentTimeline(tl)
-            except Exception:
-                pass
+            switch_err = _set_current_timeline_checked(
+                proj, tl, what="appending the clip_infos")
+            if switch_err:
+                return switch_err
             timeline_start = _timeline_start_frame(tl)
             built = []
             for i, ci in enumerate(raw):
@@ -22651,10 +22698,10 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
         tl = mp.CreateEmptyTimeline(name)
         if not tl:
             return _err("Failed to create selects timeline")
-        try:
-            proj.SetCurrentTimeline(tl)
-        except Exception:
-            pass
+        switch_err = _set_current_timeline_checked(
+            proj, tl, what="assembling the selects")
+        if switch_err:
+            return switch_err
         timeline_start = _timeline_start_frame(tl)
         built = []
         build_errors = []
@@ -23038,10 +23085,14 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
         tl, _tl_index = _find_timeline_by_name(proj, plan.get("timeline_name"))
         if not tl:
             return _err(f"Timeline '{plan.get('timeline_name')}' not found")
-        try:
-            proj.SetCurrentTimeline(tl)
-        except Exception:
-            pass
+        # The lift is handle-based and hits the right timeline; the append that
+        # puts the replacement back is current-timeline-based. A failed switch
+        # here punches a hole in the target and drops the alternate on whatever
+        # the editor had open, under a reported success.
+        switch_err = _set_current_timeline_checked(
+            proj, tl, what="swapping the item")
+        if switch_err:
+            return switch_err
         before = _edit_engine_capture(tl)
         before["track_counts"] = _edit_engine_track_counts(tl)
         slot_start = int(item_block.get("timeline_start_frame"))

--- a/src/utils/app_control.py
+++ b/src/utils/app_control.py
@@ -78,13 +78,23 @@ def quit_resolve_app(resolve_obj, force: bool = False, save_project: bool = True
             if project and save_project:
                 logger.info("Saving project before quitting")
                 # Try to save the project
+                # Only the exception was handled. SaveProject also reports a
+                # refusal with a bare False -- which is what a project attached
+                # to no database returns -- and quitting on that throws the
+                # session away silently.
                 try:
-                    project.SaveProject()
+                    saved = project.SaveProject()
                 except Exception as e:
                     logger.error(f"Failed to save project: {str(e)}")
                     if not force:
                         logger.error("Aborting quit due to save failure")
                         return False
+                else:
+                    if saved is False:
+                        logger.error("SaveProject returned False; the project was NOT saved")
+                        if not force:
+                            logger.error("Aborting quit due to save failure")
+                            return False
         
         # Attempt to quit using the API
         if hasattr(resolve_obj, 'Quit') and callable(getattr(resolve_obj, 'Quit')):

--- a/src/utils/audio_fairlight_live_probe.py
+++ b/src/utils/audio_fairlight_live_probe.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.utils.timeline_kernel_probe import ProbeRecorder, render_markdown_report, utc_timestamp
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 
 def _require_success(label: str, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -146,7 +147,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         timeline = media_pool.CreateTimelineFromClips(timeline_name, [video_clip])
         if not timeline:
             raise AssertionError("Failed to create audio timeline")
-        project.SetCurrentTimeline(timeline)
+        # A discarded False here would run the whole probe against whatever
+        # timeline was already current, and every measurement below would be a
+        # reading of the wrong thing reported as a reading of this one.
+        switched, switch_detail = set_current_timeline(project, timeline)
+        if not switched:
+            raise AssertionError(
+                describe_switch_failure(switch_detail, "probing the audio timeline"))
         print(f"Created timeline: {timeline_name}")
 
         video_clip_id = _clip_id(video_clip)

--- a/src/utils/color_grade_live_probe.py
+++ b/src/utils/color_grade_live_probe.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.utils.timeline_kernel_probe import ProbeRecorder, render_markdown_report, utc_timestamp
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 
 def _require_success(label: str, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -188,7 +189,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         timeline = media_pool.CreateTimelineFromClips(timeline_name, [clip])
         if not timeline:
             raise AssertionError("Failed to create color grade timeline")
-        project.SetCurrentTimeline(timeline)
+        # A discarded False here would run the whole probe against whatever
+        # timeline was already current, and every measurement below would be a
+        # reading of the wrong thing reported as a reading of this one.
+        switched, switch_detail = set_current_timeline(project, timeline)
+        if not switched:
+            raise AssertionError(
+                describe_switch_failure(switch_detail, "probing the color grade timeline"))
         media_pool.AppendToTimeline([clip])
         timeline.SetCurrentTimecode("01:00:00:01")
         server.resolve_control("open_page", {"page": "color"})

--- a/src/utils/fusion_composition_live_probe.py
+++ b/src/utils/fusion_composition_live_probe.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.utils.timeline_kernel_probe import ProbeRecorder, render_markdown_report, utc_timestamp
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 
 def _require_success(label: str, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -139,7 +140,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         timeline = media_pool.CreateTimelineFromClips(timeline_name, [clip])
         if not timeline:
             raise AssertionError("Failed to create Fusion timeline")
-        project.SetCurrentTimeline(timeline)
+        # A discarded False here would run the whole probe against whatever
+        # timeline was already current, and every measurement below would be a
+        # reading of the wrong thing reported as a reading of this one.
+        switched, switch_detail = set_current_timeline(project, timeline)
+        if not switched:
+            raise AssertionError(
+                describe_switch_failure(switch_detail, "probing the Fusion timeline"))
         timeline.SetCurrentTimecode("01:00:00:01")
         print(f"Created timeline: {timeline_name}")
 

--- a/src/utils/probe_catalogue.py
+++ b/src/utils/probe_catalogue.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import Any, List
 
 from src.utils.mode_matrix import Probe
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 CATALOGUE: List[Probe] = []
 
@@ -731,11 +732,22 @@ def _probe_editorial_nested(ctx):
               if (c.GetClipProperty("Type") or "") == "Timeline"]
     if not nested:
         return None
-    ctx.project.SetCurrentTimeline(outer)
+    # AppendToTimeline writes to the CURRENT timeline, so a discarded False
+    # here would nest the clip into ctx.timeline and then count PROBE_OUTER's
+    # empty track -- a measurement of the wrong timeline, reported as this one's.
+    switched, detail = set_current_timeline(ctx.project, outer)
+    if not switched:
+        return describe_switch_failure(detail, "nesting the probe timeline")
     appended = pool.AppendToTimeline([{"mediaPoolItem": nested[0]}])
     count = len(outer.GetItemListInTrack("video", 1) or [])
-    ctx.project.SetCurrentTimeline(ctx.timeline)
-    return f"{bool(appended)}/{count}"
+    restored, restore_detail = set_current_timeline(ctx.project, ctx.timeline)
+    result = f"{bool(appended)}/{count}"
+    if not restored:
+        # The measurement stands; the teardown did not. Say so in the result
+        # rather than leaving the next probe on PROBE_OUTER without warning.
+        result += " (probe timeline left current: " + \
+            describe_switch_failure(restore_detail, "restoring the probe timeline") + ")"
+    return result
 
 
 @probe("editorial.set_clips_linked", "editorial", timeout=90, needs=("timeline",),

--- a/src/utils/project_cleanup.py
+++ b/src/utils/project_cleanup.py
@@ -13,8 +13,11 @@ disposable-project flow gets it for free:
    instead of silently leaking.
 """
 
+import logging
 import time
 from typing import Any, Dict, Optional
+
+logger = logging.getLogger("davinci-resolve-mcp.project_cleanup")
 
 
 #: The name Resolve gives the project it opens when it has nothing else to open.
@@ -103,10 +106,21 @@ def delete_project_safely(
             # cannot be saved, so the next close or switch raises a modal no
             # script can dismiss. That is a wedged application, not a tidy-up.
             if switch_to and switch_to != name:
+                # A discarded False leaves the session on the unsaveable
+                # "Untitled Project" this comment exists to avoid, and the next
+                # close or switch raises a modal no script can dismiss. Logged
+                # loudly: the caller is mid-delete and cannot be aborted here,
+                # but a silent wedge is what made this hard to diagnose.
                 try:
-                    pm.LoadProject(switch_to)
-                except Exception:
-                    pass
+                    if not pm.LoadProject(switch_to):
+                        logger.error(
+                            "LoadProject(%r) returned False after closing %r; the "
+                            "session is left on an unsaveable Untitled Project and "
+                            "the next close will raise a modal", switch_to, name,
+                        )
+                except Exception as exc:
+                    logger.error("LoadProject(%r) raised after closing %r: %s",
+                                 switch_to, name, exc)
 
         last_error = None
         for attempt in range(1 + max(0, int(retries))):

--- a/src/utils/render_deliver_live_probe.py
+++ b/src/utils/render_deliver_live_probe.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.utils.timeline_kernel_probe import ProbeRecorder, render_markdown_report, utc_timestamp
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 
 def _require_success(label: str, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -183,7 +184,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         timeline = media_pool.CreateTimelineFromClips(timeline_name, [clip])
         if not timeline:
             raise AssertionError("Failed to create synthetic render timeline")
-        project.SetCurrentTimeline(timeline)
+        # A discarded False here would run the whole probe against whatever
+        # timeline was already current, and every measurement below would be a
+        # reading of the wrong thing reported as a reading of this one.
+        switched, switch_detail = set_current_timeline(project, timeline)
+        if not switched:
+            raise AssertionError(
+                describe_switch_failure(switch_detail, "probing the synthetic render timeline"))
         print(f"Created timeline: {timeline_name}")
 
         chosen = _choose_render_format_codec(server)

--- a/src/utils/resolve_writes.py
+++ b/src/utils/resolve_writes.py
@@ -1,0 +1,79 @@
+"""Resolve mutators whose return value must not be discarded.
+
+Every write in the DaVinci Resolve scripting API reports itself with a bare
+boolean and nothing else. Dropping that boolean turns a failed write into a
+successful-looking no-op, which is the only failure shape worse than a crash:
+the tool reports what it meant to do, and the project does not have it.
+
+`SetCurrentTimeline` is the sharpest case in this repo, which is why it lives
+here. `AppendToTimeline`, `GetCurrentTimeline` and every other "current
+timeline" call writes to whatever the PROJECT believes is current, never to the
+handle in scope, so a discarded `False` sends an assembly to the timeline the
+editor was looking at while the caller reports the new timeline's name and id.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+
+def unique_id(obj: Any) -> Optional[str]:
+    """`obj.GetUniqueId()`, or None. Never raises."""
+    if obj is None:
+        return None
+    try:
+        return obj.GetUniqueId()
+    except Exception:
+        return None
+
+
+def set_current_timeline(project: Any, timeline: Any) -> Tuple[bool, Dict[str, Any]]:
+    """Switch the project's current timeline. Returns (ok, detail).
+
+    The bare bool is not trusted on its own. A Resolve attached to no database
+    answers version queries normally while every project mutation returns False
+    or None, and a `True` that did not take has been observed there, so the
+    switch is confirmed by reading the current timeline back.
+
+    When the readback is unavailable (a build or transport that does not answer
+    `GetCurrentTimeline`) the bool is the only evidence there is, and it is
+    used. That is a weaker check, not a reason to refuse the work.
+
+    `detail` always carries `returned`, `wanted_timeline_id`,
+    `current_timeline_id` and, on an exception, `exception`.
+    """
+    detail: Dict[str, Any] = {
+        "returned": None,
+        "wanted_timeline_id": unique_id(timeline),
+        "current_timeline_id": None,
+    }
+    try:
+        detail["returned"] = project.SetCurrentTimeline(timeline)
+    except Exception as exc:
+        detail["exception"] = str(exc)
+        return False, detail
+
+    try:
+        detail["current_timeline_id"] = unique_id(project.GetCurrentTimeline())
+    except Exception:
+        detail["current_timeline_id"] = None
+
+    wanted = detail["wanted_timeline_id"]
+    current = detail["current_timeline_id"]
+    if wanted is not None and current is not None:
+        return wanted == current, detail
+    return bool(detail["returned"]), detail
+
+
+def describe_switch_failure(detail: Dict[str, Any], what: str) -> str:
+    """One line naming what did not happen, for a log or an error envelope."""
+    if "exception" in detail:
+        return (
+            f"Could not switch the current timeline before {what}: "
+            f"{detail['exception']}. Nothing was written."
+        )
+    return (
+        f"Could not switch the current timeline before {what}. "
+        f"SetCurrentTimeline returned {detail.get('returned')!r} and the current "
+        f"timeline is still {detail.get('current_timeline_id')!r}, not "
+        f"{detail.get('wanted_timeline_id')!r}. Continuing would write to the "
+        "wrong timeline while reporting success."
+    )

--- a/src/utils/review_annotation_live_probe.py
+++ b/src/utils/review_annotation_live_probe.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.utils.timeline_kernel_probe import ProbeRecorder, render_markdown_report, utc_timestamp
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 
 def _require_success(label: str, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -148,7 +149,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         timeline = media_pool.CreateTimelineFromClips(timeline_name, [clip])
         if not timeline:
             raise AssertionError("Failed to create review annotation timeline")
-        project.SetCurrentTimeline(timeline)
+        # A discarded False here would run the whole probe against whatever
+        # timeline was already current, and every measurement below would be a
+        # reading of the wrong thing reported as a reading of this one.
+        switched, switch_detail = set_current_timeline(project, timeline)
+        if not switched:
+            raise AssertionError(
+                describe_switch_failure(switch_detail, "probing the review annotation timeline"))
         timeline.SetCurrentTimecode("01:00:00:01")
         print(f"Created timeline: {timeline_name}")
 

--- a/src/utils/timeline_conform_live_probe.py
+++ b/src/utils/timeline_conform_live_probe.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.utils.timeline_kernel_probe import ProbeRecorder, render_markdown_report, utc_timestamp
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 
 def _require_success(label: str, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -157,7 +158,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         )
         if not timeline:
             raise AssertionError("Failed to create conform timeline")
-        project.SetCurrentTimeline(timeline)
+        # A discarded False here would run the whole probe against whatever
+        # timeline was already current, and every measurement below would be a
+        # reading of the wrong thing reported as a reading of this one.
+        switched, switch_detail = set_current_timeline(project, timeline)
+        if not switched:
+            raise AssertionError(
+                describe_switch_failure(switch_detail, "probing the conform timeline"))
         media_pool.AppendToTimeline(
             [
                 {"mediaPoolItem": clip_b, "startFrame": 0, "endFrame": 48, "recordFrame": 86472, "trackIndex": 1, "mediaType": 1},

--- a/src/utils/timeline_kernel_live_probe.py
+++ b/src/utils/timeline_kernel_live_probe.py
@@ -947,7 +947,13 @@ def run_probe(server, output_dir: Path, keep_open: bool = False) -> Dict[str, An
         audio_item = server._find_timeline_item_by_id(timeline, audio_id)
         if not audio_item:
             raise AssertionError(f"Could not recover audio item: {audio_id}")
-        timeline.SetClipsLinked([source_item, audio_item], True)
+        # Everything the probe measures below assumes the pair is linked. A
+        # discarded False would measure UNLINKED behaviour and record it as
+        # linked behaviour.
+        if not timeline.SetClipsLinked([source_item, audio_item], True):
+            raise AssertionError(
+                "SetClipsLinked refused the source/audio pair; every linked-item "
+                "measurement below would be a reading of unlinked items")
 
         source_duration = _frame_int(source_item.GetDuration())
         metadata["source"] = {

--- a/src/utils/timeline_versioning.py
+++ b/src/utils/timeline_versioning.py
@@ -35,6 +35,7 @@ from src.utils.resolve_probe import has_method
 from typing import Any, Dict, List, Optional, Tuple
 
 from src.utils import actor_identity, timeline_brain_db
+from .resolve_writes import set_current_timeline, describe_switch_failure
 
 logger = logging.getLogger("resolve-mcp.timeline-versioning")
 
@@ -166,7 +167,16 @@ def archive_current_timeline(
     # DuplicateTimeline drops the duplicate in the *current* folder (Archive),
     # but it also switches Resolve's current timeline to the duplicate. Restore
     # the working timeline as the active one so downstream mutation hits it.
-    project.SetCurrentTimeline(tl)
+    # A discarded False here sends every subsequent mutation into the ARCHIVE
+    # copy while the caller believes it is editing the working timeline, so the
+    # archive fails loudly instead.
+    switched, switch_detail = set_current_timeline(project, tl)
+    if not switched:
+        return {"success": False,
+                "error": describe_switch_failure(
+                    switch_detail, "returning to the working timeline after archiving"),
+                "archived_timeline_name": archived_name,
+                "switch": switch_detail}
 
     # Timebase snapshot — timeline_clip_usage stores ABSOLUTE record frames
     # (GetStart() includes the start-timecode offset), so readers need the
@@ -612,10 +622,13 @@ def rollback_to_version(
     if restored is None:
         return {"success": False, "error": f"DuplicateTimeline('{restored_name}') failed"}
 
-    project.SetCurrentTimeline(restored)
+    switched, switch_detail = set_current_timeline(project, restored)
 
     return {
         "success": True,
+        "current_timeline_switched": switched,
+        "switch_error": (None if switched else describe_switch_failure(
+            switch_detail, "opening the restored timeline")),
         "rolled_back_from_version": version,
         "restored_timeline_name": restored_name,
         "archive_of_previous": archive_result,

--- a/tests/test_current_timeline_switch.py
+++ b/tests/test_current_timeline_switch.py
@@ -1,0 +1,143 @@
+"""A discarded SetCurrentTimeline is work done on the wrong timeline.
+
+`AppendToTimeline`, `GetCurrentTimeline` and every other "current timeline"
+call writes to whatever the PROJECT believes is current, not to the handle in
+scope. Seven callsites in src/server.py switched the current timeline and threw
+the return away, six of them inside `try/except: pass`, which catches an
+exception and never a `False`. The failure shape was the worst available: the
+assembly happened, on the timeline the editor was looking at, and the tool
+returned the NEW timeline's name and id as a success.
+
+`edit_engine.execute_swap` was the sharpest case. The lift is handle-based and
+hits the right timeline; the append that puts the replacement back is
+current-timeline-based. A failed switch punched a hole in the target and
+dropped the alternate somewhere else, and the handler still returned
+`success: bool(appended)` = True.
+"""
+
+import unittest
+
+from src.server import _set_current_timeline_checked
+
+
+class _Timeline:
+    def __init__(self, timeline_id):
+        self.timeline_id = timeline_id
+
+    def GetUniqueId(self):
+        return self.timeline_id
+
+
+class _Project:
+    """SetCurrentTimeline as Resolve implements it: a bare bool, and on a
+    failure the current timeline does not move."""
+
+    def __init__(self, current=None, *, returns=True, moves=True, raises=False,
+                 has_getter=True):
+        self.current = current
+        self.returns = returns
+        self.moves = moves
+        self.raises = raises
+        self.has_getter = has_getter
+        self.calls = []
+
+    def SetCurrentTimeline(self, timeline):
+        self.calls.append(timeline)
+        if self.raises:
+            raise RuntimeError("bridge is wedged")
+        if self.moves:
+            self.current = timeline
+        return self.returns
+
+    def GetCurrentTimeline(self):
+        if not self.has_getter:
+            raise AttributeError("GetCurrentTimeline")
+        return self.current
+
+
+class SetCurrentTimelineCheckedTest(unittest.TestCase):
+    def test_a_real_switch_returns_no_error(self):
+        wanted = _Timeline("tl-new")
+        project = _Project(current=_Timeline("tl-old"))
+
+        self.assertIsNone(
+            _set_current_timeline_checked(project, wanted, what="the test")
+        )
+        self.assertIs(project.current, wanted)
+
+    def test_a_false_return_is_a_structured_error(self):
+        wanted = _Timeline("tl-new")
+        project = _Project(current=_Timeline("tl-old"), returns=False, moves=False)
+
+        out = _set_current_timeline_checked(project, wanted, what="assembling the selects")
+
+        self.assertEqual(out["error"]["code"], "TIMELINE_SWITCH_FAILED")
+        self.assertEqual(out["error"]["category"], "resolve_api_failed")
+        self.assertFalse(out["error"]["retryable"])
+        self.assertIn("assembling the selects", out["error"]["message"])
+        self.assertEqual(out["error"]["state"]["wanted_timeline_id"], "tl-new")
+        self.assertEqual(out["error"]["state"]["current_timeline_id"], "tl-old")
+
+    def test_a_true_that_did_not_take_is_caught_by_the_readback(self):
+        """Observed on a Resolve attached to no database: True, no switch."""
+        wanted = _Timeline("tl-new")
+        project = _Project(current=_Timeline("tl-old"), returns=True, moves=False)
+
+        out = _set_current_timeline_checked(project, wanted, what="the test")
+
+        self.assertEqual(out["error"]["code"], "TIMELINE_SWITCH_FAILED")
+
+    def test_an_exception_is_reported_not_swallowed(self):
+        project = _Project(raises=True)
+
+        out = _set_current_timeline_checked(project, _Timeline("tl-new"), what="the test")
+
+        self.assertEqual(out["error"]["code"], "TIMELINE_SWITCH_FAILED")
+        self.assertIn("bridge is wedged", out["error"]["message"])
+
+    def test_a_missing_getter_falls_back_to_the_bool(self):
+        """A weaker check, not a reason to refuse the work."""
+        project = _Project(has_getter=False)
+
+        self.assertIsNone(
+            _set_current_timeline_checked(project, _Timeline("tl-new"), what="the test")
+        )
+
+    def test_a_missing_getter_plus_a_false_still_fails(self):
+        project = _Project(has_getter=False, returns=False, moves=False)
+
+        out = _set_current_timeline_checked(project, _Timeline("tl-new"), what="the test")
+
+        self.assertEqual(out["error"]["code"], "TIMELINE_SWITCH_FAILED")
+
+
+class CallsitesRefuseInsteadOfWritingElsewhereTest(unittest.TestCase):
+    """The class-level guard: no bare, unchecked SetCurrentTimeline in src/."""
+
+    def test_no_callsite_discards_the_return(self):
+        import ast
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parent.parent / "src"
+        offenders = []
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Expr):
+                    continue
+                call = node.value
+                if not isinstance(call, ast.Call):
+                    continue
+                func = call.func
+                if isinstance(func, ast.Attribute) and func.attr == "SetCurrentTimeline":
+                    offenders.append(f"{path.relative_to(root.parent)}:{node.lineno}")
+        self.assertEqual(
+            offenders, [],
+            "SetCurrentTimeline's return is discarded here. A False leaves the "
+            "project on the old timeline while the caller reports success:\n  "
+            + "\n  ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discarded_resolve_returns.py
+++ b/tests/test_discarded_resolve_returns.py
@@ -1,0 +1,201 @@
+"""No Resolve mutator may drop its return without a written reason.
+
+Every write in the Resolve scripting API reports itself with a bare boolean and
+nothing else, so a discarded return turns a failed write into a
+successful-looking no-op. That is the only failure shape worse than a crash:
+the tool reports what it meant to do, and the project does not have it.
+
+An AST pass over src/ found 113 bare-expression statements calling a
+capitalised Resolve mutator. 47 of them were fixed (see the CHANGELOG); the
+rest are listed below with the reason each one is genuinely fire-and-forget.
+The point of the allowlist is that "fire-and-forget" has to be ARGUED, once,
+in writing, and a NEW discarded return has to be argued too instead of joining
+the pile unnoticed.
+
+Three reasons recur, and only these three are accepted:
+
+  NIL   The API returns nil/None, so the return carries no information at all.
+        Fusion's Lua bridge is the whole of this category: SetInput, SetAttrs,
+        SetPos, SetData, SetExpression, Delete, StartUndo, Render, LoadSettings
+        and AddModifier all return nil whether or not they took. Where these
+        matter, the fix is a readback, not a return check, and the ones that
+        matter have one.
+  TEARDOWN  Cleanup or restore that runs after the measured work. Turning a
+        failed teardown into a failed operation would report successful work as
+        a failure, and the failure is visible (a leftover job, a still in the
+        Gallery, a bin left open) rather than silent.
+  PROBE_CAPTURED  A probe harness where the return IS the measurement and is
+        captured into a separate variable on the next line, or where the whole
+        step is torn down and re-measured anyway.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+SRC = pathlib.Path(__file__).resolve().parent.parent / "src"
+
+MUTATOR_PREFIXES = (
+    "Set", "Add", "Delete", "Import", "Save", "Append", "Create", "Load", "Link",
+    "Relink", "Unlink", "Export", "Apply", "Move", "Insert", "Refresh", "Render",
+    "Start", "Stop", "Remove",
+)
+
+NIL = "Fusion Lua bridge: returns nil whether or not it took, so the return is not evidence"
+TEARDOWN = "teardown after the measured work; a failure here is visible, not silent, and is logged"
+PROBE = "probe harness: the return is the measurement and is captured separately, or the step is re-measured"
+
+# (module path relative to src/, enclosing function, method) -> reason.
+ALLOWED: dict[tuple[str, str, str], str] = {
+    # --- Fusion, via the Lua bridge (returns nil) ---------------------------
+    ("server.py", "fusion_comp", "SetInput"): NIL,
+    ("server.py", "fusion_comp", "SetAttrs"): NIL,
+    ("server.py", "fusion_comp", "SetPos"): NIL,
+    ("server.py", "fusion_comp", "Delete"): NIL,
+    ("server.py", "fusion_comp", "Render"): NIL,
+    ("server.py", "fusion_comp", "StartUndo"): NIL,
+    ("server.py", "fusion_comp", "LoadSettings"): NIL,
+    ("server.py", "fusion_comp", "AddModifier"): (
+        NIL + "; verified instead by reading GetConnectedOutput back, because "
+        "without the spline the assignment sets a STATIC value and no keyframe"
+    ),
+    ("server.py", "_fusion_add_mask", "SetInput"): NIL,
+    ("server.py", "_fusion_add_mask", "SetAttrs"): NIL,
+    ("server.py", "_safe_add_fusion_tool", "SetAttrs"): NIL,
+    ("server.py", "_safe_set_fusion_inputs", "SetInput"): NIL + "; the action takes readback=True",
+    ("server.py", "_fusion_set_point_input", "SetInput"): NIL,
+    ("server.py", "_fusion_set_text_plus", "SetInput"): NIL + "; verified by get_text_plus readback",
+    ("server.py", "_fusion_comp_bulk_set_inputs", "SetInput"): NIL,
+    ("server.py", "_fusion_comp_bulk_set_inputs", "StartUndo"): NIL,
+    ("server.py", "_fusion_comp_bulk_set_expressions", "SetExpression"): NIL,
+    ("server.py", "_fusion_comp_bulk_set_expressions", "StartUndo"): NIL,
+    ("server.py", "_fusion_group_settings_load", "StartUndo"): NIL + "; tracked by undo_started",
+    ("server.py", "_fusion_group_settings_load", "LoadSettings"): NIL,
+    ("server.py", "_fusion_group_settings_load", "SaveSettings"): (
+        NIL + "; the backup is verified by os.path.isfile, which is what makes the "
+        "load reversible"
+    ),
+    ("server.py", "_fusion_group_settings_export", "SaveSettings"): (
+        NIL + "; verified by os.path.isfile on the path it was asked to write"
+    ),
+    ("server.py", "_fusion_delete_keyframe", "DeleteKeyFrames"): (
+        "measured on a live build to return None whether or not it removed anything; "
+        "verified by re-reading the keyframe list (v2.98.3)"
+    ),
+    ("server.py", "_run_inline_lua", "SetData"): (
+        NIL + "; the completion sentinel is verified by reading __mcp_done__ back, "
+        "because a stale value hands the previous run's output back as this run's"
+    ),
+
+    # --- teardown ----------------------------------------------------------
+    ("server.py", "_playhead_frame_render", "DeleteRenderJob"): TEARDOWN,
+    ("server.py", "_playhead_frame_render", "SetRenderSettings"): (
+        TEARDOWN + "; explicitly not a restore either -- without GetRenderSettings "
+        "there is nothing to restore FROM"
+    ),
+    ("server.py", "_playhead_frame_full", "DeleteStills"): TEARDOWN,
+    ("server.py", "render", "StopRendering"): (
+        "the API returns None; the caller polls IsRenderingInProgress"
+    ),
+    ("project.py", "stop_rendering", "StopRendering"): (
+        "the API returns None; the granular twin of the compound render path"
+    ),
+    ("graph.py", "graph_set_lut", "RefreshLUTList"): (
+        TEARDOWN + "; the granular twin of the compound path, which logs it"
+    ),
+
+    # --- probe harnesses ---------------------------------------------------
+    ("probe_catalogue.py", "_probe_pool_add_subfolder", "SetCurrentFolder"): PROBE,
+    ("probe_catalogue.py", "_probe_pool_add_subfolder", "DeleteFolders"): PROBE,
+    ("probe_catalogue.py", "_probe_pool_append_to_timeline", "AppendToTimeline"): PROBE,
+    ("probe_catalogue.py", "_probe_pool_clip_marker_roundtrip", "DeleteMarkerAtFrame"): PROBE,
+    ("probe_catalogue.py", "_probe_timeline_marker_roundtrip", "DeleteMarkerAtFrame"): PROBE,
+    ("probe_catalogue.py", "_probe_item_marker_roundtrip", "DeleteMarkerAtFrame"): PROBE,
+    ("probe_catalogue.py", "_probe_timeline_track_enable_roundtrip", "SetTrackEnable"): PROBE,
+    ("probe_catalogue.py", "_probe_color_group_roundtrip", "RemoveFromColorGroup"): PROBE,
+    ("probe_catalogue.py", "_probe_color_group_roundtrip", "DeleteColorGroup"): PROBE,
+    ("probe_catalogue.py", "_probe_gallery_export_stills", "DeleteStills"): PROBE,
+    ("probe_catalogue.py", "_probe_render_job_roundtrip", "SetRenderSettings"): PROBE,
+    ("probe_catalogue.py", "_probe_render_to_disk", "SetRenderSettings"): PROBE,
+    ("probe_catalogue.py", "_probe_render_to_disk", "SetCurrentRenderFormatAndCodec"): PROBE,
+    ("probe_catalogue.py", "_probe_render_to_disk", "StartRendering"): PROBE,
+    ("probe_catalogue.py", "_probe_render_to_disk", "DeleteRenderJob"): PROBE,
+    ("probe_catalogue.py", "_probe_projectlevel_multi_job", "SetRenderSettings"): PROBE,
+    ("probe_catalogue.py", "_probe_projectlevel_multi_job", "DeleteRenderJob"): PROBE,
+    ("probe_catalogue.py", "_probe_lifecycle_load_and_close", "LoadProject"): PROBE,
+    ("probe_catalogue.py", "_probe_lifecycle_delete_after_close_releases_lock", "LoadProject"): PROBE,
+    ("probe_catalogue.py", "_probe_editorial_linked", "SetClipsLinked"): PROBE,
+    ("color_grade_live_probe.py", "run_probe", "AppendToTimeline"): PROBE,
+    ("color_grade_live_probe.py", "run_probe", "SetCurrentTimecode"): PROBE,
+    ("timeline_conform_live_probe.py", "run_probe", "AppendToTimeline"): PROBE,
+    ("fusion_composition_live_probe.py", "run_probe", "SetCurrentTimecode"): PROBE,
+    ("review_annotation_live_probe.py", "run_probe", "SetCurrentTimecode"): PROBE,
+}
+
+
+def _discarded_mutator_calls():
+    """(module, function, method, line) for every bare-expression Resolve write."""
+    found = []
+    for path in sorted(SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        owner = {}
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for child in ast.walk(node):
+                    owner.setdefault(child, node.name)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Expr):
+                continue
+            call = node.value
+            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
+                continue
+            method = call.func.attr
+            # Capitalised first letter is the discriminator: Resolve's API is
+            # always PascalCase and Python's stdlib never is, so `.append(` on a
+            # local list cannot be mistaken for `.AppendToTimeline(`.
+            if not (method[:1].isupper() and method.startswith(MUTATOR_PREFIXES)):
+                continue
+            found.append((path.name, owner.get(node, "<module>"), method, node.lineno,
+                          str(path.relative_to(SRC.parent))))
+    return found
+
+
+class DiscardedResolveReturnsTest(unittest.TestCase):
+    def test_the_scan_finds_something(self):
+        """A scanner that matches nothing passes everything."""
+        self.assertGreater(len(_discarded_mutator_calls()), 20)
+
+    def test_every_discarded_return_has_a_written_reason(self):
+        offenders = []
+        for module, func, method, line, rel in _discarded_mutator_calls():
+            if (module, func, method) in ALLOWED:
+                continue
+            offenders.append(f"{rel}:{line}  {func}() drops {method}()'s return")
+        self.assertEqual(
+            offenders, [],
+            "A Resolve mutator's return was discarded with no reason on record. "
+            "Either check it -- a False here is a silent no-op reported as success "
+            "-- or add it to ALLOWED in this file with the reason it is genuinely "
+            "fire-and-forget:\n  " + "\n  ".join(offenders),
+        )
+
+    def test_the_allowlist_has_not_gone_stale(self):
+        """An entry for code that no longer exists hides the next real one."""
+        live = {(module, func, method)
+                for module, func, method, _line, _rel in _discarded_mutator_calls()}
+        stale = sorted(key for key in ALLOWED if key not in live)
+        self.assertEqual(
+            stale, [],
+            "these ALLOWED entries no longer match any callsite; delete them:\n  "
+            + "\n  ".join(str(key) for key in stale),
+        )
+
+    def test_every_reason_says_something(self):
+        for key, reason in ALLOWED.items():
+            with self.subTest(key=key):
+                self.assertGreater(len(reason), 25, f"{key}: the reason is not a reason")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multicam_setup.py
+++ b/tests/test_multicam_setup.py
@@ -111,12 +111,20 @@ class MediaPoolStub:
 
 
 class ProjectStub:
-    def __init__(self):
+    def __init__(self, switch_succeeds=True):
         self.current_timeline = None
+        self.switch_succeeds = switch_succeeds
 
     def SetCurrentTimeline(self, timeline):
+        # Resolve reports the switch with a bare bool and does not move the
+        # current timeline when it fails, which is what the False case models.
+        if not self.switch_succeeds:
+            return False
         self.current_timeline = timeline
         return True
+
+    def GetCurrentTimeline(self):
+        return self.current_timeline
 
 
 class MulticamSetupTests(unittest.TestCase):


### PR DESCRIPTION
Resolve's API reports a refused write by returning False, and a set of call sites dropped that return. Some sat inside a bare `try/except: pass`, so a failed write looked exactly like a successful one and the server carried on.

The one that bites hardest is `SetCurrentTimeline`. When the switch fails, the next edit lands on whatever timeline Resolve still had current, so the work goes somewhere the caller never asked for and nothing says so.

**What is here**

- `src/utils/resolve_writes.py`: a small checked helper, plus `_set_current_timeline_checked`, which returns the error envelope instead of continuing.
- The affected call sites routed through it, in `src/server.py`, `src/granular/`, and the utils probes.
- One deliberate exception, commented in place: the restore inside a `finally` after a frame capture logs a warning rather than returning, because returning there would replace the caller's real result (or its real exception) with a restore failure.
- The other 28 discarded mutator returns checked the same way. The ones that stay discarded are best-effort cleanups in `finally` blocks, or calls whose failure is already visible in the next read, and each says so in a comment.

**Tests**

- `tests/test_current_timeline_switch.py` (7 tests): the switch failing, succeeding, raising, and the finally-restore path.
- `tests/test_discarded_resolve_returns.py` (4 tests): the checked paths report failure, and the deliberate set is pinned so a later refactor cannot quietly widen it.

Full suite on this branch: 3043 tests, and the failure set is byte-identical to `main` without these commits (4 failures, 5 errors, 18 skipped, all pre-existing in my environment). No new failures, none fixed.

Branched off current `main`. No changelog entry, since that file is release-managed here; happy to add one in whatever form you prefer.