### PR TITLE
fix(media_analysis): plan["output_root"] is a mapping, not a path

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -9733,6 +9733,20 @@ def _media_analysis_bool(value: Any, default: bool = False) -> bool:
     return bool(value)
 
 
+def _media_analysis_plan_project_root(created: Any) -> str:
+    """Extract the project root path from a created batch job.
+
+    `plan["output_root"]` holds the mapping `resolve_output_root()` returns
+    ({"success", "base_root", "project_root", "project_directory", ...}), not a
+    path. `str()` on it yields a dict repr, which is a non-empty string and so
+    passes a truthiness guard while naming no directory that exists.
+    """
+    output_root = (created.get("plan") or {}).get("output_root") or ""
+    if isinstance(output_root, dict):
+        output_root = output_root.get("project_root") or ""
+    return str(output_root)
+
+
 MEDIA_ANALYSIS_ASYNC_QUEUED = "queued"
 MEDIA_ANALYSIS_ASYNC_RUNNING = "running"
 
@@ -22310,7 +22324,7 @@ async def media_analysis(action: str, params: Optional[Dict[str, Any]] = None, c
         # get a runner. Reached either by the analyze_* divert (which sets
         # _async_mode) or by calling start_batch_job with background=true.
         job_id = str((created.get("job") or {}).get("job_id") or "")
-        project_root = str((created.get("plan") or {}).get("output_root") or "")
+        project_root = _media_analysis_plan_project_root(created)
         wants_runner = p.get("_async_mode") == MEDIA_ANALYSIS_ASYNC_RUNNING or (
             _media_analysis_bool(p.get("background"), False)
             or _media_analysis_bool(p.get("async_job"), False)

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -22,6 +22,7 @@ from src.server import (
     _media_analysis_effective_preferences,
     _media_analysis_merge_metadata_field,
     _media_analysis_marker_candidates_from_report,
+    _media_analysis_plan_project_root,
     _media_analysis_metadata_writeback_enabled,
     _media_analysis_missing_capabilities_response,
     _media_analysis_publish_confirmed,
@@ -5347,6 +5348,53 @@ class LoudnessParsingTests(unittest.TestCase):
                 mine = _media_analysis_module._parse_loudness(sample)
                 for key in ("integrated_lufs", "loudness_range_lu", "true_peak_dbtp"):
                     self.assertEqual(mine[key], theirs[key], f"{name}/{key}")
+
+
+
+class MediaAnalysisPlanProjectRootTests(unittest.TestCase):
+    """plan["output_root"] is a mapping, not a path.
+
+    resolve_output_root() returns {"success", "base_root", "project_root", ...}.
+    str() on that mapping produces a dict repr — a non-empty string, so it
+    survives the `if wants_runner and job_id and project_root:` guard and is
+    handed to start_batch_job_runner as a directory name. The runner finds no
+    job store under it and reports {"started": False, "reason": "job_not_found"},
+    which sends the caller off to debug a job that exists and is fine.
+    """
+
+    def test_extracts_project_root_from_the_mapping(self):
+        created = {
+            "plan": {
+                "output_root": {
+                    "success": True,
+                    "base_root": "/analysis",
+                    "project_root": "/analysis/My_Project_abc123",
+                    "project_directory": "My_Project_abc123",
+                }
+            }
+        }
+        self.assertEqual(
+            _media_analysis_plan_project_root(created),
+            "/analysis/My_Project_abc123",
+        )
+
+    def test_does_not_return_a_dict_repr(self):
+        created = {"plan": {"output_root": {"project_root": "/analysis/P"}}}
+        root = _media_analysis_plan_project_root(created)
+        self.assertNotIn("{", root)
+        self.assertNotIn("project_root", root)
+
+    def test_accepts_a_plain_string_output_root(self):
+        created = {"plan": {"output_root": "/analysis/P"}}
+        self.assertEqual(_media_analysis_plan_project_root(created), "/analysis/P")
+
+    def test_missing_or_empty_yields_empty_string(self):
+        # Empty must stay falsy: it is what makes the runner guard decline
+        # instead of starting against a bogus path.
+        for created in ({}, {"plan": {}}, {"plan": {"output_root": {}}},
+                        {"plan": {"output_root": None}}):
+            self.assertEqual(_media_analysis_plan_project_root(created), "", created)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

`start_batch_job` derives the runner's project root like this (`src/server.py`, current `main`):

```python
project_root = str((created.get("plan") or {}).get("output_root") or "")
```

But `plan["output_root"]` holds the mapping `resolve_output_root()` returns — it is typed `-> Dict[str, Any]` in `src/utils/media_analysis.py` and returns `{"success", "base_root", "project_root", "project_directory", ...}`. So `str()` produces a dict repr:

```
"{'success': True, 'base_root': '/analysis', 'project_root': '/analysis/P', 'project_directory': 'P'}"
```

## Why it is not caught

That string is **non-empty**, so it satisfies the guard immediately below:

```python
if wants_runner and job_id and project_root:
    started = start_media_analysis_batch_job_runner(project_root, job_id, ...)
```

The runner is then handed a "directory" that names nothing on disk. It finds no job store there and returns `{"started": False, "reason": "job_not_found"}`, so the caller gets:

> Job created but not started (job_not_found). Drive it with `media_analysis(action='run_batch_job_slice', ...)`

…and goes off to debug a job that exists and is perfectly healthy. Net effect: **`background=true` and `async_job=true` silently never run**, and the reported reason points away from the cause.

Demonstration on the same fixture the new tests use:

```
>>> old = str((created.get('plan') or {}).get('output_root') or '')
"{'success': True, 'base_root': '/analysis', 'project_root': '/analysis/My_Project_abc123', ...}"
truthy? True    -> passes the runner guard
isdir?  False
```

## Why I think this is server.py's bug and not the mapping's

Every other consumer in the tree already treats this field as a mapping:

| Location | Reads it as |
|---|---|
| `src/batch_cli.py:179` | `(plan.get("output_root") or {}).get("project_root", "?")` |
| `src/analysis_dashboard.py` | `.project_root` / `.base_root` / `.project_directory` throughout (`_context_payload`, `output_root["project_root"]`, …) |
| `src/server.py` (before this PR) | `str(...)` |

`server.py` was the only place calling `str()` on it, so I fixed the consumer rather than changing the mapping's shape — that keeps it non-breaking for `batch_cli` and the dashboard.

## The change

Extracted the coercion into `_media_analysis_plan_project_root()`, matching the existing `_media_analysis_*` helper convention:

```python
def _media_analysis_plan_project_root(created: Any) -> str:
    output_root = (created.get("plan") or {}).get("output_root") or ""
    if isinstance(output_root, dict):
        output_root = output_root.get("project_root") or ""
    return str(output_root)
```

The extraction is what makes it testable: the surrounding `start_batch_job` branch needs a live Resolve project (`proj.GetMediaPool()`, `_media_analysis_records_from_target`), while the coercion itself is pure, so the regression test runs headlessly in CI.

Behaviour preserved deliberately:
- a plain-string `output_root` still passes straight through, in case any caller supplies one;
- a missing or empty one still yields `""`, so the guard keeps **declining** rather than starting a runner against a bogus path.

An alternative one-liner would have been to read `created["job"]["project_root"]`, which is already a plain string. I did not, because it silently changes which of the two sources wins if `job` and `plan` ever disagree; this fix keeps the existing source and only reads it correctly.

## Tests

Added `MediaAnalysisPlanProjectRootTests` to `tests/test_media_analysis.py` — 4 cases: extracts from the mapping, never returns a dict repr, accepts a plain string, and yields `""` for missing/empty/`None`.

```
$ python -m unittest tests.test_media_analysis.MediaAnalysisPlanProjectRootTests
Ran 4 tests in 0.000s
OK

$ python -m unittest tests.test_batch_cli
Ran 19 tests in 0.149s
OK
```

Verified against a live DaVinci Resolve Studio 21.0.4.5 on macOS 15 — this fix has been running locally since 2026-08-27 and the async analysis path works with it applied.