### PR TITLE
Fix Windows UnicodeDecodeError in tests/scripts (missing encoding="utf-8")

### DIFF
--- a/scripts/audit_api_parity.py
+++ b/scripts/audit_api_parity.py
@@ -49,7 +49,7 @@ def parse_documented_methods(docs_path: Path) -> Dict[str, Set[str]]:
     """
     classes: Dict[str, Set[str]] = {}
     current_class: str | None = None
-    text = docs_path.read_text()
+    text = docs_path.read_text(encoding="utf-8")
     # Truncate at the first deprecation marker
     for marker in ("\nDeprecated Resolve API Functions",
                    "\nUnsupported Resolve API Functions"):
@@ -86,7 +86,7 @@ def collect_source_text() -> str:
         if "__pycache__" in py_path.parts:
             continue
         try:
-            parts.append(py_path.read_text())
+            parts.append(py_path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError):
             continue
     return "\n".join(parts)
@@ -100,7 +100,7 @@ def find_broken_api_imports() -> List[Tuple[Path, int, str]]:
         if "__pycache__" in py_path.parts:
             continue
         try:
-            for i, line in enumerate(py_path.read_text().splitlines(), 1):
+            for i, line in enumerate(py_path.read_text(encoding="utf-8").splitlines(), 1):
                 if pattern.search(line):
                     hits.append((py_path.relative_to(REPO_ROOT), i, line.strip()))
         except (OSError, UnicodeDecodeError):
@@ -199,7 +199,7 @@ def find_undocumented_method_wrappers(
         if "__pycache__" in py_path.parts:
             continue
         try:
-            for i, line in enumerate(py_path.read_text().splitlines(), 1):
+            for i, line in enumerate(py_path.read_text(encoding="utf-8").splitlines(), 1):
                 for m in call_pattern.finditer(line):
                     name = m.group(1)
                     if name in documented or name in seen:

--- a/scripts/bisect_headless_hang.py
+++ b/scripts/bisect_headless_hang.py
@@ -74,7 +74,7 @@ def step(label, fn, secs=45, pm=None):
 
 
 def dump():
-    Path(sys.argv[1]).write_text(json.dumps(RESULTS, indent=2, default=str))
+    Path(sys.argv[1]).write_text(json.dumps(RESULTS, indent=2, default=str), encoding="utf-8")
 
 
 def main():

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -240,7 +240,7 @@ def _normalize_separators(text: str) -> str:
 def file_contains(path: Path, needles: list[str]) -> tuple[bool, str]:
     if not path.exists():
         return False, "missing"
-    text = _normalize_separators(path.read_text(errors="replace"))
+    text = _normalize_separators(path.read_text(errors="replace", encoding="utf-8"))
     missing = [needle for needle in needles if _normalize_separators(needle) not in text]
     if missing:
         return False, "missing: " + ", ".join(missing)
@@ -250,7 +250,7 @@ def file_contains(path: Path, needles: list[str]) -> tuple[bool, str]:
 def version_from_server() -> str:
     if not SERVER.exists():
         return "unknown"
-    match = re.search(r'^VERSION\s*=\s*"([^"]+)"', SERVER.read_text(errors="replace"), re.M)
+    match = re.search(r'^VERSION\s*=\s*"([^"]+)"', SERVER.read_text(errors="replace", encoding="utf-8"), re.M)
     return match.group(1) if match else "unknown"
 
 

--- a/scripts/gen_api_limitations.py
+++ b/scripts/gen_api_limitations.py
@@ -139,7 +139,7 @@ def main(argv: list[str]) -> int:
     args = _parse_args(argv)
     content = render()
     if args.check:
-        current = DOC_PATH.read_text() if DOC_PATH.exists() else ""
+        current = DOC_PATH.read_text(encoding="utf-8") if DOC_PATH.exists() else ""
         if current != content:
             print(
                 f"STALE: {DOC_PATH.relative_to(REPO_ROOT)} is out of date.\n"
@@ -149,7 +149,7 @@ def main(argv: list[str]) -> int:
             return 1
         print(f"OK: {DOC_PATH.relative_to(REPO_ROOT)} is up to date.")
         return 0
-    DOC_PATH.write_text(content)
+    DOC_PATH.write_text(content, encoding="utf-8")
     print(f"Wrote {DOC_PATH.relative_to(REPO_ROOT)}")
     return 0
 

--- a/scripts/mode_matrix.py
+++ b/scripts/mode_matrix.py
@@ -162,7 +162,7 @@ def completed_probes(path: Path) -> Dict[str, Dict[str, Any]]:
     results: Dict[str, Dict[str, Any]] = {}
     if not path.exists():
         return results
-    for line in path.read_text(errors="replace").splitlines():
+    for line in path.read_text(errors="replace", encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
@@ -183,7 +183,7 @@ def last_phase(path: Path) -> Optional[Dict[str, Any]]:
     if not path.exists():
         return None
     marker = None
-    for line in path.read_text(errors="replace").splitlines():
+    for line in path.read_text(errors="replace", encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
@@ -197,7 +197,7 @@ def last_phase(path: Path) -> Optional[Dict[str, Any]]:
 
 
 def append(path: Path, record: Dict[str, Any]) -> None:
-    with path.open("a") as handle:
+    with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, default=str) + "\n")
 
 

--- a/scripts/mode_matrix_worker.py
+++ b/scripts/mode_matrix_worker.py
@@ -177,7 +177,7 @@ def main() -> int:
     wanted = set(args.probes)
     probes = [p for p in CATALOGUE if p.name in wanted]
 
-    with args.out.open("a") as handle:
+    with args.out.open("a", encoding="utf-8") as handle:
         try:
             build_fixture(ctx)
         except Exception as exc:

--- a/scripts/pixel_equality.py
+++ b/scripts/pixel_equality.py
@@ -103,7 +103,7 @@ def build_assets() -> None:
             for g in (0.0, 1.0):
                 for r in (0.0, 1.0):
                     lines.append(f"{min(b + 0.15, 1.0):.6f} {g:.6f} {min(r + 0.15, 1.0):.6f}")
-        LUT.write_text("\n".join(lines) + "\n")
+        LUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def frame_hashes(path: Path) -> List[str]:
@@ -338,7 +338,7 @@ def run(mode: str, out: Path) -> int:
 
 
 def compare(gui_path: Path, headless_path: Path, out: Optional[Path]) -> int:
-    gui, headless = json.loads(gui_path.read_text()), json.loads(headless_path.read_text())
+    gui, headless = json.loads(gui_path.read_text(encoding="utf-8")), json.loads(headless_path.read_text(encoding="utf-8"))
     if gui["metadata"]["headless"] is not False or headless["metadata"]["headless"] is not True:
         print("REFUSE: mode metadata does not match the arguments.", file=sys.stderr)
         return 1

--- a/scripts/render_stress.py
+++ b/scripts/render_stress.py
@@ -161,7 +161,7 @@ class CrashWatch:
             self.offset = size  # rotation/truncation resets the mark
             return None
         try:
-            with CRASH_ARCHIVE.open("r", errors="replace") as handle:
+            with CRASH_ARCHIVE.open("r", errors="replace", encoding="utf-8") as handle:
                 handle.seek(self.offset)
                 text = handle.read()
         except OSError:
@@ -172,7 +172,7 @@ class CrashWatch:
 
 def log_tail(lines: int = 80) -> str:
     try:
-        content = RESOLVE_LOG.read_text(errors="replace").splitlines()
+        content = RESOLVE_LOG.read_text(errors="replace", encoding="utf-8").splitlines()
     except OSError:
         return ""
     return "\n".join(content[-lines:])

--- a/scripts/resolve_bridge_probe.py
+++ b/scripts/resolve_bridge_probe.py
@@ -56,7 +56,7 @@ def process_name(pid):
         except Exception:
             return ""
     try:  # Linux
-        with open("/proc/%d/comm" % pid) as handle:
+        with open("/proc/%d/comm" % pid, encoding="utf-8") as handle:
             return handle.read().strip()
     except (OSError, IOError):
         pass
@@ -142,7 +142,7 @@ def main():
         directory = os.path.dirname(REPORT_PATH)
         if not os.path.isdir(directory):
             os.makedirs(directory)
-        with open(REPORT_PATH, "w") as handle:
+        with open(REPORT_PATH, "w", encoding="utf-8") as handle:
             json.dump(probe, handle, indent=2, sort_keys=True)
         written = REPORT_PATH
     except (OSError, IOError) as exc:

--- a/scripts/resolve_capability_probe.py
+++ b/scripts/resolve_capability_probe.py
@@ -231,7 +231,7 @@ def main():
     try:
         if not os.path.isdir(REPORT_DIR):
             os.makedirs(REPORT_DIR)
-        with open(path, "w") as handle:
+        with open(path, "w", encoding="utf-8") as handle:
             json.dump(report, handle, indent=2, sort_keys=True)
         written = path
     except (OSError, IOError) as exc:

--- a/scripts/roundtrip_matrix.py
+++ b/scripts/roundtrip_matrix.py
@@ -391,8 +391,8 @@ def _verdict(entry: Dict[str, Any], strategy: str) -> str:
 
 
 def compare(gui_path: Path, headless_path: Path, out: Optional[Path]) -> int:
-    gui = json.loads(gui_path.read_text())
-    headless = json.loads(headless_path.read_text())
+    gui = json.loads(gui_path.read_text(encoding="utf-8"))
+    headless = json.loads(headless_path.read_text(encoding="utf-8"))
     assert gui["metadata"]["headless"] is False, f"{gui_path} is not a GUI run"
     assert headless["metadata"]["headless"] is True, f"{headless_path} is not a headless run"
 

--- a/scripts/roundtrip_rich.py
+++ b/scripts/roundtrip_rich.py
@@ -385,7 +385,7 @@ def run(mode: str, out: Path) -> int:
 
 
 def compare(gui_path: Path, headless_path: Path, out: Optional[Path]) -> int:
-    gui, headless = json.loads(gui_path.read_text()), json.loads(headless_path.read_text())
+    gui, headless = json.loads(gui_path.read_text(encoding="utf-8")), json.loads(headless_path.read_text(encoding="utf-8"))
     assert gui["metadata"]["headless"] is False and headless["metadata"]["headless"] is True
     lines = ["# Complex-cut round trip: what each format keeps", "",
              "Two video tracks, audio, a per-item transform, clip colours, flags, item and "

--- a/tests/benchmark_server.py
+++ b/tests/benchmark_server.py
@@ -261,7 +261,7 @@ def main() -> None:
     
     # Save results to file
     result_file = f"benchmark_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
-    with open(result_file, 'w') as f:
+    with open(result_file, 'w', encoding="utf-8") as f:
         json.dump(results, f, indent=2)
     
     logger.info(f"Benchmark results saved to {result_file}")

--- a/tests/live_edit_engine_validation.py
+++ b/tests/live_edit_engine_validation.py
@@ -118,7 +118,7 @@ def main() -> int:
         for row in manifest["clips"]:
             record = row["record"]
             is_talk = "talk" in str(record.get("clip_name"))
-            with open(row["analysis_json"]) as fh:
+            with open(row["analysis_json"], encoding="utf-8") as fh:
                 report = json.load(fh)
             duration = (report.get("cut_analysis") or {}).get("duration_seconds") or 20.0
             visual = {

--- a/tests/live_fuse_diagnose.py
+++ b/tests/live_fuse_diagnose.py
@@ -68,21 +68,21 @@ def main():
     installed = []
 
     minimal_path = os.path.join(fuses_dir, "McpMinimal.fuse")
-    with open(minimal_path, "w") as f:
+    with open(minimal_path, "w", encoding="utf-8") as f:
         f.write(MINIMAL_FUSE)
     installed.append(("minimal", "McpMinimal", minimal_path))
     print(f"[OK] hand-written minimal: {os.path.basename(minimal_path)}")
 
     gen_source = fuse_templates.color_matrix("McpGenerated", {"ops": ["brightness"]})
     gen_path = os.path.join(fuses_dir, "McpGenerated.fuse")
-    with open(gen_path, "w") as f:
+    with open(gen_path, "w", encoding="utf-8") as f:
         f.write(gen_source)
     installed.append(("generated", "McpGenerated", gen_path))
     print(f"[OK] generated color_matrix: {os.path.basename(gen_path)}")
 
     # Print what's in the generated file for visual inspection
     print("\n=== Generated Fuse first 40 lines ===")
-    with open(gen_path) as f:
+    with open(gen_path, encoding="utf-8") as f:
         for i, line in enumerate(f):
             if i >= 40:
                 break

--- a/tests/live_resolve21_validation.py
+++ b/tests/live_resolve21_validation.py
@@ -498,7 +498,7 @@ def main():
 
 def readme_date():
     try:
-        with open(SCRIPTING_README, "r", errors="replace") as fh:
+        with open(SCRIPTING_README, "r", errors="replace", encoding="utf-8") as fh:
             for line in fh:
                 if line.lower().startswith("last updated"):
                     return line.strip()
@@ -661,7 +661,7 @@ def emit(report, path):
     for status, count in sorted(tally.items()):
         print(f"  {status:20} {count}")
     if path:
-        with open(path, "w") as fh:
+        with open(path, "w", encoding="utf-8") as fh:
             json.dump(report, fh, indent=2, default=str)
         print(f"\n  report written to {path}")
 

--- a/tests/test_action_list_drift.py
+++ b/tests/test_action_list_drift.py
@@ -89,7 +89,7 @@ def _listed_actions(fn, consts):
 
 class ActionListDriftTest(unittest.TestCase):
     def test_unknown_action_lists_match_dispatch(self):
-        tree = ast.parse(SERVER.read_text())
+        tree = ast.parse(SERVER.read_text(encoding="utf-8"))
         consts = _module_list_constants(tree)
         problems = []
         checked_names = []
@@ -125,7 +125,7 @@ class ActionListDriftTest(unittest.TestCase):
         because of exactly this — the panel proxied to the helpers directly,
         which masked it. Guard the whole class.
         """
