### PR TITLE
fix: avoid fusionscript teardown in doctor and installer probes

### DIFF
--- a/install.py
+++ b/install.py
@@ -1329,37 +1329,57 @@ def access_violation_message(returncode, version=None):
 
 
 def verify_resolve_connection(python_path, api_path, lib_path):
-    """Try to import DaVinciResolveScript and connect."""
+    """Probe Resolve without exposing short-lived children to Fusion teardown.
+
+    The persistent bridge is tried before Blackmagic's native scripting module.
+    If direct scripting is genuinely required, the disposable child flushes its
+    result and hard-exits after any native import attempt so fusionscript's
+    background RemoteApp thread cannot race CPython finalization.
+    """
     if not api_path:
         return False, "Resolve API path not found"
 
     env = {**os.environ, **build_server_env(python_path, api_path, lib_path)}
     modules_path = env["PYTHONPATH"]
     repo_root = str(Path(__file__).resolve().parent)
-    # Route through connect_resolve so Network mode (RESOLVE_SCRIPT_HOST, propagated
-    # into env by build_server_env) uses the explicit IP-targeted overload. Fall
-    # back to Local-mode discovery if the helper cannot be imported.
     test_script = textwrap.dedent(f"""\
+        import os
         import sys
         sys.path.insert(0, {modules_path!r})
         sys.path.insert(0, {repo_root!r})
+        native_import_attempted = False
         try:
-            import DaVinciResolveScript as dvr
             try:
                 from src.utils.resolve_connection import connect_resolve
             except Exception:
-                connect_resolve = lambda mod: mod.scriptapp('Resolve')
-            resolve = connect_resolve(dvr)
+                connect_resolve = None
+
+            resolve = None
+            if connect_resolve is not None:
+                resolve = connect_resolve(None)
+
+            if resolve is None:
+                native_import_attempted = True
+                import DaVinciResolveScript as dvr
+                if connect_resolve is not None:
+                    resolve = connect_resolve(dvr)
+                else:
+                    resolve = dvr.scriptapp('Resolve')
+
             if resolve:
                 name = resolve.GetProductName()
                 ver = resolve.GetVersionString()
-                print(f"CONNECTED: {{name}} {{ver}}")
+                print(f"CONNECTED: {{name}} {{ver}}", flush=True)
             else:
-                print("IMPORTED_OK: Module loads but Resolve not running or not responding")
+                print("IMPORTED_OK: Module loads but Resolve not running or not responding", flush=True)
         except ImportError as e:
-            print(f"IMPORT_ERROR: {{e}}")
+            print(f"IMPORT_ERROR: {{e}}", flush=True)
         except Exception as e:
-            print(f"ERROR: {{e}}")
+            print(f"ERROR: {{e}}", flush=True)
+        if native_import_attempted:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(0)
     """)
 
     process_timeout = 10.0
@@ -1399,6 +1419,7 @@ def verify_resolve_connection(python_path, api_path, lib_path):
         return False, "Connection timed out"
     except Exception as e:
         return False, str(e)
