### PR TITLE
fix(edit-engine): variant item counts come from the timeline, not the append reply

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -6539,6 +6539,26 @@ def _variant_item_placement(item) -> Dict[str, Any]:
     }
 
 
+def _snapshot_track_item_counts(snapshot: Dict[str, Any]) -> Dict[str, int]:
+    """Per-track-type item counts read from a conform snapshot of a live timeline.
+
+    This is the ONLY honest answer to "what did the assembly actually place".
+    The obvious alternative — counting what `MediaPool.AppendToTimeline`
+    returned — is a witness derived from the same call it would be checking, and
+    it lies in two measured ways: the in-app bridge caps any proxied list at
+    `max_items` (an 864-clipInfo append came back as 500 items, so a variant
+    holding 432 video + 432 audio was reported as 250 + 250), and Resolve drops
+    colliding records from the reply without an error (see the api_truth entry
+    "MediaPool.AppendToTimeline (overlapping records — earlier item wins)").
+    Re-reading the timeline per track cannot be fooled by either.
+    """
+    counts: Dict[str, int] = {}
+    for track_type, block in (snapshot.get("tracks") or {}).items():
+        rows = (block or {}).get("tracks") or []
+        counts[str(track_type)] = sum(int(row.get("item_count") or 0) for row in rows)
+    return counts
+
+
 def _variant_audio_summary(built):
     """Video/audio range counts for an assembled variant, warning when it carries
     no audio. create_variant_from_ranges places exactly the ranges given, so a
@@ -6549,6 +6569,61 @@ def _variant_audio_summary(built):
     if audio == 0:
         summary["warning"] = "video-only (no audio): add ranges with track_type='audio' to carry sound"
     return summary
+
+
+def _variant_audio_accounting(variant: Dict[str, Any], *, planned_video: int,
+                              planned_audio: int) -> Dict[str, Any]:
+    """The planned-vs-placed block on a tighten / silence-ripple readback.
+
+    Shared by execute_tighten and execute_silence_ripple so the two cannot
+    drift: they answer the same operator question, "did every range I planned
+    actually land in the variant".
+
+    Placed counts come from the assembler's post-assembly re-read of the
+    timeline, never from what `AppendToTimeline` returned — see
+    `_snapshot_track_item_counts` for why the append's reply is not evidence.
+    A count that is short for a *reporting* reason and a count that is short
+    because material was dropped must never look the same here: on a silence
+    ripple the operator's whole fear is dropped material, so a disagreement is
+    stated outright rather than left to be discovered by hand-auditing tracks.
+    """
+    placed = variant.get("placed_item_counts")
+    video = (placed or {}).get("video")
+    audio = (placed or {}).get("audio")
+    accounting: Dict[str, Any] = {
+        "planned_audio_ranges": planned_audio,
+        "planned_video_ranges": planned_video,
+        "variant_audio_items": audio,
+        "variant_video_items": video,
+        "counts_source": "post-assembly per-track read of the variant timeline",
+    }
+    if video is None or audio is None:
+        accounting["note"] = (
+            "Placed item counts are UNAVAILABLE — the variant could not be re-read "
+            "after assembly. Verify with timeline_item get_items_in_track before "
+            "using this variant."
+        )
+        return accounting
+    disagreements = []
+    if video != planned_video:
+        disagreements.append(f"video {video}/{planned_video}")
+    if audio != planned_audio:
+        disagreements.append(f"audio {audio}/{planned_audio}")
+    if disagreements:
+        accounting["note"] = (
+            "PLACED COUNT DISAGREES WITH THE PLAN (placed/planned: "
+            + ", ".join(disagreements)
+            + ") — ranges did not land. Resolve drops colliding records from an "
+            "append without erroring; check readback.gaps_overlaps and the "
+            "tracks themselves before using this variant."
+        )
+    elif planned_audio:
+        accounting["note"] = "Variant carries audio mirrored from the video cuts."
+    else:
+        accounting["note"] = (
+            "Variant is VIDEO-ONLY (silent) — re-plan with include_audio=True for sound."
+        )
+    return accounting
 
 
 def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> Dict[str, Any]:
@@ -6701,16 +6776,21 @@ def _timeline_create_variant_from_ranges(proj, source_tl, p: Dict[str, Any]) -> 
     if p.get("cdl"):
         target_ids = [row.get("timeline_item_id") for row in items_out if row.get("timeline_item_id") and row.get("range", {}).get("media_type") == 1]
         look_result = _timeline_apply_look_to_items(new_tl, {"target_ids": target_ids, "cdl": p.get("cdl")})
+    # One snapshot, two consumers: gap detection and the placed-item counts.
+    # `items` above is only as complete as the append's REPLY, so it is not
+    # evidence of what landed — `placed_item_counts` re-reads the timeline.
+    snapshot = _timeline_conform_snapshot(new_tl, {})
     return {
         "success": True,
         "name": new_tl.GetName(),
         "id": new_tl.GetUniqueId(),
         "items": items_out,
+        "placed_item_counts": _snapshot_track_item_counts(snapshot),
         "placement_mismatches": placement_mismatches,
         "audio": _variant_audio_summary(built),
         "markers": marker_results,
         "look": look_result,
-        "gaps_overlaps": _detect_gaps_overlaps_from_snapshot(_timeline_conform_snapshot(new_tl, {}), {}),
+        "gaps_overlaps": _detect_gaps_overlaps_from_snapshot(snapshot, {}),
     }
 
 
@@ -24092,24 +24172,11 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
                     structural_diff if include_details
                     else _compact_structural_diff(structural_diff)
                 ),
-                "audio_accounting": {
-                    "planned_audio_ranges": audio_keep_ranges,
-                    "planned_video_ranges": video_keep_ranges,
-                    # variant_* count placed items; variant["audio"] counts requested ranges.
-                    "variant_audio_items": sum(
-                        1 for it in (variant.get("items") or [])
-                        if (it.get("range") or {}).get("media_type") == 2
-                    ),
-                    "variant_video_items": sum(
-                        1 for it in (variant.get("items") or [])
-                        if (it.get("range") or {}).get("media_type") == 1
-                    ),
-                    "note": (
-                        "Variant carries audio mirrored from the video cuts."
-                        if audio_keep_ranges
-                        else "Variant is VIDEO-ONLY (silent) — re-plan with include_audio=True for sound."
-                    ),
-                },
+                # variant_* count PLACED items, re-read from the variant;
+                # variant["audio"] counts requested ranges.
+                "audio_accounting": _variant_audio_accounting(
+                    variant, planned_video=video_keep_ranges, planned_audio=audio_keep_ranges,
+                ),
             },
             "plan_id": plan.get("plan_id"),
         }
@@ -24228,23 +24295,9 @@ def edit_engine(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[st
                     structural_diff if include_details
                     else _compact_structural_diff(structural_diff)
                 ),
-                "audio_accounting": {
-                    "planned_audio_ranges": audio_keep_ranges,
-                    "planned_video_ranges": video_keep_ranges,
-                    "variant_audio_items": sum(
-                        1 for it in (variant.get("items") or [])
-                        if (it.get("range") or {}).get("media_type") == 2
-                    ),
-                    "variant_video_items": sum(
-                        1 for it in (variant.get("items") or [])
-                        if (it.get("range") or {}).get("media_type") == 1
-                    ),
-                    "note": (
-                        "Variant carries audio mirrored from the video cuts."
-                        if audio_keep_ranges
-                        else "Variant is VIDEO-ONLY (silent) — re-plan with include_audio=True for sound."
-                    ),
-                },
+                "audio_accounting": _variant_audio_accounting(
+                    variant, planned_video=video_keep_ranges, planned_audio=audio_keep_ranges,
+                ),
             },
             "plan_id": plan.get("plan_id"),
         }

--- a/src/utils/resolve_bridge_client.py
+++ b/src/utils/resolve_bridge_client.py
@@ -33,6 +33,18 @@ proxy deliberately does not.
   timeline item-by-item is the shape that bites.
 - **Bridge absence.** If the in-Resolve script is not running, construction fails
   with a clear message rather than pretending; there is nothing to fall back to.
+- **Incomplete replies.** A returned container longer than the surface's
+  `max_items` comes back short. That used to be invisible, and a short list is
+  indistinguishable from a genuinely short result — an 864-clipInfo
+  `AppendToTimeline` returned 500 items and a caller counted them as the whole
+  answer. The surface now reports every drop and `_BoundMethod` surfaces it
+  (`transport.truncations`, plus a warning naming the method).
+
+  It warns rather than raising, deliberately: the native call has already *run*
+  by the time the reply is encoded, so raising would turn completed Resolve work
+  — a placed 864-item assembly — into an error and orphan the result. The honest
+  handling is for the caller to stop treating a returned list as a count, which
+  is why the tools that report item counts re-read them from the timeline.
 """
 
 from __future__ import annotations