-        tree = ast.parse(SERVER.read_text())
+        tree = ast.parse(SERVER.read_text(encoding="utf-8"))
         problems = []
 
         def membership_set(test):

--- a/tests/test_api_limitations_doc.py
+++ b/tests/test_api_limitations_doc.py
@@ -33,14 +33,14 @@ class ApiLimitationsDocTest(unittest.TestCase):
         gen = _load_generator()
         self.assertTrue(DOC.exists(), "api-limitations.md is missing — run the generator")
         self.assertEqual(
-            DOC.read_text(),
+            DOC.read_text(encoding="utf-8"),
             gen.render(),
             "api-limitations.md is stale; run: "
             "venv/bin/python scripts/gen_api_limitations.py",
         )
 
     def test_doc_is_marked_generated(self):
-        self.assertIn("GENERATED FILE", DOC.read_text())
+        self.assertIn("GENERATED FILE", DOC.read_text(encoding="utf-8"))
 
     def test_submit_values_are_valid(self):
         for e in API_TRUTH:

--- a/tests/test_brain_edits.py
+++ b/tests/test_brain_edits.py
@@ -189,14 +189,14 @@ class BrainEdits(unittest.TestCase):
         # live there and contain both entries.
         registry_path = os.path.join(self.base, brain_edits.REGISTRY_FILENAME)
         self.assertTrue(os.path.isfile(registry_path), msg="registry not created")
-        with open(registry_path, "r") as fh:
+        with open(registry_path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
         project_names = {e["project_name"] for e in payload["entries"]}
         self.assertEqual(project_names, {"project_a", "project_b"})
 
     def test_registry_handles_corrupt_file(self) -> None:
         registry_path = os.path.join(self.base, brain_edits.REGISTRY_FILENAME)
-        with open(registry_path, "w") as fh:
+        with open(registry_path, "w", encoding="utf-8") as fh:
             fh.write("not json {")
         # Should not raise — corrupt registry is replaced fresh.
         brain_edits.log_brain_edit(
@@ -205,7 +205,7 @@ class BrainEdits(unittest.TestCase):
             edit_type="x",
             project_name="project_a",
         )
-        with open(registry_path, "r") as fh:
+        with open(registry_path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
         self.assertEqual(len(payload["entries"]), 1)
 

--- a/tests/test_cdl_and_install_config.py
+++ b/tests/test_cdl_and_install_config.py
@@ -380,7 +380,7 @@ class InstallConfigTests(unittest.TestCase):
         self.assertEqual(run_mock.call_args.kwargs["env"]["PYTHONPATH"], "modules")
 
     def test_windows_stdio_helper_disables_newline_translation(self):
-        source = (PROJECT_ROOT / "src" / "utils" / "mcp_stdio.py").read_text()
+        source = (PROJECT_ROOT / "src" / "utils" / "mcp_stdio.py").read_text(encoding="utf-8")
         self.assertIn('newline=""', source)
 
 
@@ -476,12 +476,12 @@ class ConfigMergeTests(unittest.TestCase):
                 '  "theme": "One Dark",\n'
                 '  "terminal": { "env": { "PATH": "/custom/bin:$PATH" } },\n'
                 "}\n"
-            )
+            , encoding="utf-8")
 
             success, _ = self._write_config(config_path)
             self.assertTrue(success)
 
