### PR TITLE
Fix Windows UnicodeDecodeError risk in src/ (missing encoding="utf-8")

### DIFF
--- a/src/utils/brain_edits.py
+++ b/src/utils/brain_edits.py
@@ -348,7 +348,7 @@ def update_brain_edits_registry(
     payload: Dict[str, Any]
     if os.path.isfile(path):
         try:
-            with open(path, "r") as fh:
+            with open(path, "r", encoding="utf-8") as fh:
                 payload = json.load(fh)
         except (OSError, json.JSONDecodeError):
             payload = {"entries": []}
@@ -368,7 +368,7 @@ def update_brain_edits_registry(
     payload["updated_at"] = _now_iso()
 
     tmp_path = path + ".tmp"
-    with open(tmp_path, "w") as fh:
+    with open(tmp_path, "w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2, default=str)
     os.replace(tmp_path, path)
     return {"success": True, "registry_path": path, "entry_count": len(entries)}
@@ -379,7 +379,7 @@ def read_brain_edits_registry(project_root: str) -> Dict[str, Any]:
     if not os.path.isfile(path):
         return {"entries": [], "registry_path": path}
     try:
-        with open(path, "r") as fh:
+        with open(path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
     except (OSError, json.JSONDecodeError):
         return {"entries": [], "registry_path": path}

--- a/src/utils/page_lock.py
+++ b/src/utils/page_lock.py
@@ -49,7 +49,7 @@ def page_lock():
     try:
         if _depth == 1 and _HAS_FCNTL:
             try:
-                _fh = open(_LOCKFILE, "w")
+                _fh = open(_LOCKFILE, "w", encoding="utf-8")
                 fcntl.flock(_fh, fcntl.LOCK_EX)
             except OSError:
                 # Advisory lock is best-effort; never block real work on it.


### PR DESCRIPTION
## Summary
- Follow-up to #174, same root cause: `open()`/`.read_text()`/`.write_text()` without `encoding=` fall back to the OS locale encoding — cp1252 on Windows — and crash with `UnicodeDecodeError` on non-ASCII content.
- `src/` was largely already careful about this (most read/write calls already pass `encoding=` or use binary mode). Swept the whole tree with the same AST-based patcher used for #174 and found only 2 real gaps:
  - `src/utils/brain_edits.py`: 3 sites — the brain-edits JSON registry read/write.
  - `src/utils/page_lock.py`: 1 site — the advisory lockfile open.
- Left untouched, by design (not oversights): `os.open()` in `src/utils/private_state.py` (low-level fd API, no `encoding` param), `webbrowser.open()` in `src/analysis_dashboard.py` (opens a URL, unrelated function), and `Image.open()` / `PILImage.open()` in `src/utils/embeddings.py` and `src/utils/analysis_caps.py` (Pillow, rejects `encoding=`). All match the naive `.open(` text pattern but aren't Path/file opens — verified individually and excluded from the automated pass.

## Test plan
- [x] `python -m py_compile` on both changed files.
- [x] Full suite (`python -m unittest discover -s tests -p "test_*.py"`, 1874 tests on current `main`) run before and after this change: identical failure/error set in both runs (27 failures / 186 errors / 5 skipped, all pre-existing and unrelated — live-Resolve-connection-dependent or platform-dependent).
- Note: this repo's `tests/test_import.py` currently needs `PYTHONUTF8=1` to run at all on Windows (that's what #174 fixes) — used here only to unblock verification of this independent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)