@@ -117,6 +129,31 @@ class BridgeTransport:
         # keeps request/response pairing simple and matches the _bridge_lock
         # discipline the rest of the server already follows.
         self._lock = threading.RLock()
+        #: Replies the surface reported as incomplete, newest last: one row per
+        #: (method, dropped, total). Kept so a caller that suspects a short
+        #: enumeration can prove it instead of inferring it from a count that
+        #: looks plausible. Bounded — this is a diagnostic, not a log.
+        self.truncations: List[Dict[str, Any]] = []
+
+    def note_truncation(self, method: str, truncated: Any) -> None:
+        """Record and announce a reply the surface could not carry in full."""
+        if not isinstance(truncated, dict):
+            return
+        row = {"method": method, **truncated}
+        with self._lock:
+            self.truncations.append(row)
+            del self.truncations[:-32]
+        # Shapes here come off the wire from a bridge that may be older than
+        # this client, so nothing is indexed or assumed present.
+        containers = truncated.get("containers")
+        first = containers[0] if isinstance(containers, list) and containers else {}
+        logger.warning(
+            "bridge reply for %s was TRUNCATED: %s of %s elements dropped (limit %s). "
+            "The returned list is not a count — re-read the object instead.",
+            method, truncated.get("dropped"),
+            first.get("total") if isinstance(first, dict) else None,
+            truncated.get("limit"),
+        )
 
     def request(self, operation: str, arguments: Dict[str, Any]) -> Any:
         payload = {
@@ -251,6 +288,7 @@ class _BoundMethod:
             {"target": self._handle, "method": self._name,
              "args": [_encode_argument(a) for a in args]},
         )