-            result = json.loads(config_path.read_text())
+            result = json.loads(config_path.read_text(encoding="utf-8"))
             # Existing keys survive the merge.
             self.assertEqual(result["theme"], "One Dark")
             self.assertEqual(result["terminal"]["env"]["PATH"], "/custom/bin:$PATH")
@@ -493,12 +493,12 @@ class ConfigMergeTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_path = Path(tmp) / "settings.json"
-            config_path.write_text(json.dumps({"theme": "Ayu", "lsp": {"x": 1}}))
+            config_path.write_text(json.dumps({"theme": "Ayu", "lsp": {"x": 1}}), encoding="utf-8")
 
             success, _ = self._write_config(config_path)
             self.assertTrue(success)
 
-            result = json.loads(config_path.read_text())
+            result = json.loads(config_path.read_text(encoding="utf-8"))
             self.assertEqual(result["theme"], "Ayu")
             self.assertEqual(result["lsp"], {"x": 1})
             self.assertIn("davinci-resolve", result["context_servers"])
@@ -509,14 +509,14 @@ class ConfigMergeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             config_path = Path(tmp) / "settings.json"
             garbage = '{ "theme": "One Dark" this is not valid json at all '
-            config_path.write_text(garbage)
+            config_path.write_text(garbage, encoding="utf-8")
 
             success, message = self._write_config(config_path)
 
             self.assertFalse(success)
             self.assertIn("could not be parsed", message)
             # The original file must be left untouched.
-            self.assertEqual(config_path.read_text(), garbage)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), garbage)
 
     def test_missing_file_is_created(self):
         import tempfile
@@ -527,7 +527,7 @@ class ConfigMergeTests(unittest.TestCase):
             success, _ = self._write_config(config_path)
             self.assertTrue(success)
 
-            result = json.loads(config_path.read_text())
+            result = json.loads(config_path.read_text(encoding="utf-8"))
             self.assertIn("davinci-resolve", result["context_servers"])
 
     def test_opencode_config_merges_with_opencode_schema(self):
@@ -550,7 +550,7 @@ class ConfigMergeTests(unittest.TestCase):
                         "mcp": {"other-server": {"type": "local", "enabled": True}},
                     }
                 )
-            )
+            , encoding="utf-8")
             opencode_client["get_path"] = lambda: config_path
 
             success, _ = install.write_client_config(
@@ -562,7 +562,7 @@ class ConfigMergeTests(unittest.TestCase):
             )
             self.assertTrue(success)
 
-            result = json.loads(config_path.read_text())
+            result = json.loads(config_path.read_text(encoding="utf-8"))
             # Existing keys and sibling servers survive the merge.
             self.assertEqual(result["theme"], "tokyonight")
             self.assertIn("other-server", result["mcp"])
@@ -599,7 +599,7 @@ class ConfigMergeTests(unittest.TestCase):
             success, message = self._write_codex(config_path)
             self.assertTrue(success, message)
 
-            entry = _parse_toml(config_path.read_text())["mcp_servers"]["davinci-resolve"]
+            entry = _parse_toml(config_path.read_text(encoding="utf-8"))["mcp_servers"]["davinci-resolve"]
             self.assertEqual(entry["command"], "/tmp/python")
             self.assertEqual(entry["args"], ["/tmp/server.py"])
 
@@ -614,12 +614,12 @@ class ConfigMergeTests(unittest.TestCase):
                 "[mcp_servers.other]\n"
                 'command = "npx"\n'
                 'args = ["-y", "other-mcp"]\n'
-            )
+            , encoding="utf-8")
 
             success, message = self._write_codex(config_path)
             self.assertTrue(success, message)
 
-            text = config_path.read_text()
+            text = config_path.read_text(encoding="utf-8")
             parsed = _parse_toml(text)
             self.assertEqual(parsed["model"], "gpt-5-codex")
             self.assertEqual(parsed["approval_policy"], "on-request")
@@ -642,12 +642,12 @@ class ConfigMergeTests(unittest.TestCase):
                 "\n"
                 "[mcp_servers.other]\n"
                 'command = "npx"\n'
-            )
+            , encoding="utf-8")
 
             success, message = self._write_codex(config_path)
             self.assertTrue(success, message)
 
-            text = config_path.read_text()
+            text = config_path.read_text(encoding="utf-8")
             parsed = _parse_toml(text)
             self.assertEqual(
                 parsed["mcp_servers"]["davinci-resolve"]["command"], "/tmp/python"
@@ -657,7 +657,7 @@ class ConfigMergeTests(unittest.TestCase):
             self.assertEqual(parsed["mcp_servers"]["other"]["command"], "npx")
             # Rewriting twice is idempotent — no duplicate table.
             self._write_codex(config_path)
-            self.assertEqual(config_path.read_text().count("[mcp_servers.davinci-resolve]"), 1)
+            self.assertEqual(config_path.read_text(encoding="utf-8").count("[mcp_servers.davinci-resolve]"), 1)
 
     def test_codex_invalid_toml_is_not_overwritten(self):
         if install._toml_loader() is None:
@@ -665,13 +665,13 @@ class ConfigMergeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             config_path = Path(tmp) / "config.toml"
             garbage = 'model = "gpt-5-codex\n[oops\n'
-            config_path.write_text(garbage)
+            config_path.write_text(garbage, encoding="utf-8")
 
             success, message = self._write_codex(config_path)
 
             self.assertFalse(success)
             self.assertIn("not valid TOML", message)
-            self.assertEqual(config_path.read_text(), garbage)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), garbage)
 
     def test_codex_inline_definition_is_refused_not_duplicated(self):
         # An inline `davinci-resolve = { ... }` cannot be spliced line-by-line;
@@ -683,13 +683,13 @@ class ConfigMergeTests(unittest.TestCase):
                 "[mcp_servers]\n"
                 'davinci-resolve = { command = "/old/python", args = ["/old/server.py"] }\n'
             )
-            config_path.write_text(original)
+            config_path.write_text(original, encoding="utf-8")
 
             success, message = self._write_codex(config_path)
 
             self.assertFalse(success)
             self.assertIn("manually", message)
-            self.assertEqual(config_path.read_text(), original)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original)
 
     def test_codex_merge_preserves_per_tool_subtables(self):
         # A hand-written Codex config puts per-tool approval modes in
@@ -710,12 +710,12 @@ class ConfigMergeTests(unittest.TestCase):
                 "\n"
                 "[mcp_servers.other]\n"
                 'command = "npx"\n'
-            )
+            , encoding="utf-8")
 
             success, message = self._write_codex(config_path)
             self.assertTrue(success, message)
 
-            text = config_path.read_text()
+            text = config_path.read_text(encoding="utf-8")
             entry = _parse_toml(text)["mcp_servers"]["davinci-resolve"]
             self.assertEqual(entry["command"], "/tmp/python")
             self.assertEqual(entry["tools"]["timeline"]["approval_mode"], "approve")
@@ -742,12 +742,12 @@ class ConfigMergeTests(unittest.TestCase):
                 '  "/old/server.py",\n'
                 "]\n"
                 "tool_timeout_sec = 90\n"
-            )
+            , encoding="utf-8")
 
             success, message = self._write_codex(config_path)
             self.assertTrue(success, message)
 
-            text = config_path.read_text()
+            text = config_path.read_text(encoding="utf-8")
             entry = _parse_toml(text)["mcp_servers"]["davinci-resolve"]
             self.assertEqual(entry["command"], "/tmp/python")
             self.assertEqual(entry["args"], ["/tmp/server.py"])
