### PR TITLE
feat(security): refuse unsupported destructive dry runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.211.0 — unsupported destructive dry-runs now refuse honestly
+
+### Added
+
+- **Known destructive marker operations without native dry-run support now refuse instead of pretending to simulate.**
+  When a caller passes `dry_run=true` to registered marker actions that go
+  straight to Resolve mutators, the security wrapper returns
+  `status: dry_run_unavailable`, `simulated: false`, and `executed: false`.
+  The response includes the same static risk assessment used by
+  `inspect_operation`, plus a structured `DRY_RUN_UNAVAILABLE` error explaining
+  that nothing was simulated and nothing was executed.
+
+- **The refusal list is explicit and registry-checked.**
+  Only known destructive actions listed as lacking native dry-run support are
+  refused. Actions with real dry-run paths still reach their handlers, and
+  unknown future actions pass through rather than being blocked by a guessed
+  policy. A test pins that every unsupported dry-run entry is also a registered
+  destructive action, so stale refusal entries cannot accumulate silently.
+
+### Changed
+
+- **Unsupported dry-run refusals are handled inside the destructive-operation security wrapper.**
+  This keeps the lifecycle pipeline observational by default while still
+  refusing unsafe dry-run requests at the existing policy boundary, before
+  Resolve state lookup, archive creation, or handler execution.
+
 ## What's New in v2.210.0 — every destructive action now carries a real risk rating
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-2.210.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.211.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(353%20full)-blue.svg)](#server-modes)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 简体中文
 
-[![Version](https://img.shields.io/badge/version-2.210.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.211.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(353%20full)-blue.svg)](#服务器模式)
@@ -12,7 +12,7 @@
 [![Python](https://img.shields.io/badge/python-3.10+-green.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-> 本翻译对应 v2.210.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
+> 本翻译对应 v2.211.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
 
 一个 Model Context Protocol (MCP) 服务器，让 AI 助手通过官方脚本 API 控制 DaVinci Resolve Studio（达芬奇）。它提供完整的 API 覆盖，外加带护栏的工作流助手，涵盖剪辑、媒体池整理、渲染设置、审阅标记、调色、Fusion、Fairlight、项目生命周期任务、扩展开发，以及不碰源媒体的媒体分析。
 

--- a/install.py
+++ b/install.py
@@ -37,7 +37,7 @@ from src.utils.update_check import (
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.210.0"
+VERSION = "2.211.0"
 # Only hard floor: mcp[cli] requires Python 3.10+. There is no upper bound —
 # Resolve's scripting bridge loads into newer interpreters on recent builds
 # (Python 3.14 verified against Resolve Studio 20.3.2). Older Resolve builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.210.0",
+  "version": "2.211.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "davinci-resolve-mcp",
-      "version": "2.210.0",
+      "version": "2.211.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.210.0",
+  "version": "2.211.0",
   "description": "NPM bootstrapper for the DaVinci Resolve MCP Server.",
   "license": "MIT",
   "author": "Samuel Gursky <samgursky@gmail.com>",

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -87,7 +87,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.210.0"
+VERSION = "2.211.0"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 353-tool granular server instead
 """
 
-VERSION = "2.210.0"
+VERSION = "2.211.0"
 
 import base64
 import os

--- a/src/utils/destructive_hook.py
+++ b/src/utils/destructive_hook.py
@@ -252,6 +252,83 @@ DRY_RUN_DEFAULT_TRUE_ACTIONS: frozenset = frozenset({
 })
 
 
+UNSUPPORTED_DRY_RUN_ACTIONS: frozenset = frozenset({
+    ("timeline_markers", "add"),
+    ("timeline_markers", "delete_at_frame"),
+    ("timeline_markers", "delete_by_color"),
+    ("timeline_markers", "delete_by_custom_data"),
+    ("timeline_markers", "update_custom_data"),
+    ("timeline_item_markers", "add"),
+    ("timeline_item_markers", "add_flag"),
+    ("timeline_item_markers", "clear_clip_color"),
+    ("timeline_item_markers", "clear_flags"),
+    ("timeline_item_markers", "delete_at_frame"),
+    ("timeline_item_markers", "delete_by_color"),
+    ("timeline_item_markers", "delete_by_custom_data"),
+    ("timeline_item_markers", "set_clip_color"),
+    ("timeline_item_markers", "update_custom_data"),
+})
+
+
+def _explicit_dry_run_requested(params: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(params, dict):
+        return False
+    if "dry_run" in params:
+        return bool(params["dry_run"])
+    if "dryRun" in params:
+        return bool(params["dryRun"])
+    return False
+
+
+def lacks_native_dry_run(
+    tool_name: str, action: str, params: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """True when this explicit dry-run request has no verified handler support."""
+    return (
+        _explicit_dry_run_requested(params)
+        and (tool_name, action) in UNSUPPORTED_DRY_RUN_ACTIONS
+    )
+
+
+def _dry_run_unavailable_response(
+    *,
+    operation_id: str,
+    tool_name: str,
+    action: str,
+    assessment: RiskAssessment,
+) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "status": "dry_run_unavailable",
+        "dry_run": True,
+        "simulated": False,
+        "executed": False,
+        "operation_id": operation_id,
+        "security": {
+            "risk_level": assessment.level.value,
+            "risk_established": assessment.recognised,
+            "safe_mode": _safe_mode_enabled(),
+            "blocked": True,
+            "policy": "destructive.dry_run_support",
+        },
+        "risk": assessment.to_dict(),
+        "error": {
+            "message": (
+                f"'{tool_name}.{action}' does not have a verified dry-run path. "
+                "Nothing was simulated and nothing was executed."
+            ),
+            "code": "DRY_RUN_UNAVAILABLE",
+            "category": "dry_run_unavailable",
+            "retryable": False,
+            "remediation": (
+                "Use inspect_operation for static risk details, use a supported "
+                "safe/probe action when available, or call again without dry_run "
+                "after reviewing the operation."
+            ),
+        },
+    }
+
+
 def _payload_is_plan_only(
     tool_name: str, action: str, params: Optional[Dict[str, Any]],
 ) -> bool:
@@ -634,6 +711,23 @@ def destructive_op(tool_name: str) -> Callable[[Callable[..., Any]], Callable[..
             assessment = assess_action_risk(tool_name, action, params)
             risk_level = assessment.level.value
             risk_recognised = assessment.recognised
+            if lacks_native_dry_run(tool_name, action, params):
+                _audit_security_event(
+                    operation_id=operation_id,
+                    tool_name=tool_name,
+                    action=action,
+                    risk_level=risk_level,
+                    status="blocked",
+                    params=params,
+                    reason="dry_run_unavailable",
+                    recognised=risk_recognised,
+                )
+                return _dry_run_unavailable_response(
+                    operation_id=operation_id,
+                    tool_name=tool_name,
+                    action=action,
+                    assessment=assessment,
+                )
             if not _safe_mode_allows(risk_level, params, risk_recognised):
                 _audit_security_event(
                     operation_id=operation_id,

--- a/tests/test_destructive_hook.py
+++ b/tests/test_destructive_hook.py
@@ -278,6 +278,71 @@ class SecurityPolicy(unittest.TestCase):
         [event] = self._audit_events()
         self.assertEqual(event["status"], "allowed")
 
+    def test_known_unsupported_dry_run_refuses_without_calling_handler(self) -> None:
+        self._prefs(safe_mode=False)
+
+        def failing_provider():
+            raise AssertionError("dry-run refusal should not resolve project state")
+        destructive_hook.register_project_root_provider(failing_provider)
+
+        calls: list[str] = []
+
+        @destructive_hook.destructive_op("timeline_markers")
+        def fake_markers(action: str, params=None):
+            calls.append(action)
+            return {"success": True}
+
+        result = fake_markers("add", {"frame": 12, "dry_run": True})
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["status"], "dry_run_unavailable")
+        self.assertEqual(result["error"]["code"], "DRY_RUN_UNAVAILABLE")
+        self.assertFalse(result["simulated"])
+        self.assertFalse(result["executed"])
+        self.assertEqual(result["security"]["risk_level"], "low")
+        self.assertEqual(calls, [])
+        [event] = self._audit_events()
+        self.assertEqual(event["status"], "blocked")
+        self.assertEqual(event["reason"], "dry_run_unavailable")
+
+    def test_supported_dry_run_still_reaches_handler(self) -> None:
+        self._prefs(safe_mode=False)
+        destructive_hook.register_project_root_provider(lambda: None)
+        calls: list[str] = []
+
+        @destructive_hook.destructive_op("timeline")
+        def fake_timeline(action: str, params=None):
+            calls.append(action)
+            return {"success": True, "dry_run": True, "plan": []}
+
+        result = fake_timeline("apply_cuts", {"cuts": [], "dry_run": True})
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["dry_run"])
+        self.assertNotIn("simulated", result)
+        self.assertEqual(calls, ["apply_cuts"])
+
+    def test_unknown_dry_run_is_not_refused_by_default(self) -> None:
+        self._prefs(safe_mode=False)
+        destructive_hook.register_project_root_provider(lambda: None)
+        calls: list[str] = []
+
+        @destructive_hook.destructive_op("timeline")
+        def fake_timeline(action: str, params=None):
+            calls.append(action)
+            return {"success": True, "called_through": True}
+
+        with mock.patch.object(
+            destructive_hook, "is_destructive", lambda *_a, **_k: True
+        ):
+            result = fake_timeline(
+                "zz_synthetic_unrated_action",
+                {"dry_run": True},
+            )
+
+        self.assertTrue(result["called_through"])
+        self.assertEqual(calls, ["zz_synthetic_unrated_action"])
+
 
 class WrapperWithProvider(unittest.TestCase):
     """End-to-end: install a synthetic provider and verify the wrapper paths."""
@@ -482,6 +547,19 @@ class EveryDestructiveActionIsClassified(unittest.TestCase):
             "gate them — add each to _CRITICAL_ACTIONS, _HIGH_RISK_ACTIONS, "
             "_MEDIUM_RISK_ACTIONS or _LOW_RISK_ACTIONS in execution_lifecycle "
             "after reading its handler:\n  " + "\n  ".join(unrated),
+        )
+
+    def test_unsupported_dry_run_actions_are_registered_destructive_actions(self) -> None:
+        stale = sorted(
+            f"{tool}.{action}"
+            for tool, action in destructive_hook.UNSUPPORTED_DRY_RUN_ACTIONS
+            if action not in destructive_hook.DESTRUCTIVE_ACTIONS_BY_TOOL.get(tool, frozenset())
+        )
+        self.assertEqual(
+            stale,
+            [],
+            "unsupported dry-run refusals only make sense for registered "
+            "destructive operations:\n  " + "\n  ".join(stale),
         )
 
     def test_a_rated_action_reports_the_same_level_to_both_surfaces(self) -> None:


### PR DESCRIPTION
## Summary

This change makes destructive dry-run handling honest for registered marker operations that do not have a verified native dry-run path.

The security wrapper now detects explicit dry-run requests for known destructive marker actions that currently call Resolve mutators directly. Instead of allowing those calls to continue or pretending that a simulation happened, it returns a structured refusal before Resolve state lookup, archive creation, or handler execution.

The refusal response is intentionally explicit:

- success is false
- status is dry_run_unavailable
- dry_run is true
- simulated is false
- executed is false
- the response includes the same static risk assessment used by inspect_operation
- the error code is DRY_RUN_UNAVAILABLE

This preserves the trust boundary around dry_run. A caller asking for a dry run should never receive a fabricated success response for an operation that was not actually simulated.

## Why this belongs in the destructive-operation wrapper

The lifecycle pipeline is kept observational by default. Upstream tests already pin that default lifecycle hooks do not short-circuit and do not answer on behalf of handlers. This change keeps that invariant intact by placing the refusal at the existing destructive-operation security boundary, where policy refusals already live.

That placement also means the refusal happens before any pre-mutation archive or live Resolve/project state lookup. For unsupported dry runs, there is nothing to archive and nothing to execute, so the safest and clearest behavior is to refuse immediately and report the static risk.

## Scope

The unsupported dry-run list is explicit and deliberately narrow. It currently covers marker operations whose handlers go straight to Resolve mutators and do not implement a dry-run branch:

- timeline_markers.add
- timeline_markers.delete_at_frame
- timeline_markers.delete_by_color
- timeline_markers.delete_by_custom_data
- timeline_markers.update_custom_data
- timeline_item_markers.add
- timeline_item_markers.add_flag
- timeline_item_markers.clear_clip_color
- timeline_item_markers.clear_flags
- timeline_item_markers.delete_at_frame
- timeline_item_markers.delete_by_color
- timeline_item_markers.delete_by_custom_data
- timeline_item_markers.set_clip_color
- timeline_item_markers.update_custom_data

The change does not try to infer unsupported dry-run behavior for unknown future actions. Unknown actions continue to pass through to their handler path instead of being blocked by a guessed policy.

## Non-goals

This does not add a fake simulator.

This does not intercept every dry_run request globally.

This does not change actions that already have real dry-run support. For example, a destructive action with an implemented dry-run plan still reaches its own handler and returns its native dry-run response.

## Tests

Added tests covering:

- known unsupported destructive dry-runs refuse before handler execution
- the refusal does not resolve project state or create archive/versioning work
- the response reports simulated=false and executed=false
- supported native dry-runs still reach their handler
- unknown dry-run actions are not refused by default
- unsupported dry-run registry entries must also be registered destructive actions

Verification run locally:

- .venv/bin/python -m unittest tests.test_destructive_hook tests.test_execution_lifecycle
- .venv/bin/python -m unittest discover -s tests
- .venv/bin/python -m py_compile src/utils/destructive_hook.py tests/test_destructive_hook.py src/server.py src/granular/common.py install.py
- git diff --check

Full unittest discovery result: 3303 tests OK, 36 skipped.

## Version

Bumped the project version to 2.211.0 across the runtime, installer, package metadata, README badges, translated README version note, package lockfile, and changelog.