+        self._transport.note_truncation(self._name, (result or {}).get("truncated"))
         return _decode_value(self._transport, (result or {}).get("value"))
 
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
@@ -345,6 +383,7 @@ class BridgeProxy:
                 probe = self._transport.request("get_attribute",
                                                 {"target": self._handle, "name": name}) or {}
                 if probe.get("kind") == "value":
+                    self._transport.note_truncation(name, probe.get("truncated"))
                     return _decode_value(self._transport, probe.get("value"))
                 if (name in _FUSION_UNENUMERATED_METHODS
                         and self._methods() & _FUSION_OBJECT_MARKERS):

--- a/src/utils/resolve_bridge_ops.py
+++ b/src/utils/resolve_bridge_ops.py
@@ -174,13 +174,22 @@ class ResolveOperations:
     #: loses a handle gets a clear `stale_handle` error and can re-fetch.
     MAX_HANDLES = 4096
 
+    #: Elements carried out of one encoded return value. A timeline-scale
+    #: enumeration has to fit: the old 500 silently halved an 864-item
+    #: `AppendToTimeline` return, and the caller counted the 500 it got as the
+    #: whole truth (a 432+432 variant read back as 250+250, issue: silence-ripple
+    #: audio_accounting). Whatever the ceiling is, exceeding it is now REPORTED
+    #: — see `_encode` — because a short list that looks complete is the failure
+    #: mode, not the bound itself.
+    DEFAULT_MAX_ITEMS = 2000
+
     def __init__(
         self,
         resolve: Any,
         *,
         media_roots: List[str],
         output_roots: List[str],
-        max_items: int = 500,
+        max_items: int = DEFAULT_MAX_ITEMS,
         lifecycle: Optional[Callable[[str], Dict[str, Any]]] = None,
     ) -> None:
         if resolve is None:
@@ -191,7 +200,16 @@ class ResolveOperations:
         # pretending to stop something they have no handle on.
         self._lifecycle = lifecycle
         self.policy = PathPolicy(media_roots, output_roots)
-        self.max_items = max(1, min(int(max_items), 5000))
+        # Capped at MAX_HANDLES, not at some larger round number: every live
+        # object in an encoded list mints a handle, so a list longer than the
+        # table evicts its own earliest entries before the client can use them
+        # and hands back handles that are already `stale_handle`. A ceiling
+        # above the table would trade a short list for a poisoned one.
+        self.max_items = max(1, min(int(max_items), self.MAX_HANDLES))
+        #: Set by `_encode` when a return value did not fit, read by the ops
+        #: that encode. Not a counter across calls — it answers "was THIS reply
+        #: complete", which is the only question a caller can act on.
+        self._encode_truncation: List[Dict[str, Any]] = []
         self._routes: Dict[str, Callable[[Dict[str, Any]], Any]] = {
             name: getattr(self, f"op_{name}") for name in self.OPERATIONS
         }
@@ -507,20 +525,67 @@ class ResolveOperations:
         Every object produced by one call carries the same shape, including the
         elements of a returned list — a track's timeline items are homogeneous,
         which is exactly the case where sharing a cached method set pays.