@@ -769,12 +769,12 @@ class ConfigMergeTests(unittest.TestCase):
                 "\n"
                 "[mcp_servers.davinci-resolve.tools.timeline]\n"
                 'approval_mode = "approve"\n'
-            )
+            , encoding="utf-8")
 
             self._write_codex(config_path)
-            once = config_path.read_text()
+            once = config_path.read_text(encoding="utf-8")
             self._write_codex(config_path)
-            self.assertEqual(config_path.read_text(), once)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), once)
 
     def test_codex_dry_run_writes_nothing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -854,7 +854,7 @@ class AntigravityConfigPathTests(unittest.TestCase):
             for rel in existing:
                 target = fake_home / rel
                 target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_text("{}\n")
+                target.write_text("{}\n", encoding="utf-8")
             with patch.object(install, "home", return_value=fake_home):
                 resolved = install.antigravity_config()
             return resolved.relative_to(fake_home).as_posix()

--- a/tests/test_control_panel_auth.py
+++ b/tests/test_control_panel_auth.py
@@ -299,7 +299,7 @@ class PrivateStateTest(unittest.TestCase):
                 self.assertEqual(d, tmp)
                 path = os.path.join(d, "x.json")
                 # Pre-existing world-readable file must not survive.
-                with open(path, "w") as fh:
+                with open(path, "w", encoding="utf-8") as fh:
                     fh.write("old")
                 os.chmod(path, 0o644)
                 private_state.write_private_json(path, {"token": "s"})

--- a/tests/test_dashboard_transport.py
+++ b/tests/test_dashboard_transport.py
@@ -29,7 +29,7 @@ class DashboardTransportTest(unittest.TestCase):
         T.write_transport_state("streamable-http", "127.0.0.1", 8799, "tok")
         # ensure the state pid is this (alive) process so read_transport_state keeps it
         import json
-        with open(T.TRANSPORT_STATE_PATH, "w") as fh:
+        with open(T.TRANSPORT_STATE_PATH, "w", encoding="utf-8") as fh:
             json.dump({"transport": "streamable-http", "host": "127.0.0.1", "port": 8799,
                        "url": "http://127.0.0.1:8799", "token": "tok", "loopback": True,
                        "pid": os.getpid()}, fh)

