### PR TITLE
fix: handle advanced launcher metadata before server import

### DIFF
--- a/bin/davinci-resolve-advanced-mcp.mjs
+++ b/bin/davinci-resolve-advanced-mcp.mjs
@@ -11,7 +11,35 @@
  */
 
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import fs from 'node:fs';
 import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
+const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+const version = packageJson.version || '0.0.0-dev';
+
+function usage() {
+  return `DaVinci Resolve Advanced MCP ${version}
+
+Usage:
+  davinci-resolve-advanced-mcp
+  davinci-resolve-advanced-mcp --version
+  davinci-resolve-advanced-mcp --help
+
+Starts the offline DaVinci Resolve advanced MCP server over stdio.
+`;
+}
+
+const command = process.argv[2];
+if (command === '--help' || command === '-h' || command === 'help') {
+  process.stdout.write(usage());
+  process.exit(0);
+}
+if (command === '--version' || command === '-v' || command === 'version') {
+  process.stdout.write(`${version}\n`);
+  process.exit(0);
+}
 
 // Node floor (package.json engines: >=20.9), enforced at STARTUP rather than
 // discovered per-feature: under an old Node the pure-JS tools limp along
@@ -34,7 +62,6 @@ if (major < 20 || (major === 20 && minor < 9)) {
   process.exit(1);
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverEntry = path.resolve(__dirname, '..', 'resolve-advanced', 'server', 'index.mjs');
 
 const { startServer } = await import(pathToFileURL(serverEntry).href);

--- a/install.py
+++ b/install.py
@@ -1474,7 +1474,7 @@ def verify_resolve_connection(python_path, api_path, lib_path):
 
 def print_banner():
     title = f"DaVinci Resolve MCP Server — Installer v{VERSION}"
-    subtitle = "32 compound · 329 full · 3 platforms"
+    subtitle = "36 compound · 353 full · 3 platforms"
     print()
     print(bold("  ╔══════════════════════════════════════════════════════╗"))
     print(bold(f"  ║{title:^54}║"))

--- a/tests/test_doc_tool_counts.py
+++ b/tests/test_doc_tool_counts.py
@@ -19,7 +19,8 @@ green 2560-test run and would only have surfaced in the publish gate, which runs
 a script.
 
 Fix drift by updating the docs to the printed counts, not by loosening this test.
-The counts are cross-checked against the runtime tool registry and agree: 34 / 353.
+Keep this guard free of hand-written expected counts; it computes the authoritative
+values from the source tree so the assertion moves with the implementation.
 
 Decorators are counted from the **parsed syntax tree**, not by matching the text
 `@mcp.tool(`. A regex counts the string wherever it appears, including inside a
@@ -84,6 +85,7 @@ class DocToolCountsDriftTest(unittest.TestCase):
             ("docs/install.md", f"`src/server.py` | {comp} |"),
             ("docs/install.md", f"`src/resolve_mcp_server.py` | {gran} |"),
             ("docs/install.md", f"full {gran}-tool server"),
+            ("install.py", f'{comp} compound · {gran} full · 3 platforms'),
             ("src/resolve_mcp_server.py", f"({gran} granular tools)"),
             ("tests/test_import.py", f"assert total == {gran}"),
             # test_import.py hard-codes the compound count too. Adding a 35th

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,6 +2,8 @@
 
 import ast
 import json
+import shutil
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -138,7 +140,47 @@ def test_npm_package_metadata():
     for stamped in ("install.py", "src/server.py", "src/granular/common.py"):
         assert package["version"] == _string_assignment(PROJECT_ROOT / stamped, "VERSION"), stamped
     assert package["bin"]["davinci-resolve-mcp"] == "./bin/davinci-resolve-mcp.mjs"
+    assert package["bin"]["davinci-resolve-advanced-mcp"] == "./bin/davinci-resolve-advanced-mcp.mjs"
     assert (PROJECT_ROOT / "bin" / "davinci-resolve-mcp.mjs").exists()
+    assert (PROJECT_ROOT / "bin" / "davinci-resolve-advanced-mcp.mjs").exists()
+
+
+def test_advanced_launcher_help_and_version_do_not_import_server_deps():
+    """Fresh source checkouts should expose bin metadata before npm install.
+
+    The advanced launcher used to import the stdio server before looking at
+    argv, so even `--help` failed with ERR_MODULE_NOT_FOUND when node_modules was
+    absent. Keep help/version dependency-light like the main launcher.
+    """
+    node = shutil.which("node")
+    if not node:
+        return
+    package = json.loads((PROJECT_ROOT / "package.json").read_text(encoding="utf-8"))
+    launcher = PROJECT_ROOT / "bin" / "davinci-resolve-advanced-mcp.mjs"
+
+    help_result = subprocess.run(
+        [node, str(launcher), "--help"],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    assert help_result.returncode == 0, help_result.stderr
+    assert "davinci-resolve-advanced-mcp --version" in help_result.stdout
+    assert "ERR_MODULE_NOT_FOUND" not in help_result.stderr
+
+    version_result = subprocess.run(
+        [node, str(launcher), "--version"],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    assert version_result.returncode == 0, version_result.stderr
+    assert version_result.stdout.strip() == package["version"]
+    assert "ERR_MODULE_NOT_FOUND" not in version_result.stderr
 
 
 def test_package_lock_in_sync():


### PR DESCRIPTION
## Summary

- make the advanced launcher handle metadata flags before importing the MCP server
- keep `davinci-resolve-advanced-mcp --help` and `--version` usable in fresh source checkouts before `npm install`
- update the installer banner to the current compound/full tool counts
- extend smoke/drift coverage for the advanced bin and installer banner

## Problem

The advanced launcher imported `resolve-advanced/server/index.mjs` before inspecting command-line arguments. In a fresh source checkout without `node_modules`, even metadata-only commands such as `node bin/davinci-resolve-advanced-mcp.mjs --help` failed with `ERR_MODULE_NOT_FOUND` for `@modelcontextprotocol/sdk`.

That made the second documented bin less friendly than the main launcher, whose help and version paths are dependency-light. While checking that surface, the interactive installer banner also showed stale tool counts: `32 compound · 329 full`, while the current documented and tested counts are `36 compound · 353 full`.

## Implementation

The advanced launcher now resolves package metadata and handles simple metadata commands before importing the stdio MCP server:

- reads the root `package.json` version
- returns usage for `--help`, `-h`, and `help`
- returns the package version for `--version`, `-v`, and `version`
- only imports `resolve-advanced/server/index.mjs` after those checks

The installer banner now reports the current tool counts, and the existing tool-count drift guard checks `install.py` so this banner cannot drift independently again.

## Compatibility and safety

- no change to normal advanced MCP server startup
- no change to tool schemas, actions, or Resolve operation behavior
- help/version remain stdout-only and exit before stdio server startup
- dependency loading for actual server execution is unchanged
- installer banner change is display-only

## Tests

Added coverage for:

- root package metadata including both published bins
- advanced launcher `--help` before server dependency import
- advanced launcher `--version` before server dependency import
- installer banner tool counts in the existing drift guard

Validation performed:

```text
node bin/davinci-resolve-advanced-mcp.mjs --help
node bin/davinci-resolve-advanced-mcp.mjs --version
venv/bin/python tests/test_import.py
venv/bin/python -m unittest tests.test_doc_tool_counts
npm pack --dry-run --cache /private/tmp/davinci-resolve-mcp-npm-cache
git diff --check
```

## Live validation

Not run. This change only affects launcher metadata handling, installer banner text, and offline smoke/drift tests. No Resolve scripting behavior changed.