+
+        **Dropping elements is recorded, never silent.** A container longer than
+        `max_items` used to come back shortened with nothing anywhere saying so,
+        and a short list is indistinguishable from a genuinely short result: an
+        864-clipInfo `AppendToTimeline` returned 500 items, the caller counted
+        them, and a variant holding 432 video + 432 audio was reported to the
+        operator as 250 + 250 — which reads exactly like 182 ranges failing to
+        land. The bound itself is legitimate (see `max_items`); hiding it is
+        not, so every drop is reported alongside the value.
         """
         if value is None or isinstance(value, (bool, int, float, str)):
             return value
         if depth > 6:
             return str(value)
         if isinstance(value, (list, tuple)):
-            return [self._encode(v, depth + 1, shape) for v in list(value)[: self.max_items]]
+            items = list(value)
+            self._note_truncation(len(items), "list", depth, shape)
+            return [self._encode(v, depth + 1, shape) for v in items[: self.max_items]]
         if isinstance(value, dict):
-            return {str(k): self._encode(v, depth + 1, shape) for k, v in list(value.items())[: self.max_items]}
+            pairs = list(value.items())
+            self._note_truncation(len(pairs), "dict", depth, shape)
+            return {str(k): self._encode(v, depth + 1, shape) for k, v in pairs[: self.max_items]}
         return {
             "__handle__": self._mint(value, shape),
             "__type__": type(value).__name__,
             "__shape__": shape,
         }
+
+    def _note_truncation(self, total: int, kind: str, depth: int, shape: str) -> None:
+        if total <= self.max_items:
+            return
+        self._encode_truncation.append({
+            "shape": shape, "kind": kind, "depth": depth,
+            "returned": self.max_items, "total": total,
+            "dropped": total - self.max_items,
+        })
+
+    def _encoded(self, value: Any, shape: str) -> Dict[str, Any]:
+        """Encode one return value into a reply, carrying any truncation with it.
+
+        The `truncated` block is the whole point: a caller that reads `value` as
+        a complete answer is wrong exactly when this key is present, and it
+        cannot know that from the value alone.
+        """
+        self._encode_truncation = []
+        encoded = self._encode(value, shape=shape)
+        reply: Dict[str, Any] = {"value": encoded}
+        if self._encode_truncation:
+            dropped = sum(row["dropped"] for row in self._encode_truncation)
+            reply["truncated"] = {
+                "dropped": dropped,
+                "limit": self.max_items,
+                "containers": self._encode_truncation[:8],
+                "hint": (
+                    "This reply is INCOMPLETE — the value is not evidence of how many "
+                    "items exist. Re-read in smaller pieces, or count from the object "
+                    "itself rather than from this list."
+                ),
+            }
+            self._encode_truncation = []
+        return reply
 
     def _decode(self, value: Any) -> Any:
         """Argument -> live object, rehydrating handles the bridge itself issued."""
@@ -571,7 +636,7 @@ class ResolveOperations:
                 "resolve_raised",
                 f"Resolve raised while running {method}: {str(exc)[:200]}",
             )
-        return {"value": self._encode(result, shape=f"{self._shape_of(target_key)}.{method}")}
+        return self._encoded(result, shape=f"{self._shape_of(target_key)}.{method}")
 
     def op_list_methods(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """The public attribute names on a target — what `hasattr` should answer.
@@ -690,7 +755,8 @@ class ResolveOperations:
             return {"kind": "none",
                     "note": "present-but-None; on Resolve objects this is indistinguishable "
                             "from absent, because getattr never raises"}