--- a/tests/test_destructive_decorator_coverage.py
+++ b/tests/test_destructive_decorator_coverage.py
@@ -26,7 +26,7 @@ SERVER_PATH = os.path.join(
 class DestructiveDecoratorCoverage(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        with open(SERVER_PATH, "r") as fh:
+        with open(SERVER_PATH, "r", encoding="utf-8") as fh:
             cls.source = fh.read()
 
     def test_every_registered_tool_is_decorated(self) -> None:

--- a/tests/test_destructive_registry_drift.py
+++ b/tests/test_destructive_registry_drift.py
@@ -47,7 +47,7 @@ def _implemented_actions(fn):
 
 def _destructive_op_tools():
     """Map @_destructive_op("tool") -> set of implemented action strings."""
-    tree = ast.parse(SERVER.read_text())
+    tree = ast.parse(SERVER.read_text(encoding="utf-8"))
     out = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef):

--- a/tests/test_doc_tool_counts.py
+++ b/tests/test_doc_tool_counts.py
@@ -57,7 +57,7 @@ def _count_decorators(*rel_globs: str) -> int:
 
 
 def _advanced_count() -> int:
-    idx = (ROOT / "resolve-advanced" / "server" / "index.mjs").read_text()
+    idx = (ROOT / "resolve-advanced" / "server" / "index.mjs").read_text(encoding="utf-8")
     m = re.search(r"const TOOLS\s*=\s*\[([^\]]+)\]", idx)
     if not m:
         raise AssertionError("could not find the TOOLS array in resolve-advanced/server/index.mjs")
@@ -102,7 +102,7 @@ class DocToolCountsDriftTest(unittest.TestCase):
 
         stale = []
         for rel, needle in checks:
-            text = (ROOT / rel).read_text()
+            text = (ROOT / rel).read_text(encoding="utf-8")
             if needle not in text:
                 stale.append(f"{rel}: expected to contain {needle!r}")
 
@@ -112,7 +112,7 @@ class DocToolCountsDriftTest(unittest.TestCase):
         # went out to every agent. Any *other* number in front of the phrase is
         # drift, wherever it sits.
         for rel in ("src/server.py", "docs/SKILL.md", "docs/contributing.md"):
-            text = (ROOT / rel).read_text()
+            text = (ROOT / rel).read_text(encoding="utf-8")
             for wrong in re.findall(r"\b(\d+)\s+compound tools", text):
                 if int(wrong) != comp:
                     stale.append(

--- a/tests/test_doctor_paths.py
+++ b/tests/test_doctor_paths.py
@@ -224,7 +224,7 @@ class EscapedPathMatchingTests(unittest.TestCase):
         path = self._write(json.dumps({"args": [needle]}))
         # Round-tripping through json is the point: this is the escaping doctor
         # reads back off disk, not a hand-written approximation of it.
-        self.assertIn("\\\\", path.read_text())
+        self.assertIn("\\\\", path.read_text(encoding="utf-8"))
         ok, detail = doctor.file_contains(path, [needle])
         self.assertTrue(ok, detail)
 
@@ -327,10 +327,10 @@ class ResolveProbeLifecycleTests(unittest.TestCase):
         modules = root / "modules"
         utils.mkdir(parents=True)
         modules.mkdir()
-        (repo / "src" / "__init__.py").write_text("")
-        (utils / "__init__.py").write_text("")
-        (utils / "resolve_connection.py").write_text(helper)
-        (modules / "DaVinciResolveScript.py").write_text(dvr)
+        (repo / "src" / "__init__.py").write_text("", encoding="utf-8")
+        (utils / "__init__.py").write_text("", encoding="utf-8")
+        (utils / "resolve_connection.py").write_text(helper, encoding="utf-8")
+        (modules / "DaVinciResolveScript.py").write_text(dvr, encoding="utf-8")
         return repo, modules
 
     def test_bridge_first_skips_native_fusion_import(self) -> None:

--- a/tests/test_fuse_dctl_authoring.py
+++ b/tests/test_fuse_dctl_authoring.py
@@ -577,7 +577,7 @@ class TestRoundtripFilesystem(unittest.TestCase):
         # Drop a non-MCP file in the Fuses dir; default list should hide it.
         os.makedirs(self.fake_paths['fuses_dir'], exist_ok=True)
         non_mcp_path = os.path.join(self.fake_paths['fuses_dir'], 'Foreign.fuse')
-        with open(non_mcp_path, 'w') as f:
+        with open(non_mcp_path, 'w', encoding="utf-8") as f:
             f.write("-- not authored by MCP\nFuRegisterClass()\n")
 
         try:

--- a/tests/test_grade_loop.py
+++ b/tests/test_grade_loop.py
@@ -90,7 +90,7 @@ class TestCubeLut(unittest.TestCase):
 
     def test_one_dimensional_lut_is_refused_by_name(self):
         path = os.path.join(self.dir, "curve.cube")
-        with open(path, "w") as handle:
+        with open(path, "w", encoding="utf-8") as handle:
             handle.write("LUT_1D_SIZE 4\n0 0 0\n0.3 0.3 0.3\n0.6 0.6 0.6\n1 1 1\n")
         with self.assertRaises(cube_lut.CubeLutError) as caught:
             cube_lut.read_cube(path)
@@ -98,7 +98,7 @@ class TestCubeLut(unittest.TestCase):
 
     def test_truncated_table_is_refused(self):
         path = os.path.join(self.dir, "short.cube")
-        with open(path, "w") as handle:
+        with open(path, "w", encoding="utf-8") as handle:
             handle.write("LUT_3D_SIZE 4\n0 0 0\n1 1 1\n")
         with self.assertRaises(cube_lut.CubeLutError):
             cube_lut.read_cube(path)
@@ -288,7 +288,7 @@ class TestPlanAndValidation(unittest.TestCase):
         self.source = os.path.join(self.dir, "source.mov")
         pathlib.Path(self.source).write_bytes(b"x")
         self.lut = os.path.join(self.dir, "look.cube")
-        pathlib.Path(self.lut).write_text("LUT_3D_SIZE 2\n" + "0 0 0\n" * 8)
+        pathlib.Path(self.lut).write_text("LUT_3D_SIZE 2\n" + "0 0 0\n" * 8, encoding="utf-8")
 
     def test_plan_reports_the_budget_and_touches_nothing(self):
         before = sorted(os.listdir(self.dir))
@@ -424,7 +424,7 @@ class TestToolSurface(unittest.TestCase):
         source = os.path.join(directory, "s.mov")
         pathlib.Path(source).write_bytes(b"x")
         lut = os.path.join(directory, "l.cube")
-        pathlib.Path(lut).write_text("LUT_3D_SIZE 2\n" + "0 0 0\n" * 8)
+        pathlib.Path(lut).write_text("LUT_3D_SIZE 2\n" + "0 0 0\n" * 8, encoding="utf-8")
         result = self._call(action="grade_loop",
                             params={"source_path": source, "lut_path": lut, "times": [0.0]})
         self.assertTrue(result["dry_run"])

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -11,7 +11,7 @@ GRANULAR_DIR = PROJECT_ROOT / "src" / "granular"
 
 
 def _parse(path: Path) -> ast.AST:
-    return ast.parse(path.read_text())
+    return ast.parse(path.read_text(encoding="utf-8"))
 
 
 def _is_mcp_tool_decorator(decorator: ast.expr) -> bool:
@@ -98,7 +98,7 @@ class McpSdkPinTest(unittest.TestCase):
         # lets a fresh install resolve to 2.x. Conditional on server.py's
         # import so the guard retires itself when the server is ported to the
         # 2.x layout, rather than blocking that port.
-        server_src = (PROJECT_ROOT / "src" / "server.py").read_text()
+        server_src = (PROJECT_ROOT / "src" / "server.py").read_text(encoding="utf-8")
         if "from mcp.server.fastmcp import" not in server_src:
             self.skipTest("server.py no longer imports mcp.server.fastmcp")
 
@@ -114,7 +114,7 @@ class McpSdkPinTest(unittest.TestCase):
         ]
         specs += [
             line.strip()
-            for line in (PROJECT_ROOT / "requirements.txt").read_text().splitlines()
+            for line in (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
             if line.strip().startswith("mcp[cli]")
         ]
         self.assertGreaterEqual(
@@ -131,7 +131,7 @@ class McpSdkPinTest(unittest.TestCase):
 
 
 def test_npm_package_metadata():
-    package = json.loads((PROJECT_ROOT / "package.json").read_text())
+    package = json.loads((PROJECT_ROOT / "package.json").read_text(encoding="utf-8"))
     assert package["name"] == "davinci-resolve-mcp"
     # Every VERSION stamp must move together — src/granular/common.py drifted
     # unguarded through at least one release before it was added here.
@@ -153,8 +153,8 @@ def test_package_lock_in_sync():
 
     Regenerate with `npm install --package-lock-only`, and commit the result.
     """
-    package = json.loads((PROJECT_ROOT / "package.json").read_text())
-    lock = json.loads((PROJECT_ROOT / "package-lock.json").read_text())
+    package = json.loads((PROJECT_ROOT / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((PROJECT_ROOT / "package-lock.json").read_text(encoding="utf-8"))
     root = lock["packages"][""]
 
     assert lock["version"] == package["version"], (
@@ -186,7 +186,7 @@ def test_compound_tool_count():
 
 
 def test_prompt_registrations():
-    source = (PROJECT_ROOT / "src" / "server.py").read_text()
+    source = (PROJECT_ROOT / "src" / "server.py").read_text(encoding="utf-8")
     # 2 baseline (davinci_resolve_workflow + analyze_media) + 5 F2 workflow prompts
     # + 7 per-domain workflow routers.
     assert source.count("@mcp.prompt") == 14

--- a/tests/test_knowledge_tool.py
+++ b/tests/test_knowledge_tool.py
@@ -88,7 +88,7 @@ class TestResolution(unittest.TestCase):
         """`resolve-color` points at the colour decision guide; the guide must arrive."""
         resolved = knowledge.get("resolve-color")
         self.assertIn("docs/guides/color-decision-guide.md", resolved["inlined"])
-        guide_body = (knowledge.REPO_ROOT / "docs/guides/color-decision-guide.md").read_text()
+        guide_body = (knowledge.REPO_ROOT / "docs/guides/color-decision-guide.md").read_text(encoding="utf-8")
         # A distinctive line from the guide, not the path that pointed at it.
         sample = [line for line in guide_body.splitlines() if line.startswith("## ")][0]
         self.assertIn(sample.lstrip("# ").strip(), resolved["content"])
@@ -101,7 +101,7 @@ class TestResolution(unittest.TestCase):
         for reference in first_level:
             path = knowledge.REPO_ROOT / reference
             if path.is_file():
-                second_level |= set(knowledge._doc_references(path.read_text()))
+                second_level |= set(knowledge._doc_references(path.read_text(encoding="utf-8")))
         for reference in second_level - first_level:
             self.assertNotIn(
                 f"_Source: `{reference}`_", resolved,

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -307,7 +307,7 @@ def test_api():
     print(f"Pass rate: {ok/(ok+fail)*100:.1f}%")
 
     # Save results
-    with open('tests/live_api_results.json', 'w') as f:
+    with open('tests/live_api_results.json', 'w', encoding="utf-8") as f:
         json.dump(results, f, indent=2)
     print(f"\nDetailed results saved to tests/live_api_results.json")
 

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -36,7 +36,7 @@ class StateFileTest(unittest.TestCase):
 
     def test_stale_pid_treated_as_gone(self):
         import json
-        with open(T.TRANSPORT_STATE_PATH, "w") as fh:
+        with open(T.TRANSPORT_STATE_PATH, "w", encoding="utf-8") as fh:
             json.dump({"pid": 2 ** 31 - 1, "transport": "sse"}, fh)  # nonexistent pid
         self.assertIsNone(T.read_transport_state())
 

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -1301,7 +1301,7 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                 "clip_analysis_markers": {"markers": [], "marker_count": 0},
             }
             report_path = os.path.join(clip_dir, "analysis.json")
-            with open(report_path, "w") as handle:
+            with open(report_path, "w", encoding="utf-8") as handle:
                 json.dump(report, handle)
 
             clip = _PublishClipStub("clip-pub-1", "demo.mp4", media_file)
@@ -1388,7 +1388,7 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
                     ],
                 },
             }
-            with open(os.path.join(clip_dir, "analysis.json"), "w") as h:
+            with open(os.path.join(clip_dir, "analysis.json"), "w", encoding="utf-8") as h:
                 json.dump(report, h)
             jpeg = b"\xff\xd8\xff\xd9"
             with open(os.path.join(clip_dir, "frames", "sampled_0001.jpg"), "wb") as h:
@@ -4916,7 +4916,7 @@ class PathExistenceProbeTests(unittest.TestCase):
     def test_fresh_probe_reports_real_and_missing_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
             real = os.path.join(tmp, "a.mov")
-            open(real, "w").close()
+            open(real, "w", encoding="utf-8").close()
             missing = os.path.join(tmp, "gone.mov")
             result = self.dash._probe_paths_exist([real, missing, None, ""], probe=True)
         self.assertTrue(result[real])
@@ -4927,7 +4927,7 @@ class PathExistenceProbeTests(unittest.TestCase):
     def test_background_poll_reuses_cache_without_restating(self):
         with tempfile.TemporaryDirectory() as tmp:
             real = os.path.join(tmp, "a.mov")
-            open(real, "w").close()
+            open(real, "w", encoding="utf-8").close()
             # Warm the cache with a real probe, then delete the file.
             self.dash._probe_paths_exist([real], probe=True)
             os.remove(real)
@@ -4943,7 +4943,7 @@ class PathExistenceProbeTests(unittest.TestCase):
     def test_fresh_probe_restats_after_cache_cleared(self):
         with tempfile.TemporaryDirectory() as tmp:
             real = os.path.join(tmp, "a.mov")
-            open(real, "w").close()
+            open(real, "w", encoding="utf-8").close()
             self.dash._probe_paths_exist([real], probe=True)
             os.remove(real)
             self.dash._PATH_EXISTS_CACHE.clear()  # simulate TTL expiry
@@ -4999,7 +4999,7 @@ class InventoryCacheReuseTests(unittest.TestCase):
             entry = self._entry()
             self.assertEqual(self.dash._assemble_inventory_payload(tmp, entry)["counts"]["analyzed"], 0)
             os.makedirs(os.path.join(tmp, "clips", "a-key"))
-            with open(os.path.join(tmp, "clips", "a-key", "analysis.json"), "w") as fh:
+            with open(os.path.join(tmp, "clips", "a-key", "analysis.json"), "w", encoding="utf-8") as fh:
                 fh.write("{}")
             self.assertEqual(self.dash._assemble_inventory_payload(tmp, entry)["counts"]["analyzed"], 1)
 

--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -137,7 +137,7 @@ class TestAuthoring(unittest.TestCase):
     def test_otio_round_trips_through_our_own_parser(self):
         """Writing a file and Resolve honouring it are different claims; this is the first."""
         result = self._author("otio")
-        document = json.loads(pathlib.Path(result["output_path"]).read_text())
+        document = json.loads(pathlib.Path(result["output_path"]).read_text(encoding="utf-8"))
         self.assertEqual(document["OTIO_SCHEMA"].split(".")[0], "Timeline")
         clips = [
             child for track in document["tracks"]["children"]
@@ -153,7 +153,7 @@ class TestAuthoring(unittest.TestCase):
     def test_source_frames_are_timecode_absolute(self):
         """A source_range measured from zero imports as an EMPTY timeline in Resolve."""
         result = self._author("otio")
-        document = json.loads(pathlib.Path(result["output_path"]).read_text())
+        document = json.loads(pathlib.Path(result["output_path"]).read_text(encoding="utf-8"))
         clip = next(
             child for track in document["tracks"]["children"]
             for child in track["children"]
@@ -190,7 +190,7 @@ class TestAuthoring(unittest.TestCase):
         otio = offline_fallback.author(
             clips, os.path.join(self.dir, "keep.otio"), target="otio", fps=24)
         self.assertEqual([w["id"] for w in otio["warnings"]], [])
-        self.assertIn("LinearTimeWarp", pathlib.Path(otio["output_path"]).read_text())
+        self.assertIn("LinearTimeWarp", pathlib.Path(otio["output_path"]).read_text(encoding="utf-8"))
 
     def test_drt_names_the_resolve_version_it_targets(self):
         result = self._author("drt")
@@ -216,7 +216,7 @@ class TestAuthoring(unittest.TestCase):
 
     def test_edl_carries_the_record_timecode(self):
         result = self._author("edl")
-        text = pathlib.Path(result["output_path"]).read_text()
+        text = pathlib.Path(result["output_path"]).read_text(encoding="utf-8")
         self.assertIn("TITLE: Test", text)
         self.assertIn("00:00:00:00", text)
 

--- a/tests/test_panel_docs_drift.py
+++ b/tests/test_panel_docs_drift.py
@@ -37,8 +37,8 @@ def _labels_in_block(block: str) -> list[str]:
 class PanelDocsDriftTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.source = DASHBOARD.read_text()
-        cls.guide = GUIDE.read_text()
+        cls.source = DASHBOARD.read_text(encoding="utf-8")
+        cls.guide = GUIDE.read_text(encoding="utf-8")
         cls.guide_lower = cls.guide.lower()
 
     def test_every_panel_section_is_documented(self):
@@ -67,7 +67,7 @@ class PanelDocsDriftTest(unittest.TestCase):
 
     def test_no_orphaned_screenshots(self):
         referenced = set(re.findall(r"!\[[^\]]*\]\(\.\./images/control-panel/([^)]+)\)", self.guide))
-        readme = (ROOT / "README.md").read_text()
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
         referenced.update(re.findall(r"docs/images/control-panel/([\w.-]+)", readme))
         orphans = [p.name for p in IMAGES.glob("*.png") if p.name not in referenced]
         self.assertEqual(orphans, [], f"screenshots on disk that no doc references: {orphans}")

--- a/tests/test_persistence_safety.py
+++ b/tests/test_persistence_safety.py
@@ -23,13 +23,13 @@ class ReadJsonStrictTest(unittest.TestCase):
     def test_empty_file_returns_empty(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "e.json")
-            open(p, "w").close()
+            open(p, "w", encoding="utf-8").close()
             self.assertEqual(s._read_json_strict(p), {})
 
     def test_corrupt_existing_file_raises(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "c.json")
-            with open(p, "w") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write("{ not valid json ")
             with self.assertRaises(s.ConfigParseError):
                 s._read_json_strict(p)
@@ -37,7 +37,7 @@ class ReadJsonStrictTest(unittest.TestCase):
     def test_valid_file_parses(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "v.json")
-            with open(p, "w") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 json.dump({"a": 1}, fh)
             self.assertEqual(s._read_json_strict(p), {"a": 1})
 
@@ -45,38 +45,38 @@ class ReadJsonStrictTest(unittest.TestCase):
 class PreferencesClobberGuardTest(unittest.TestCase):
     def _corrupt_prefs(self, d):
         p = os.path.join(d, "media-analysis-preferences.json")
-        with open(p, "w") as fh:
+        with open(p, "w", encoding="utf-8") as fh:
             fh.write('{ "vision_default": "on",  <<corrupt>> ')
         return p
 
     def test_set_defaults_refuses_to_overwrite_corrupt_prefs(self):
         with tempfile.TemporaryDirectory() as d:
             p = self._corrupt_prefs(d)
-            before = open(p).read()
+            before = open(p, encoding="utf-8").read()
             with mock.patch.object(s, "_media_analysis_preferences_path", return_value=p):
                 out = s._setup_set_media_analysis_defaults({"vision_default": "off"}, dry_run=False)
             self.assertIn("error", out)
             # The corrupt file must be left untouched, not clobbered.
-            self.assertEqual(open(p).read(), before)
+            self.assertEqual(open(p, encoding="utf-8").read(), before)
 
     def test_set_ai_governance_refuses_on_corrupt_prefs(self):
         with tempfile.TemporaryDirectory() as d:
             p = self._corrupt_prefs(d)
-            before = open(p).read()
+            before = open(p, encoding="utf-8").read()
             with mock.patch.object(s, "_media_analysis_preferences_path", return_value=p):
                 out = s.media_pool_item("set_ai_governance", {"preset": "trusted"})
             self.assertIn("error", out)
-            self.assertEqual(open(p).read(), before)
+            self.assertEqual(open(p, encoding="utf-8").read(), before)
 
     def test_valid_prefs_still_write_and_merge(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "media-analysis-preferences.json")
-            with open(p, "w") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 json.dump({"vision_default": "on", "keep_me": "yes"}, fh)
             with mock.patch.object(s, "_media_analysis_preferences_path", return_value=p):
                 out = s._setup_set_media_analysis_defaults({"vision_default": "off"}, dry_run=False)
             self.assertNotIn("error", out)
-            saved = json.load(open(p))
+            saved = json.load(open(p, encoding="utf-8"))
             # Prior unrelated key preserved (merge, not clobber).
             self.assertEqual(saved.get("keep_me"), "yes")
             self.assertEqual(saved.get("vision_default"), "off")
@@ -86,7 +86,7 @@ class CorrectionsClobberGuardTest(unittest.TestCase):
     def test_strict_read_raises_on_corrupt(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "corrections.json")
-            with open(p, "w") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write("{ broken ")
             with self.assertRaises(s.ConfigParseError):
                 s._v2_read_corrections(p, strict=True)
@@ -94,7 +94,7 @@ class CorrectionsClobberGuardTest(unittest.TestCase):
     def test_nonstrict_read_still_defaults_on_corrupt(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "corrections.json")
-            with open(p, "w") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write("{ broken ")
             data = s._v2_read_corrections(p)  # read-only callers stay forgiving
             self.assertEqual(data["current"], {})
@@ -105,9 +105,9 @@ class CorrectionsClobberGuardTest(unittest.TestCase):
             clip_dir = os.path.join(d, "clip1")
             os.makedirs(clip_dir)
             corr = os.path.join(clip_dir, "corrections.json")
-            with open(corr, "w") as fh:
+            with open(corr, "w", encoding="utf-8") as fh:
                 fh.write('{ "current": { "clip:x:visual.shot_size": ... ')  # corrupt
-            before = open(corr).read()
+            before = open(corr, encoding="utf-8").read()
             with mock.patch.object(s, "_v2_corrections_path_for_clip", return_value=corr):
                 out = s._v2_update_field(
                     d,
@@ -115,7 +115,7 @@ class CorrectionsClobberGuardTest(unittest.TestCase):
                     entity_type="clip",
                 )
             self.assertIn("error", out)
-            self.assertEqual(open(corr).read(), before)  # human history preserved
+            self.assertEqual(open(corr, encoding="utf-8").read(), before)  # human history preserved
 
 
 class AtomicWriteTest(unittest.TestCase):
@@ -128,7 +128,7 @@ class AtomicWriteTest(unittest.TestCase):
                 # after a direct write of the file via the same pattern.
                 path = os.path.join(d, "bin_summary.md")
                 tmp = path + ".tmp"
-                with open(tmp, "w") as fh:
+                with open(tmp, "w", encoding="utf-8") as fh:
                     fh.write("x")
                 os.replace(tmp, path)
                 self.assertTrue(os.path.exists(path))
@@ -139,7 +139,7 @@ class AtomicWriteTest(unittest.TestCase):
             p = os.path.join(d, "update-check.json")
             with mock.patch.object(s, "update_state_path", return_value=p):
                 s._write_setup_update_state({"snooze_hours": 12, "mode": "notify"})
-            self.assertEqual(json.load(open(p)), {"snooze_hours": 12, "mode": "notify"})
+            self.assertEqual(json.load(open(p, encoding="utf-8")), {"snooze_hours": 12, "mode": "notify"})
             self.assertFalse(any(name.startswith("update-check.json.tmp") for name in os.listdir(d)))
 
 

--- a/tests/test_platform_paths.py
+++ b/tests/test_platform_paths.py
@@ -40,7 +40,7 @@ class ResolvePathEnvOverrideTest(unittest.TestCase):
     def test_existing_env_lib_overrides_default(self):
         with tempfile.TemporaryDirectory() as tmp:
             lib = os.path.join(tmp, "fusionscript.so")
-            with open(lib, "w"):
+            with open(lib, "w", encoding="utf-8"):
                 pass
             env = _env_without_overrides()
             env["RESOLVE_SCRIPT_LIB"] = lib

--- a/tests/test_project_spec.py
+++ b/tests/test_project_spec.py
@@ -80,7 +80,7 @@ class SpecLoadTest(unittest.TestCase):
     def test_load_json_file(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "spec.json")
-            with open(path, "w") as fh:
+            with open(path, "w", encoding="utf-8") as fh:
                 json.dump(SPEC_DICT, fh)
             spec = ps.load_spec(path)
             self.assertEqual(spec.project, "MyShow")

--- a/tests/test_readwrite_audit.py
+++ b/tests/test_readwrite_audit.py
@@ -74,10 +74,10 @@ class AuditTest(unittest.TestCase):
         point of it — but a bare assertEqual on two large documents says
         nothing about how to clear it, so name the regeneration command.
         """
-        src = (ROOT / "src" / "server.py").read_text()
+        src = (ROOT / "src" / "server.py").read_text(encoding="utf-8")
         doc = ROOT / "docs" / "reference" / "readwrite-symmetry.md"
         self.assertEqual(
-            doc.read_text(),
+            doc.read_text(encoding="utf-8"),
             audit_rw.render_report(src),
             f"docs/reference/readwrite-symmetry.md is stale. "
             f"Regenerate it with: {audit_rw.REGEN_COMMAND}",
@@ -88,7 +88,7 @@ class AuditTest(unittest.TestCase):
 
     def test_stdout_mode_does_not_write_the_report(self):
         doc = ROOT / "docs" / "reference" / "readwrite-symmetry.md"
-        before = doc.read_text()
+        before = doc.read_text(encoding="utf-8")
         original = audit_rw.DOC_PATH
         with tempfile.TemporaryDirectory() as tmp:
             audit_rw.DOC_PATH = os.path.join(tmp, "readwrite-symmetry.md")
@@ -99,7 +99,7 @@ class AuditTest(unittest.TestCase):
                 audit_rw.DOC_PATH = original
             self.assertFalse(os.path.exists(os.path.join(tmp, "readwrite-symmetry.md")))
         self.assertIn("# Read/Write Symmetry Audit", out.getvalue())
-        self.assertEqual(doc.read_text(), before)
+        self.assertEqual(doc.read_text(encoding="utf-8"), before)
 
     def test_named_action_list_is_scanned(self):
         src = '''

--- a/tests/test_resolve20_api.py
+++ b/tests/test_resolve20_api.py
@@ -266,7 +266,7 @@ def main():
         cleanup(pm, original_project_name)
 
     out_path = os.path.join(os.path.dirname(__file__), "test_resolve20_results.json")
-    with open(out_path, "w") as handle:
+    with open(out_path, "w", encoding="utf-8") as handle:
         json.dump(results, handle, indent=2)
 
     print("\n=== Results ===")

--- a/tests/test_resolve_bridge.py
+++ b/tests/test_resolve_bridge.py
@@ -417,7 +417,7 @@ class OperationSurfaceTests(unittest.TestCase):
     def test_media_paths_outside_the_roots_are_not_leaked(self) -> None:
         import os
         inside = os.path.join(self.ROOT, "a.mov")
-        open(inside, "w").close()
+        open(inside, "w", encoding="utf-8").close()
         ops = self._ops(clips=[("inside", inside), ("outside", "/etc/passwd")])
         by_name = {c["name"]: c["file_path"] for c in ops.dispatch("list_media", {})["clips"]}
         # Resolve's own path is returned verbatim (it is what relinking needs);
@@ -2600,7 +2600,7 @@ class BoundMethodKeywordTests(unittest.TestCase):
         import re
 
         root = pathlib.Path(__file__).resolve().parent.parent
-        api_doc = (root / "docs" / "reference" / "resolve_scripting_api.txt").read_text()
+        api_doc = (root / "docs" / "reference" / "resolve_scripting_api.txt").read_text(encoding="utf-8")
         api_methods = set(re.findall(r"^\s{2}([A-Z][A-Za-z0-9]+)\(", api_doc, re.M))
         self.assertGreater(len(api_methods), 100, "API doc parse looks broken")
 

--- a/tests/test_script_plugin.py
+++ b/tests/test_script_plugin.py
@@ -428,7 +428,7 @@ class TestRoundtripFilesystem(unittest.TestCase):
         edit_dir = os.path.join(self.fake_paths['scripts_root'], 'Edit')
         os.makedirs(edit_dir, exist_ok=True)
         foreign = os.path.join(edit_dir, 'Foreign.lua')
-        with open(foreign, 'w') as f:
+        with open(foreign, 'w', encoding="utf-8") as f:
             f.write("-- not authored by MCP\nprint('hi')\n")
 
         try:
@@ -537,7 +537,7 @@ class TestScriptExecution(unittest.TestCase):
         target_dir = os.path.join(self.fake_paths['scripts_root'], category)
         os.makedirs(target_dir, exist_ok=True)
         path = os.path.join(target_dir, f"{name}.{language}")
-        with open(path, 'w') as f:
+        with open(path, 'w', encoding="utf-8") as f:
             f.write(source)
         return path
 
@@ -809,10 +809,10 @@ class TestPythonScriptExitGuard(unittest.TestCase):
     def test_script_directory_is_on_sys_path_for_sibling_imports(self):
         from src.server import _execute_python_script
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, 'helper.py'), 'w') as f:
+            with open(os.path.join(d, 'helper.py'), 'w', encoding="utf-8") as f:
                 f.write("VALUE = 'from-sibling'\n")
             path = os.path.join(d, 'main.py')
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding="utf-8") as f:
                 f.write("import helper\nprint(helper.VALUE)\n")
             with patch('src.server.get_resolve', return_value=None):
                 r = _execute_python_script(path, [], timeout=30)

--- a/tests/test_scripting_lib_discovery.py
+++ b/tests/test_scripting_lib_discovery.py
@@ -69,7 +69,7 @@ def _windows_install(root: str) -> str:
     os.makedirs(root, exist_ok=True)
     exe = os.path.join(root, "Resolve.exe")
     for path in (exe, os.path.join(root, "fusionscript.dll")):
-        with open(path, "w"):
+        with open(path, "w", encoding="utf-8"):
             pass
     return exe
 
@@ -91,7 +91,7 @@ def _macos_install(root: str) -> str:
     os.makedirs(fusion, exist_ok=True)
     exe = f"{macos}/Resolve"
     for path in (exe, f"{fusion}/fusionscript.so"):
-        with open(path, "w"):
+        with open(path, "w", encoding="utf-8"):
             pass
     return exe
 
@@ -137,7 +137,7 @@ class RunningResolveLibTests(unittest.TestCase):
         """Derivation must confirm the file, not assume the layout."""
         with tempfile.TemporaryDirectory() as tmp:
             exe = os.path.join(tmp, "Resolve.exe")
-            with open(exe, "w"):
+            with open(exe, "w", encoding="utf-8"):
                 pass
             with mock.patch.object(rr.platform, "system", return_value="Windows"), \
                     mock.patch.object(rr.subprocess, "run", return_value=_ps(f'"{exe}"\n')):
@@ -208,7 +208,7 @@ class GetResolvePathsDiscoveryTests(unittest.TestCase):
     def test_discovery_fills_in_a_missing_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             lib = os.path.join(tmp, "fusionscript.so")
-            with open(lib, "w"):
+            with open(lib, "w", encoding="utf-8"):
                 pass
             with mock.patch.object(platform_utils, "get_platform", return_value="darwin"), \
                     mock.patch.object(platform_utils, "discover_scripting_lib", return_value=lib), \
@@ -222,7 +222,7 @@ class GetResolvePathsDiscoveryTests(unittest.TestCase):
             override = os.path.join(tmp, "override.so")
             discovered = os.path.join(tmp, "discovered.so")
             for path in (override, discovered):
-                with open(path, "w"):
+                with open(path, "w", encoding="utf-8"):
                     pass
             env = _env_without_overrides()
             env["RESOLVE_SCRIPT_LIB"] = override
@@ -268,7 +268,7 @@ class InstallerEnvTests(unittest.TestCase):
     def test_find_resolve_paths_falls_back_to_discovery(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             lib = os.path.join(tmp, "fusionscript.dll")
-            with open(lib, "w"):
+            with open(lib, "w", encoding="utf-8"):
                 pass
             with mock.patch.object(install, "RESOLVE_PATHS", _resolve_paths_with_api(tmp)), \
                     mock.patch.object(platform_utils, "discover_scripting_lib", return_value=lib), \
@@ -280,7 +280,7 @@ class InstallerEnvTests(unittest.TestCase):
     def test_an_env_override_is_preferred_over_discovery(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             override = os.path.join(tmp, "override.dll")
-            with open(override, "w"):
+            with open(override, "w", encoding="utf-8"):
                 pass
             env = _env_without_overrides()
             env["RESOLVE_SCRIPT_LIB"] = override

--- a/tests/test_timeline_versioning.py
+++ b/tests/test_timeline_versioning.py
@@ -46,7 +46,7 @@ class _MockTimeline:
         self.duplicates.append(new_name)
         return _MockTimeline(new_name, unique_id=f"{self._unique_id}_dup")
     def Export(self, path: str, export_type: int) -> bool:
-        with open(path, "w") as fh:
+        with open(path, "w", encoding="utf-8") as fh:
             fh.write(f"FAKE DRT for {self._name}")
         return True
 

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -68,7 +68,7 @@ class UpdateCheckTests(unittest.TestCase):
             self.assertEqual(cached["status"], "update_available")
             self.assertTrue(cached["cached"])
             self.assertEqual(urlopen.call_count, 1)
-            self.assertEqual(json.loads(state_path.read_text())["status"], "update_available")
+            self.assertEqual(json.loads(state_path.read_text(encoding="utf-8"))["status"], "update_available")
 
     def test_check_for_updates_can_be_disabled(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -101,7 +101,7 @@ class UpdateCheckTests(unittest.TestCase):
 
             self.assertEqual(result["status"], "disabled")
             self.assertEqual(result["update_mode"], "never")
-            self.assertEqual(json.loads(state_path.read_text())["update_mode"], "never")
+            self.assertEqual(json.loads(state_path.read_text(encoding="utf-8"))["update_mode"], "never")
 
     def test_update_prompt_decision_respects_ignore_snooze_and_auto(self):
         base = {

--- a/tests/test_update_hardening.py
+++ b/tests/test_update_hardening.py
@@ -128,7 +128,7 @@ class RestartMarker(unittest.TestCase):
     def test_marker_handles_corrupt_json(self) -> None:
         from src.analysis_dashboard import _read_restart_marker
         os.makedirs(os.path.join(self.tmp, "logs"), exist_ok=True)
-        with open(os.path.join(self.tmp, "logs", ".mcp_restart_needed"), "w") as fh:
+        with open(os.path.join(self.tmp, "logs", ".mcp_restart_needed"), "w", encoding="utf-8") as fh:
             fh.write("not json")
         marker = _read_restart_marker(self.tmp)
         # File exists → marker still reads as needed even when corrupt.

--- a/tests/test_update_history.py
+++ b/tests/test_update_history.py
@@ -35,7 +35,7 @@ class UpdateHistoryRecording(unittest.TestCase):
         )
         path = self._history_path()
         self.assertTrue(os.path.isfile(path))
-        with open(path, "r") as fh:
+        with open(path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
         self.assertEqual(len(payload["entries"]), 1)
         entry = payload["entries"][0]
@@ -64,7 +64,7 @@ class UpdateHistoryRecording(unittest.TestCase):
                 self.tmp, kind="update", success=True,
                 from_version="x", to_version=str(i), initiator="test",
             )
-        with open(self._history_path(), "r") as fh:
+        with open(self._history_path(), "r", encoding="utf-8") as fh:
             payload = json.load(fh)
         self.assertEqual(len(payload["entries"]), 200)
         # Oldest should be entry 20 (220 - 200), newest 219
@@ -73,14 +73,14 @@ class UpdateHistoryRecording(unittest.TestCase):
 
     def test_history_survives_corrupt_file(self) -> None:
         os.makedirs(os.path.join(self.tmp, "logs"), exist_ok=True)
-        with open(self._history_path(), "w") as fh:
+        with open(self._history_path(), "w", encoding="utf-8") as fh:
             fh.write("{not json")
         # Should not crash; corrupted file is replaced with a fresh history.
         install._record_attempt(
             self.tmp, kind="update", success=True,
             from_version="x", to_version="y", initiator="test",
         )
-        with open(self._history_path(), "r") as fh:
+        with open(self._history_path(), "r", encoding="utf-8") as fh:
             payload = json.load(fh)
         self.assertEqual(len(payload["entries"]), 1)
 


### PR DESCRIPTION
## Summary
- `Path.read_text()` / `write_text()` / `open()` fall back to the OS locale encoding when `encoding=` isn't passed. On Windows (cp1252 by default) this crashes with `UnicodeDecodeError` as soon as a read target contains non-ASCII bytes — reproduced by running `python tests/test_import.py` on Windows without `PYTHONUTF8=1`, which fails parsing `src/server.py` at byte `0x90`.
- Patched every `open()` / `.open()` / `.read_text()` / `.write_text()` call in `tests/` and `scripts/` that omitted `encoding=`, via an AST-based rewrite (not regex) so binary-mode opens and calls that already pass `encoding=` were left untouched. 151 call sites across 47 files.
- One category needed manual exclusion: `PIL.Image.open()` also ends in `.open(...)` but doesn't accept `encoding=` — those 3 sites (in `scripts/contact_sheet.py` / `tests/test_contact_sheet.py`) were left as-is.

## Test plan
- [x] `python tests/test_import.py` passes with no `PYTHONUTF8=1` workaround (previously crashed with `UnicodeDecodeError` on Windows).
- [x] `python -m unittest tests.test_static_undefined_names tests.test_action_list_drift tests.test_panel_docs_drift tests.test_api_limitations_doc tests.test_doc_tool_counts tests.test_import` (the CI static-guard invocation) passes.
- [x] Full suite (`python -m unittest discover -s tests -p "test_*.py"`, 1862 tests) run before and after this change: identical failure/error set in both runs (27 failures / 186 errors / 5 skipped, all pre-existing and either live-Resolve-connection-dependent or platform-dependent — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)