### PR TITLE
feat(bridge): honor custom config path in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ python scripts/install_resolve_bridge.py
 # restart Resolve, open a project, then: Workspace > Scripts > resolve_bridge
 ```
 
+The installer and MCP client use `~/.config/davinci-resolve-mcp/bridge.json`
+by default. To keep the authenticated bridge config elsewhere, set
+`DAVINCI_RESOLVE_BRIDGE_CONFIG` while running the installer and in the MCP
+client environment; both sides will use that path.
+
 Once that listener is running it is used **automatically** whenever external
 scripting is unavailable — no environment variable required. Setting
 `DAVINCI_RESOLVE_BRIDGE=1` *forces* the bridge instead: it becomes the only

--- a/scripts/install_resolve_bridge.py
+++ b/scripts/install_resolve_bridge.py
@@ -24,9 +24,16 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-CONFIG_DIR = Path.home() / ".config/davinci-resolve-mcp"
-CONFIG_PATH = CONFIG_DIR / "bridge.json"
+DEFAULT_CONFIG_PATH = Path.home() / ".config/davinci-resolve-mcp/bridge.json"
+ENV_CONFIG_PATH = "DAVINCI_RESOLVE_BRIDGE_CONFIG"
 DEFAULT_PORT = 49632
+
+
+def config_path() -> Path:
+    """Bridge config written by this installer and read by the MCP client."""
+    override = os.environ.get(ENV_CONFIG_PATH)
+    return Path(override).expanduser() if override else DEFAULT_CONFIG_PATH
+
 
 _SCRIPTS_SUFFIX = "Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility"
 
@@ -448,10 +455,11 @@ def python_preflight() -> dict:
 
 
 def ensure_config(port: int, rotate: bool) -> dict:
+    path = config_path()
     existing: dict = {}
-    if CONFIG_PATH.exists():
+    if path.exists():
         try:
-            existing = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+            existing = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             existing = {}
     token = existing.get("token")
@@ -469,12 +477,12 @@ def ensure_config(port: int, rotate: bool) -> dict:
         "allowed_media_roots": existing_media or [str(Path.home())],
         "allowed_output_roots": existing_output or [str(Path.home() / "Movies")],
     }
-    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    tmp = CONFIG_PATH.with_suffix(".tmp")
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(config, indent=2, sort_keys=True), encoding="utf-8")
     os.chmod(tmp, 0o600)
-    tmp.replace(CONFIG_PATH)
-    os.chmod(CONFIG_PATH, 0o600)
+    tmp.replace(path)
+    os.chmod(path, 0o600)
     return config
 
 
@@ -525,8 +533,9 @@ def install(*, probe_only: bool, port: int, rotate: bool) -> dict:
         )
     result["skipped"] = [path for path, _ in skipped]
     if not probe_only:
-        loaded = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        result["config"] = {"path": str(CONFIG_PATH),
+        path = config_path()
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        result["config"] = {"path": str(path),
                             **{k: v for k, v in loaded.items() if k != "token"}}
     return result
 
@@ -558,9 +567,10 @@ def _install_to(target: Path, *, probe_only: bool, installed: list[str]) -> None
     # unreachable by construction (measured: "Operation not permitted").
     # The runtime dir is already inside the container, so the config goes
     # beside the modules. Same token, so the out-of-sandbox client still
-    # authenticates against ~/.config.
+    # authenticates against the selected config path.
     runtime_config = runtime / "bridge.json"
-    shutil.copy2(CONFIG_PATH, runtime_config)
+    path = config_path()
+    shutil.copy2(path, runtime_config)
     os.chmod(runtime_config, 0o600)
     installed.append(str(runtime_config))
     # The launcher IS the menu entry. Without it the modules sit in the
@@ -571,7 +581,7 @@ def _install_to(target: Path, *, probe_only: bool, installed: list[str]) -> None
         base64.urlsafe_b64encode(str(runtime).encode("utf-8")).decode("ascii"),
     ).replace(
         "@@CONFIG_PATH_B64@@",
-        base64.urlsafe_b64encode(str(CONFIG_PATH).encode("utf-8")).decode("ascii"),
+        base64.urlsafe_b64encode(str(path).encode("utf-8")).decode("ascii"),
     )
     launcher_path = target / "resolve_bridge.py"
     launcher_path.write_text(launcher, encoding="utf-8")
@@ -605,7 +615,7 @@ def main() -> int:
     print("  1. Restart DaVinci Resolve so it re-scans the Scripts folders.")
     print("  2. Open a saved project (the Scripts menu is empty in Project Manager).")
     print("  3. Workspace > Scripts > resolve_bridge_probe  — run it TWICE.")
-    print("  4. Read ~/.config/davinci-resolve-mcp/host-model-probe.json")
+    print(f"  4. Read {config_path().parent / 'host-model-probe.json'}")
     return 0
 
 

--- a/tests/test_resolve_bridge.py
+++ b/tests/test_resolve_bridge.py
@@ -600,6 +600,101 @@ class InstallerTargetTests(unittest.TestCase):
         import install_resolve_bridge
         self.installer = install_resolve_bridge
 
+    def test_config_path_defaults_to_the_client_default(self) -> None:
+        from unittest import mock
+
+        from src.utils import resolve_bridge_client
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(self.installer.config_path(), self.installer.DEFAULT_CONFIG_PATH)
+            self.assertEqual(self.installer.config_path(), resolve_bridge_client.config_path())
+
+    def test_config_path_override_matches_the_client_at_call_time(self) -> None:
+        import pathlib
+        import tempfile
+        from unittest import mock
+
+        from src.utils import resolve_bridge_client
+
+        first = pathlib.Path(tempfile.mkdtemp(prefix="bridge_config_a_")) / "first.json"
+        second = pathlib.Path(tempfile.mkdtemp(prefix="bridge_config_b_")) / "second.json"
+        for path in (first, second):
+            with self.subTest(path=path), mock.patch.dict(
+                os.environ, {self.installer.ENV_CONFIG_PATH: str(path)}, clear=True
+            ):
+                self.assertEqual(self.installer.config_path(), path)
+                self.assertEqual(self.installer.config_path(), resolve_bridge_client.config_path())
+
+    def test_config_path_override_expands_the_user_directory(self) -> None:
+        import pathlib
+        from unittest import mock
+
+        with mock.patch.dict(
+            os.environ,
+            {self.installer.ENV_CONFIG_PATH: "~/private/resolve-bridge.json"},
+            clear=True,
+        ):
+            self.assertEqual(
+                self.installer.config_path(),
+                pathlib.Path.home() / "private/resolve-bridge.json",
+            )
+
+    def test_install_writes_embeds_and_reports_the_overridden_config(self) -> None:
+        import base64
+        import pathlib
+        import stat
+        import tempfile
+        from unittest import mock
+
+        root = pathlib.Path(tempfile.mkdtemp(prefix="bridge_custom_config_"))
+        config = root / "private config" / "bridge.json"
+        target = root / "Fusion/Scripts/Utility"
+        env = {self.installer.ENV_CONFIG_PATH: str(config)}
+        with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch.object(self.installer, "script_targets", return_value=[target]), \
+                mock.patch.object(self.installer, "python_preflight", return_value={"ok": True}), \
+                mock.patch.object(self.installer, "stale_container_warning", return_value=None):
+            result = self.installer.install(probe_only=False, port=50123, rotate=False)
+
+        self.assertEqual(result["config"]["path"], str(config))
+        self.assertEqual(result["config"]["port"], 50123)
+        self.assertTrue(config.exists())
+        if os.name != "nt":
+            self.assertEqual(stat.S_IMODE(config.stat().st_mode), 0o600)
+            self.assertEqual(stat.S_IMODE(config.parent.stat().st_mode), 0o700)
+
+        runtime_config = root / "Fusion/.davinci_mcp_runtime/bridge.json"
+        self.assertEqual(runtime_config.read_bytes(), config.read_bytes())
+        launcher = (target / "resolve_bridge.py").read_text(encoding="utf-8")
+        encoded = base64.urlsafe_b64encode(str(config).encode("utf-8")).decode("ascii")
+        self.assertIn(encoded, launcher)
+
+    def test_main_prints_the_selected_probe_report_path(self) -> None:
+        import contextlib
+        import io
+        import pathlib
+        import sys
+        import tempfile
+        from unittest import mock
+
+        config = pathlib.Path(tempfile.mkdtemp(prefix="bridge_main_config_")) / "bridge.json"
+        result = {
+            "installed": [],
+            "probe_only": True,
+            "python": {"resolve_will_list_python_scripts": True, "advice": None},
+            "warnings": [],
+            "skipped": [],
+        }
+        output = io.StringIO()
+        with mock.patch.dict(
+            os.environ, {self.installer.ENV_CONFIG_PATH: str(config)}, clear=True
+        ), mock.patch.object(sys, "argv", ["install_resolve_bridge.py", "--probe-only"]), \
+                mock.patch.object(self.installer, "install", return_value=result), \
+                contextlib.redirect_stdout(output):
+            self.assertEqual(self.installer.main(), 0)
+
+        self.assertIn(str(config.parent / "host-model-probe.json"), output.getvalue())
+
     def test_the_sandbox_path_keeps_the_vendor_segment(self) -> None:
         # The decoy drops it; Resolve's documented path does not.
         self.assertIn("Blackmagic Design/DaVinci Resolve", self.installer._SCRIPTS_SUFFIX)

--- a/tests/test_resolve_bridge.py
+++ b/tests/test_resolve_bridge.py
@@ -639,6 +639,49 @@ class InstallerTargetTests(unittest.TestCase):
                 pathlib.Path.home() / "private/resolve-bridge.json",
             )
 
+    def test_existing_overridden_config_preserves_token_and_roots(self) -> None:
+        import json
+        import pathlib
+        import tempfile
+        from unittest import mock
+
+        config = pathlib.Path(tempfile.mkdtemp(prefix="bridge_existing_config_")) / "bridge.json"
+        token = "p" * 48
+        config.write_text(
+            json.dumps({
+                "token": token,
+                "allowed_media_roots": ["/existing/media"],
+                "allowed_output_roots": ["/existing/output"],
+            }),
+            encoding="utf-8",
+        )
+        with mock.patch.dict(
+            os.environ, {self.installer.ENV_CONFIG_PATH: str(config)}, clear=True
+        ):
+            result = self.installer.ensure_config(port=50124, rotate=False)
+
+        self.assertEqual(result["token"], token)
+        self.assertEqual(result["port"], 50124)
+        self.assertEqual(result["allowed_media_roots"], ["/existing/media"])
+        self.assertEqual(result["allowed_output_roots"], ["/existing/output"])
+
+    def test_invalid_existing_overridden_config_is_replaced_safely(self) -> None:
+        import json
+        import pathlib
+        import tempfile
+        from unittest import mock
+
+        config = pathlib.Path(tempfile.mkdtemp(prefix="bridge_invalid_config_")) / "bridge.json"
+        config.write_text("{not valid json", encoding="utf-8")
+        with mock.patch.dict(
+            os.environ, {self.installer.ENV_CONFIG_PATH: str(config)}, clear=True
+        ):
+            result = self.installer.ensure_config(port=50125, rotate=False)
+
+        self.assertEqual(result["port"], 50125)
+        self.assertGreaterEqual(len(result["token"]), 43)
+        self.assertEqual(json.loads(config.read_text(encoding="utf-8")), result)
+
     def test_install_writes_embeds_and_reports_the_overridden_config(self) -> None:
         import base64
         import pathlib


### PR DESCRIPTION
## Summary

- make the free-edition bridge installer honor `DAVINCI_RESOLVE_BRIDGE_CONFIG`
- preserve the current default at `~/.config/davinci-resolve-mcp/bridge.json` when the variable is unset
- use the selected path consistently when creating, reporting, embedding, and copying the bridge configuration
- document the override for installations that keep the bridge config outside the default location

## Problem

The bridge client already reads `DAVINCI_RESOLVE_BRIDGE_CONFIG`, but `scripts/install_resolve_bridge.py` always wrote and embedded the fixed default path. A client configured with an override could therefore look in one location while the in-app Resolve bridge was installed with another. This is especially confusing in the free-edition workflow because both sides can be installed successfully yet fail to share the same token/configuration.

## Implementation

The installer now resolves the effective configuration path at call time through `config_path()`:

- an expanded `DAVINCI_RESOLVE_BRIDGE_CONFIG` value wins when present
- the existing default path remains unchanged otherwise
- `ensure_config()` reads and writes the selected path
- `install()` reports the selected path
- `_install_to()` copies the selected config into the Resolve runtime and embeds it in the launcher
- probe guidance points to the selected config directory

Resolving at call time also keeps tests and long-lived processes consistent with the bridge client's existing behavior.

## Compatibility and safety

- fully backward compatible when the environment variable is absent
- existing tokens and allowed media/output roots are preserved when reusing a valid custom config
- invalid existing JSON follows the installer's established safe-replacement behavior
- config directory/file permissions remain `0700`/`0600` on POSIX
- no changes to the bridge protocol or Resolve operation surface

## Tests

Added coverage for:

- default installer/client path parity
- environment override parity at call time
- `~` expansion
- writing, reporting, copying, and launcher embedding of a custom path
- preservation of an existing custom token and allowed roots
- safe replacement of invalid existing JSON
- probe report guidance under the selected config directory

Validation performed after rebasing onto current `main`:

```text
38 focused installer tests passed
tests/test_import.py: ok
scripts/audit_api_parity.py: PASS
git diff --check: clean
```

Focused branch coverage for `scripts/install_resolve_bridge.py` is 89% with branch measurement enabled. The custom-path code paths introduced here are exercised.

## Live validation

The installer was also exercised with a real non-default config path against DaVinci Resolve Free 21.0.4.5 on macOS. The installed launcher and runtime copy used the selected path, the existing token was preserved, and a read-only bridge request reached a davinci project that i own and its `Timeline 1` video successfully.
