### PR TITLE
Fix Windows UnicodeDecodeError risk in install.py client-config read/write

### DIFF
--- a/install.py
+++ b/install.py
@@ -1091,7 +1091,7 @@ def read_json(path):
     existing settings (issue #71: Zed's settings.json ships with comments).
     """
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             raw = f.read()
     except FileNotFoundError:
         return {}
@@ -1120,7 +1120,7 @@ def write_json(path, data):
         backup = path.with_suffix(path.suffix + ".backup")
         shutil.copy2(path, backup)
 
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
         f.write("\n")
 


### PR DESCRIPTION
## Summary
- Third and final follow-up to #174 and #175, same root cause: `open()` without `encoding=` falls back to the OS locale encoding — cp1252 on Windows — and crashes with `UnicodeDecodeError` on non-ASCII content.
- `install.py`: 2 sites, both in `read_json()` / `write_json()`. These are the core client-config helpers used for every supported editor's `settings.json` (Claude Desktop, Zed, Cursor, VS Code, Windsurf, Cline, Roo Code, Continue, OpenCode). A config file containing any non-ASCII character — a comment, an accented username in a path, a curly quote — would break the installer on Windows.
- `resolve-advanced/` was swept as well and needed **no changes**. It contains only two Python files (`server/aaf_probe.py` and `vendor/conform-qc/adapters/resolve/driver.py`); every text read/write in them already specifies an encoding or uses binary mode.
  - `aaf_probe.py`'s single `.open(` call is `aaf2.open()` — pyaaf2's binary AAF container reader, which does not take a text encoding — left untouched by design, consistent with the `os.open` / `webbrowser.open` / Pillow exclusions in #175.

## Test plan
- [x] `python -m py_compile install.py`.
- [x] Roundtrip test against the two changed functions: wrote a UTF-8 `settings.json` containing non-ASCII characters (`café — non-ascii`), read it back via `read_json()`, added an accented value, and wrote it out via `write_json()`. Both succeed; before this change `read_json()` raised `UnicodeDecodeError` on that input under a cp1252 locale.
- Note: `install.py`'s unit coverage lives in `tests/test_cdl_and_install_config.py`, which is itself part of #174; this PR does not touch it.

## Relationship to the other PRs
Independent — this PR touches only `install.py` and can merge in any order relative to #174 and #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)