-        return {"kind": "value", "value": self._encode(value, shape=f"{self._shape_of(arguments.get('target', 'resolve'))}.{name}")}
+        encoded = self._encoded(value, shape=f"{self._shape_of(arguments.get('target', 'resolve'))}.{name}")
+        return {"kind": "value", **encoded}
 
     def op_release_handles(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Drop handles a client no longer needs, or all of them."""

--- a/tests/live_edit_engine_validation.py
+++ b/tests/live_edit_engine_validation.py
@@ -249,6 +249,29 @@ def main() -> int:
                 audio_items = v_tl.GetItemListInTrack("audio", 1) or []
                 check("tighten variant A1 not empty", len(audio_items) >= 1,
                       f"A1 items={len(audio_items)}")
+                # The accounting must equal the timeline's OWN per-track counts.
+                # A `>= 1` check passes a variant reported as 250 items when it
+                # holds 432 — which is exactly the regression this pins: the
+                # counts used to come from the append's reply, and the in-app
+                # bridge caps that reply at max_items.
+                placed = {}
+                for track_type in ("video", "audio"):
+                    total = 0
+                    for ti in range(1, int(v_tl.GetTrackCount(track_type) or 0) + 1):
+                        total += len(v_tl.GetItemListInTrack(track_type, ti) or [])
+                    placed[track_type] = total
+                check("audio_accounting equals the per-track readback",
+                      t_acct.get("variant_video_items") == placed["video"]
+                      and t_acct.get("variant_audio_items") == placed["audio"],
+                      f"reported=({t_acct.get('variant_video_items')}, "
+                      f"{t_acct.get('variant_audio_items')}) "
+                      f"actual=({placed['video']}, {placed['audio']})")
+                # And planned == placed, or the note must say so outright.
+                agrees = (t_acct.get("variant_video_items") == t_acct.get("planned_video_ranges")
+                          and t_acct.get("variant_audio_items") == t_acct.get("planned_audio_ranges"))
+                check("planned vs placed disagreement is stated, never implied",
+                      agrees or "DISAGREES" in str(t_acct.get("note")),
+                      f"audio_accounting={t_acct}")
 
         # ── E3: swap (replace the selects timeline's first item) ──
         selects_tl, _ = s._find_timeline_by_name(proj, done1.get("timeline_name"))

--- a/tests/test_resolve_bridge.py
+++ b/tests/test_resolve_bridge.py
@@ -471,6 +471,73 @@ class OperationSurfaceTests(unittest.TestCase):
         self.assertEqual(len(listing["timelines"]), 5)
         self.assertTrue(listing["truncated"])
 
+    # -- a proxied return that does not fit must SAY so ---------------------
+    #
+    # Regression: `_encode` used to shorten any list past max_items with nothing
+    # anywhere recording it, and a short list cannot be told apart from a
+    # genuinely short result. An 864-clipInfo AppendToTimeline came back as 500
+    # items, and the silence-ripple readback counted them — reporting a variant
+    # of 432 video + 432 audio as 250 + 250, which reads as dropped material.
+
+    def _counting_ops(self, produced: int):
+        class Producer:
+            def Enumerate(self_inner):
+                return [_FakeTimeline(f"T{i}") for i in range(produced)]
+
+            def GetProjectManager(self_inner):
+                return self_inner
+
+            def GetCurrentProject(self_inner):
+                return self_inner
+
+            def GetMediaPool(self_inner):
+                return self_inner
+
+        return self._ops(resolve=Producer())
+
+    def test_a_truncated_proxy_reply_reports_what_it_dropped(self) -> None:
+        ops = self._counting_ops(864)
+        ops.max_items = 500
+        reply = ops.dispatch("call", {"target": "media_pool", "method": "Enumerate"})
+        self.assertEqual(len(reply["value"]), 500)
+        truncated = reply["truncated"]
+        self.assertEqual(truncated["dropped"], 364)
+        self.assertEqual(truncated["limit"], 500)
+        self.assertEqual(truncated["containers"][0]["total"], 864)
+
+    def test_a_reply_that_fits_carries_no_truncation_key(self) -> None:
+        ops = self._counting_ops(864)
+        reply = ops.dispatch("call", {"target": "media_pool", "method": "Enumerate"})
+        self.assertEqual(len(reply["value"]), 864)
+        self.assertNotIn("truncated", reply)
+
+    def test_truncation_state_does_not_leak_between_calls(self) -> None:
+        ops = self._counting_ops(864)
+        ops.max_items = 500
+        ops.dispatch("call", {"target": "media_pool", "method": "Enumerate"})
+        ops.max_items = 2000
+        self.assertNotIn(
+            "truncated",
+            ops.dispatch("call", {"target": "media_pool", "method": "Enumerate"}),
+        )
+
+    def test_the_ceiling_never_exceeds_the_handle_table(self) -> None:
+        # A list longer than MAX_HANDLES evicts its own earliest entries while
+        # it is still being minted, so the client receives handles that are
+        # already stale. A short list beats a poisoned one.
+        from src.utils import resolve_bridge_ops as rbo
+        ops = rbo.ResolveOperations(
+            FakeResolve(), media_roots=[self.ROOT], output_roots=[self.ROOT],
+            max_items=1_000_000,
+        )
+        self.assertLessEqual(ops.max_items, rbo.ResolveOperations.MAX_HANDLES)
+
+    def test_the_default_ceiling_clears_a_timeline_scale_return(self) -> None:
+        # The reported failure sent 864 clipInfos in one append. A default that
+        # cannot carry that is the bug, not a tuning preference.
+        from src.utils import resolve_bridge_ops as rbo
+        self.assertGreater(rbo.ResolveOperations.DEFAULT_MAX_ITEMS, 864)
+
     def test_path_policy_rejects_traversal_and_relative_paths(self) -> None:
         from src.utils import resolve_bridge_ops as ops
         policy = ops.PathPolicy([self.ROOT], [self.ROOT])

--- a/tests/test_variant_audio_accounting.py
+++ b/tests/test_variant_audio_accounting.py
@@ -1,0 +1,315 @@
+"""`audio_accounting` must count what the VARIANT holds, not what the append returned.
+
+Regression for the silence-ripple readback that reported 250 video / 250 audio
+items on a variant that really held 432 of each. The counts were derived from
+`MediaPool.AppendToTimeline`'s return value, and the in-app bridge caps any
+proxied list at `max_items` — so an 864-clipInfo append came back as 500 items
+and the accounting counted the short list as truth. `readback.after.clip_count`
+was right the whole time because it re-reads the timeline per track.
+
+A readback whose witness is the same call it is checking cannot contradict that
+call. These tests pin the counts to a per-track re-read of the assembled
+timeline, so a truncated (or reordered, or short) append return cannot make the
+accounting lie again.
+
+No Resolve required: the stubs place every clipInfo but hand back a deliberately
+truncated list, which is exactly the shape the bridge produced.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+
+from src import server as s
+from src.utils import edit_engine, timeline_brain_db
+
+
+# ── stubs ────────────────────────────────────────────────────────────────────
+
+
+class MediaPoolItemStub:
+    def __init__(self, unique_id: str) -> None:
+        self._id = unique_id
+
+    def GetUniqueId(self) -> str:
+        return self._id
+
+    def GetClipProperty(self, _key: str = ""):
+        return {}
+
+
+class TimelineItemStub:
+    def __init__(self, uid: str, start: int, duration: int, mpi: MediaPoolItemStub) -> None:
+        self._id = uid
+        self._start = start
+        self._duration = duration
+        self._mpi = mpi
+
+    def GetUniqueId(self) -> str:
+        return self._id
+
+    def GetName(self) -> str:
+        return "clip.mov"
+
+    def GetStart(self) -> int:
+        return self._start
+
+    def GetEnd(self) -> int:
+        return self._start + self._duration
+
+    def GetDuration(self) -> int:
+        return self._duration
+
+    def GetMediaPoolItem(self) -> MediaPoolItemStub:
+        return self._mpi
+
+    def SetProperty(self, _key, _value) -> bool:
+        return True
+
+
+class TimelineStub:
+    """Holds items per (track_type, track_index) — the timeline's own truth."""
+
+    def __init__(self, name: str, uid: str = "tl-1") -> None:
+        self._name = name
+        self._id = uid
+        self.tracks = {"video": {1: []}, "audio": {1: []}, "subtitle": {}}
+
+    # -- identity / timing -------------------------------------------------
+    def GetName(self) -> str:
+        return self._name
+
+    def GetUniqueId(self) -> str:
+        return self._id
+
+    def GetStartFrame(self) -> int:
+        return 0
+
+    def GetEndFrame(self) -> int:
+        video = self.tracks["video"].get(1) or []
+        return video[-1].GetEnd() if video else 0
+
+    def GetStartTimecode(self) -> str:
+        return "01:00:00:00"
+
+    def GetSetting(self, key: str):
+        return "24.0" if key == "timelineFrameRate" else None
+
+    # -- tracks ------------------------------------------------------------
+    def GetTrackCount(self, track_type: str) -> int:
+        return len(self.tracks.get(track_type) or {})
+
+    def AddTrack(self, track_type: str) -> bool:
+        table = self.tracks.setdefault(track_type, {})
+        table[len(table) + 1] = []
+        return True
+
+    def GetItemListInTrack(self, track_type: str, track_index: int):
+        return list((self.tracks.get(track_type) or {}).get(track_index) or [])
+
+    def place(self, media_type: int, track_index: int, item: TimelineItemStub) -> None:
+        track_type = "video" if media_type == 1 else "audio"
+        self.tracks.setdefault(track_type, {}).setdefault(track_index, []).append(item)
+
+
+class MediaPoolStub:
+    """Places every clipInfo, but returns a TRUNCATED list — the bridge's shape.
+
+    `return_cap` mirrors `resolve_bridge_ops.ResolveOperations.max_items`: the
+    append genuinely lands every item, and only the *reply* is short.
+    """
+
+    def __init__(self, root_folder, timelines: list, *, return_cap: int) -> None:
+        self._root = root_folder
+        self._timelines = timelines
+        self._return_cap = return_cap
+        self.appended_count = 0
+
+    def GetRootFolder(self):
+        return self._root
+
+    def CreateEmptyTimeline(self, name: str):
+        timeline = TimelineStub(name, uid=f"tl-{len(self._timelines) + 1}")
+        self._timelines.append(timeline)
+        return timeline
+
+    def AppendToTimeline(self, clip_infos):
+        timeline = self._timelines[-1]
+        placed = []
+        for index, info in enumerate(clip_infos):
+            media_type = int(info.get("mediaType") or 1)
+            track_index = int(info.get("trackIndex") or 1)
+            duration = int(info["endFrame"]) - int(info["startFrame"])
+            item = TimelineItemStub(
+                uid=f"item-{index}", start=int(info.get("recordFrame") or 0),
+                duration=duration, mpi=info["mediaPoolItem"],
+            )
+            timeline.place(media_type, track_index, item)
+            placed.append(item)
+        self.appended_count = len(placed)
+        # The bridge caps the encoded reply; the placements above are unaffected.
+        return placed[: self._return_cap]
+
+
+class RootFolderStub:
+    def __init__(self, clips) -> None:
+        self._clips = clips
+
+    def GetClipList(self):
+        return self._clips
+
+    def GetSubFolderList(self):
+        return []
+
+
+class ProjectStub:
+    def __init__(self, media_pool: MediaPoolStub, timelines: list) -> None:
+        self._mp = media_pool
+        self._timelines = timelines
+        self.current = timelines[0] if timelines else None
+
+    def GetMediaPool(self):
+        return self._mp
+
+    def GetTimelineCount(self) -> int:
+        return len(self._timelines)
+
+    def GetTimelineByIndex(self, index: int):
+        try:
+            return self._timelines[int(index) - 1]
+        except (IndexError, ValueError):
+            return None
+
+    def SetCurrentTimeline(self, timeline) -> bool:
+        self.current = timeline
+        return True
+
+    def GetName(self) -> str:
+        return "Accounting Fixture"
+
+
+def track_item_counts(timeline: TimelineStub) -> dict:
+    """The timeline's own per-track truth — what the readback must agree with."""
+    counts = {}
+    for track_type in ("video", "audio"):
+        total = 0
+        for track_index in range(1, int(timeline.GetTrackCount(track_type) or 0) + 1):
+            total += len(timeline.GetItemListInTrack(track_type, track_index) or [])
+        counts[track_type] = total
+    return counts
+
+
+# ── fixture ──────────────────────────────────────────────────────────────────
+
+#: Keep segments per source item. 432 video + 432 audio = 864 clipInfos, which
+#: is what the reported run sent, and past the bridge's 500-element ceiling.
+SEGMENTS = 432
+BRIDGE_RETURN_CAP = 500
+
+
+def silence_ripple_keep_ranges(clip_id: str = "mp-1") -> list:
+    """Interleaved video/audio keep ranges — plan_silence_ripple's own shape."""
+    ranges = []
+    for index in range(SEGMENTS):
+        start = index * 100
+        end = start + 40
+        ranges.append({"clip_id": clip_id, "start_frame": start, "end_frame": end,
+                       "track_type": "video", "track_index": 1})
+        ranges.append({"clip_id": clip_id, "start_frame": start, "end_frame": end,
+                       "track_type": "audio", "media_type": 2, "track_index": 1})
+    return ranges
+
+
+def build_project(*, return_cap: int = BRIDGE_RETURN_CAP):
+    source = TimelineStub("Interview Base", uid="tl-source")
+    timelines = [source]
+    media_pool = MediaPoolStub(
+        RootFolderStub([MediaPoolItemStub("mp-1")]), timelines, return_cap=return_cap,
+    )
+    return ProjectStub(media_pool, timelines), source
+
+
+class VariantAssemblyCountsTests(unittest.TestCase):
+    """The assembler must report what it built, not what the append replied."""
+
+    def test_placed_counts_survive_a_truncated_append_return(self) -> None:
+        proj, source = build_project()
+        result = s._timeline_create_variant_from_ranges(proj, source, {
+            "name": "Interview Base — variant",
+            "ranges": silence_ripple_keep_ranges(),
+        })
+        self.assertTrue(result.get("success"), result)
+        variant = proj.GetTimelineByIndex(proj.GetTimelineCount())
+        truth = track_item_counts(variant)
+        self.assertEqual(truth, {"video": SEGMENTS, "audio": SEGMENTS})
+        # The append reply really was short — the fixture is exercising the bug.
+        self.assertEqual(len(result.get("items") or []), BRIDGE_RETURN_CAP)
+        placed = result.get("placed_item_counts") or {}
+        self.assertEqual({"video": placed.get("video"), "audio": placed.get("audio")}, truth)
+
+
+class SilenceRippleAccountingTests(unittest.TestCase):
+    """End-to-end through edit_engine('execute_silence_ripple')."""
+
+    def setUp(self) -> None:
+        self.root = tempfile.mkdtemp(prefix="variant-accounting-")
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.addCleanup(timeline_brain_db.close_all)
+        self.proj, self.source = build_project()
+        # One seam: the action's project context. Everything below it is real.
+        original = s._destructive_versioning_provider
+        s._destructive_versioning_provider = lambda: (None, self.proj, self.root, "Fixture")
+        self.addCleanup(setattr, s, "_destructive_versioning_provider", original)
+
+    def _save_plan(self) -> dict:
+        return edit_engine.save_plan(self.root, {
+            "kind": "silence_ripple",
+            "timeline_name": "Interview Base",
+            "timeline_fps": 24.0,
+            "lifts": [{"timeline_start_frame": 40, "timeline_end_frame": 100,
+                       "duration_seconds": 2.5, "rationale": "silence"}],
+            "keep_ranges": silence_ripple_keep_ranges(),
+            "include_audio": True,
+            "settings": {"include_audio": True},
+        })
+
+    def _execute(self, plan_id: str) -> dict:
+        gate = s.edit_engine("execute_silence_ripple", {"plan_id": plan_id})
+        params = {"plan_id": plan_id}
+        if gate.get("confirm_token"):
+            params["confirm_token"] = gate["confirm_token"]
+        return s.edit_engine("execute_silence_ripple", params)
+
+    def test_variant_item_counts_equal_the_timelines_own_per_track_counts(self) -> None:
+        done = self._execute(self._save_plan()["plan_id"])
+        self.assertTrue(done.get("success"), done)
+
+        variant, _index = s._find_timeline_by_name(self.proj, done["variant_timeline"])
+        self.assertIsNotNone(variant)
+        truth = track_item_counts(variant)
+
+        accounting = (done.get("readback") or {}).get("audio_accounting") or {}
+        self.assertEqual(accounting.get("variant_video_items"), truth["video"], accounting)
+        self.assertEqual(accounting.get("variant_audio_items"), truth["audio"], accounting)
+
+    def test_accounting_agrees_with_the_plan_and_with_clip_count(self) -> None:
+        done = self._execute(self._save_plan()["plan_id"])
+        accounting = (done.get("readback") or {}).get("audio_accounting") or {}
+        # The whole point of the block: planned vs placed must be comparable.
+        self.assertEqual(accounting.get("variant_video_items"),
+                         accounting.get("planned_video_ranges"), accounting)
+        self.assertEqual(accounting.get("variant_audio_items"),
+                         accounting.get("planned_audio_ranges"), accounting)
+        # And it must not contradict the readback's own clip_count, which is
+        # what made the old numbers look like 182 dropped ranges.
+        after = (done.get("readback") or {}).get("after") or {}
+        self.assertEqual(
+            accounting["variant_video_items"] + accounting["variant_audio_items"],
+            int(after["clip_count"]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`edit_engine.execute_silence_ripple` returns an `audio_accounting` block whose item counts understate what it actually built.

Observed on Resolve 21.0.4.5 (free edition, in-app bridge), executing a plan against a 189336-frame timeline with 423 silence lifts:

```json
"audio_accounting": {
  "planned_audio_ranges": 432,
  "planned_video_ranges": 432,
  "variant_audio_items": 250,
  "variant_video_items": 250
}
```

The variant really held **432 video + 432 audio items** — confirmed via `timeline_item get_items_in_track` on both tracks: start/end sequences byte-identical between tracks, contiguous from frame 108000 to 288600, `detect_gaps_overlaps` returns 0 gaps and 0 overlaps, and `sum(duration)` is 180600 on each track, matching the timeline's content length exactly. The same response's `readback.after.clip_count` reported 864 — correct.

`planned 432, got 250` reads exactly like 182 ranges silently failing to land. On a silence ripple the operator's main fear is dropped material, and establishing that this was benign cost a full review cycle of hand-auditing both tracks.

Still reproduces on `main` @ v2.207.0: `resolve_bridge_ops.py` is byte-identical to v2.93.0 (same blob hash) and the `audio_accounting` block is unchanged.

## Root cause

`ResolveOperations._encode` truncates every proxied container to `max_items` (default 500) with **no signal anywhere**:

```python
return [self._encode(v, depth + 1, shape) for v in list(value)[: self.max_items]]
```

`plan_silence_ripple` emits keep ranges interleaved video/audio, so 432 kept segments become 864 clipInfos in one `AppendToTimeline`. Resolve placed all 864 and returned all 864; the bridge encoded the first 500 — which, interleaved, is exactly **250 video + 250 audio**.

`readback.after.clip_count` was right the whole time because `capture_timeline_clip_count` re-reads `GetItemListInTrack` per track — 432 each, comfortably under the ceiling. Two numbers in one response, from two sources, only one of them truncated.

A short list is indistinguishable from a genuinely short result, which is what made this cost a review cycle rather than a glance.

## Fixes

**1. The bridge no longer truncates silently** — `resolve_bridge_ops.py`, `resolve_bridge_client.py`

Every dropped element is recorded; `op_call` / `op_get_attribute` carry a `truncated` block (dropped / limit / containers); the client records it on `transport.truncations` and logs a warning naming the method.

It **warns rather than raises**, deliberately: the native call has already run by the time the reply is encoded, so raising would turn a completed 864-item assembly into an error and orphan the timeline.

The default ceiling goes 500 → 2000, and is now clamped to `MAX_HANDLES` rather than the previous 5000 — a list longer than the handle table evicts its own earliest entries while it is still being minted, handing the client handles that are already `stale_handle`. A short list beats a poisoned one.

**2. Counts are read back from the timeline** — `server.py`

`create_variant_from_ranges` now returns `placed_item_counts` from a post-assembly per-track re-read, reusing the conform snapshot it already takes for gap detection, so this costs no extra Resolve calls.

`execute_silence_ripple` and `execute_tighten` now share one `_variant_audio_accounting` helper — tighten carried the identical bug — and a planned-vs-placed disagreement is stated outright instead of being left to a hand audit.

This mattered beyond reporting: under the old cap, a `cdl` on a large variant only reached the first 250 video items.

## Tests

- **`tests/test_variant_audio_accounting.py`** (new) — drives the real `execute_silence_ripple`, confirm-token flow included, against stubs that place all 864 clipInfos but return only 500. Fails on `main` with the exact field payload (`variant_video_items: 250` vs `planned_video_ranges: 432`).
- **`tests/test_resolve_bridge.py`** — 5 tests pinning the truncation signal, that truncation state does not leak between calls, and both ceiling invariants.
- **`tests/live_edit_engine_validation.py`** — the existing check was `variant_audio_items >= 1`, which passes the buggy 250. It now asserts equality with the per-track readback.

## Validation

- Full offline suite: **3265 tests, 0 failures, 0 errors** (26 skipped)
- `test_import.py`, `audit_api_parity.py`, `gen_api_limitations.py --check`, `agent-rules/generate.mjs --check`, `git diff --check` — all clean

**Live Resolve validation has not been run.** It needs synthetic media in a disposable project per `AGENTS.md`, which I did not set up. The live assertion is in place for whoever runs `live_edit_engine_validation.py` next.

No `api_truth` entry was added: this is a defect in this project, not a Blackmagic API limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