+
 
 # ─── Interactive UI ───────────────────────────────────────────────────────────
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -275,35 +275,71 @@ def resolve_probe(
     if not PYTHON.exists():
         return {"import_ok": False, "error": f"{PYTHON} is missing"}
 
+    # Disposable probe: ask the persistent bridge before importing Blackmagic's
+    # native Fusion module. fusionscript can leave a RemoteApp thread alive and
+    # crash CPython during interpreter finalization. If native import is needed,
+    # flush the result and hard-exit so those unsafe finalizers never run.
     code = f"""
 import json
+import os
 import sys
 sys.path.insert(0, {str(REPO)!r})
 sys.path.insert(0, {str(RESOLVE_MODULES)!r})
+native_import_attempted = False
 try:
-    import DaVinciResolveScript as dvr
     from src.utils.resolve_connection import connect_resolve
 except Exception as exc:
     payload = {{"import_ok": False, "error": repr(exc)}}
 else:
     try:
-        resolve = connect_resolve(dvr)
+        resolve = connect_resolve(None)
     except Exception as exc:
         payload = {{
-            "import_ok": True,
-            "module": getattr(dvr, "__file__", None),
+            "import_ok": None,
+            "import_skipped": True,
             "resolve_connected": False,
             "connection_error": repr(exc),
         }}
     else:
-        payload = {{
-            "import_ok": True,
-            "module": getattr(dvr, "__file__", None),
-            "resolve_connected": bool(resolve),
-            "product": resolve.GetProductName() if resolve else None,
-            "version": resolve.GetVersionString() if resolve else None,
-        }}
-print(json.dumps(payload))
+        if resolve is not None:
+            payload = {{
+                "import_ok": None,
+                "import_skipped": True,
+                "module": None,
+                "resolve_connected": True,
+                "transport": "bridge",
+                "product": resolve.GetProductName(),
+                "version": resolve.GetVersionString(),
+            }}
+        else:
+            native_import_attempted = True
+            try:
+                import DaVinciResolveScript as dvr
+            except Exception as exc:
+                payload = {{"import_ok": False, "error": repr(exc)}}
+            else:
+                try:
+                    resolve = connect_resolve(dvr)
+                except Exception as exc:
+                    payload = {{
+                        "import_ok": True,
+                        "module": getattr(dvr, "__file__", None),
+                        "resolve_connected": False,
+                        "connection_error": repr(exc),
+                    }}
+                else:
+                    payload = {{
+                        "import_ok": True,
+                        "module": getattr(dvr, "__file__", None),
+                        "resolve_connected": bool(resolve),
+                        "product": resolve.GetProductName() if resolve else None,
+                        "version": resolve.GetVersionString() if resolve else None,
+                    }}
+print(json.dumps(payload), flush=True)
+if native_import_attempted:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
 """
     env = {
         **os.environ,
@@ -481,36 +517,46 @@ def collect(
     check(results, "OK" if pyver["ok"] else "FAIL", "Python version", pyver["stdout"] or pyver["stderr"])
 
     probe = resolve_probe(resolve_host, resolve_timeout)
-    if probe.get("import_ok"):
+    if probe.get("import_skipped"):
+        check(
+            results,
+            "OK" if probe.get("resolve_connected") else "INFO",
+            "DaVinciResolveScript import",
+            "skipped — persistent bridge answered; native Fusion module not loaded"
+            if probe.get("resolve_connected")
+            else "skipped — bridge mode failed before native Fusion import",
+        )
+    elif probe.get("import_ok"):
         check(results, "OK", "DaVinciResolveScript import", str(probe.get("module")))
-        if probe.get("resolve_connected"):
-            detail = f"{probe.get('product')} {probe.get('version')}"
-            check(results, "OK", "Resolve scripting connection", detail)
-        elif probe.get("connection_error"):
-            check(
-                results,
-                "FAIL",
-                "Resolve scripting connection",
-                str(probe["connection_error"]),
-            )
-        else:
-            # This is also exactly what the free edition looks like: the module
-            # imports fine and scriptapp refuses, because Blackmagic gates
-            # *external* scripting to Studio. Sending someone to toggle a
-            # preference that cannot help them is a dead end, so name the bridge
-            # here too.
-            check(
-                results,
-                "WARN",
-                "Resolve scripting connection",
-                "Module import worked, but scriptapp returned no object. On Studio: "
-                "External scripting = Local, or Network with --resolve-host set to "
-                "the Resolve host IP, then restart Resolve. On the FREE edition "
-                "external scripting is gated off entirely — use the in-app bridge "
-                "(see 'Free-edition bridge' below).",
-            )
     else:
         check(results, "FAIL", "DaVinciResolveScript import", str(probe.get("error")))
+
+    if probe.get("resolve_connected"):
+        detail = f"{probe.get('product')} {probe.get('version')}"
+        check(results, "OK", "Resolve scripting connection", detail)
+    elif probe.get("connection_error"):
+        check(
+            results,
+            "FAIL",
+            "Resolve scripting connection",
+            str(probe["connection_error"]),
+        )
+    elif probe.get("import_ok"):
+        # This is also exactly what the free edition looks like: the module
+        # imports fine and scriptapp refuses, because Blackmagic gates
+        # *external* scripting to Studio. Sending someone to toggle a
+        # preference that cannot help them is a dead end, so name the bridge
+        # here too.
+        check(
+            results,
+            "WARN",
+            "Resolve scripting connection",
+            "Module import worked, but scriptapp returned no object. On Studio: "
+            "External scripting = Local, or Network with --resolve-host set to "
+            "the Resolve host IP, then restart Resolve. On the FREE edition "
+            "external scripting is gated off entirely — use the in-app bridge "
+            "(see 'Free-edition bridge' below).",
+        )
 
     results.extend(bridge_checks(probe))
 

--- a/tests/test_cdl_and_install_config.py
+++ b/tests/test_cdl_and_install_config.py
@@ -146,6 +146,13 @@ class InstallConfigTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIn("connect_resolve", captured["script"])
+        self.assertIn("connect_resolve(None)", captured["script"])
+        self.assertLess(
+            captured["script"].index("connect_resolve(None)"),
+            captured["script"].index("import DaVinciResolveScript"),
+        )
+        self.assertIn("native_import_attempted = True", captured["script"])
+        self.assertIn("os._exit(0)", captured["script"])
         self.assertIn(repo_root, captured["script"])
         # RESOLVE_SCRIPT_HOST propagated into the probe env by build_server_env.
         self.assertEqual(captured["env"].get("RESOLVE_SCRIPT_HOST"), "127.0.0.1")

--- a/tests/test_doctor_paths.py
+++ b/tests/test_doctor_paths.py
@@ -320,5 +320,73 @@ class ClaudeDesktopConfigTests(unittest.TestCase):
         )
 
 
+class ResolveProbeLifecycleTests(unittest.TestCase):
+    def _layout(self, root: Path, helper: str, dvr: str) -> tuple[Path, Path]:
+        repo = root / "repo"
+        utils = repo / "src" / "utils"
+        modules = root / "modules"
+        utils.mkdir(parents=True)
+        modules.mkdir()
+        (repo / "src" / "__init__.py").write_text("")
+        (utils / "__init__.py").write_text("")
+        (utils / "resolve_connection.py").write_text(helper)
+        (modules / "DaVinciResolveScript.py").write_text(dvr)
+        return repo, modules
+
+    def test_bridge_first_skips_native_fusion_import(self) -> None:
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            repo, modules = self._layout(
+                root,
+                "class Proxy:\n"
+                " def GetProductName(self): return 'Bridge Resolve'\n"
+                " def GetVersionString(self): return '1.0'\n"
+                "def connect_resolve(dvr):\n"
+                " assert dvr is None\n"
+                " return Proxy()\n",
+                "raise RuntimeError('native Fusion import must not happen')\n",
+            )
+            with mock.patch.object(doctor, "REPO", repo), mock.patch.object(
+                doctor, "RESOLVE_MODULES", modules
+            ), mock.patch.object(doctor, "PYTHON", Path(sys.executable)):
+                probe = doctor.resolve_probe()
+
+        self.assertTrue(probe["resolve_connected"])
+        self.assertTrue(probe["import_skipped"])
+        self.assertEqual(probe["transport"], "bridge")
+        self.assertEqual(probe["returncode"], 0)
+
+    def test_native_fallback_hard_exits_without_running_atexit(self) -> None:
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            finalized = root / "finalized.txt"
+            repo, modules = self._layout(
+                root,
+                "def connect_resolve(dvr):\n"
+                " return None if dvr is None else dvr.scriptapp('Resolve')\n",
+                "import atexit\nfrom pathlib import Path\n"
+                f"atexit.register(lambda: Path({str(finalized)!r}).write_text('ran'))\n"
+                "class Proxy:\n"
+                " def GetProductName(self): return 'Direct Resolve'\n"
+                " def GetVersionString(self): return '1.0'\n"
+                "def scriptapp(name): return Proxy()\n",
+            )
+            with mock.patch.object(doctor, "REPO", repo), mock.patch.object(
+                doctor, "RESOLVE_MODULES", modules
+            ), mock.patch.object(doctor, "PYTHON", Path(sys.executable)):
+                probe = doctor.resolve_probe()
+
+            self.assertTrue(probe["import_ok"])
+            self.assertTrue(probe["resolve_connected"])
+            self.assertEqual(probe["returncode"], 0)
+            self.assertFalse(finalized.exists(), "native probe ran Python finalizers")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Avoid CPython/Fusion teardown crashes in the short-lived installer and doctor probes.

The probes now follow the repository's established bridge-first connector pattern: ask `connect_resolve(None)` before importing Blackmagic's native `DaVinciResolveScript` module. If native scripting is required, the child flushes its result and exits with `os._exit(0)` after the import attempt so `fusionscript` background teardown cannot race interpreter finalization.

This keeps the existing native fallback and Windows access-violation diagnostics intact while avoiding the native module entirely when the persistent bridge can answer.

## Why

A short-lived Python probe could successfully talk to Resolve and then crash during interpreter shutdown because `fusionscript` leaves background RemoteApp state alive. The failure happens after the useful probe work, so it can look like an installer/doctor crash rather than a connection failure.

This is the same upstream failure class already accepted in PR #108: that merged fix documents `fusionscript.so`'s `RemoteApp` thread continuing to dispatch while CPython exits, with `Fusion::RemoteApp::FindLocalObject` on the crashing thread, and uses a flushed `os._exit()` guard for spawned scripts. This patch extends that already-accepted lifetime rule to the remaining short-lived doctor/install probes.

The bridge-first ordering is also consistent with issue #109, where the maintainer documented that bridge-capable connectors should not require `DaVinciResolveScript` before trying `connect_resolve(None)`.

## Changes

- `scripts/doctor.py`
  - try the persistent bridge before native Fusion import
  - report the native import as skipped when the bridge answers
  - hard-exit only after a native import attempt
- `install.py`
  - use the same bridge-first probe ordering
  - hard-exit after native import attempts
  - preserve current Windows access-violation diagnostics
- add focused lifecycle regression coverage for both probes

## Validation

- 89 focused tests: PASS
- `tests/test_import.py`: PASS
- `scripts/audit_api_parity.py`: PASS
- `scripts/gen_api_limitations.py --check`: PASS
- `node scripts/agent-rules/generate.mjs --check`: PASS
- static/doc regression group: 14 tests PASS, 1 skip
- `node bin/davinci-resolve-mcp.mjs --help`: PASS
- `node bin/davinci-resolve-mcp.mjs --version`: `2.104.1`
- `npm pack --dry-run`: PASS
- `git show --check 9c50a1f`: PASS
- live doctor probe against DaVinci Resolve Studio 21.0.4.5: PASS via bridge, native Fusion module not loaded
- live installer connection probe: PASS
- Resolve and bridge PIDs remained unchanged during validation
- no new macOS Python crash report was produced

### Full-suite baseline comparison

The full local suite is not green in this checkout environment for reasons unrelated to this patch. To distinguish patch regressions from baseline failures, the same command/interpreter was run against both untouched upstream `v2.104.1` (`190fe2c`) and this candidate:

- untouched upstream: 1842 tests; 1 failure, 147 errors, 3 skipped
- candidate: 1844 tests; 1 failure, 147 errors, 3 skipped
- all 134 reported ERROR/FAIL test names are identical
- candidate-only failures: 0

The candidate adds two lifecycle tests, both passing. Dominant baseline errors are missing local `mcp` dependency and missing `resolve-advanced/server/libs.mjs` in that test environment, plus one existing offline-guard failure.

## Release lineage

`v2.104.1` dereferences to `190fe2c62b881870a7eb6add90c660f4bf811a25`; this change is exactly one commit on top of that release as `9c50a1f03b66dce36650ebffdda70eafd6981304`.