### PR TITLE
feat(security): classify graph LUT risk by target scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.212.0 — graph LUT risk follows the target scope
+
+### Changed
+
+- **`graph.set_lut` and `graph.apply_arri_cdl_lut` now classify by graph scope.**
+  The raw graph tool defaults to the timeline node graph and can also target
+  color-group pre/post graphs, so those calls can change the rendered look of a
+  whole timeline or every clip in a group and now classify as HIGH risk. When
+  the caller explicitly scopes the same actions to `source="item"`, they remain
+  MEDIUM because the mutation is limited to one timeline item. Safe mode now
+  blocks the broad timeline/group cases unless the caller explicitly allows the
+  risky operation.
+
+### Added
+
+- **Focused regression tests for the medium-band correction.**
+  The tests assert that `inspect_operation` reports both raw graph LUT
+  mutations as HIGH risk for timeline/group targets, MEDIUM for item targets,
+  and that the safe-mode gate follows the same distinction before handler
+  execution. The existing all-actions drift guard still verifies that
+  `inspect_operation` and the gate agree for every registered destructive
+  action.
+
+- **A medium-band review matrix pins the actions left at MEDIUM.**
+  The table covers every remaining MEDIUM-rated destructive action and asserts
+  that each one is recognised, destructive, not confirmation-gated, and carries
+  the reviewed blast radius. That makes MEDIUM an explicit rating rather than a
+  quiet resting place for anything that was not promoted.
+
 ## What's New in v2.211.0 — dry_run on an action that cannot honour it now refuses instead of executing
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-2.211.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.212.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(353%20full)-blue.svg)](#server-modes)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 简体中文
 
-[![Version](https://img.shields.io/badge/version-2.211.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.212.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(353%20full)-blue.svg)](#服务器模式)
@@ -12,7 +12,7 @@
 [![Python](https://img.shields.io/badge/python-3.10+-green.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-> 本翻译对应 v2.211.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
+> 本翻译对应 v2.212.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
 
 一个 Model Context Protocol (MCP) 服务器，让 AI 助手通过官方脚本 API 控制 DaVinci Resolve Studio（达芬奇）。它提供完整的 API 覆盖，外加带护栏的工作流助手，涵盖剪辑、媒体池整理、渲染设置、审阅标记、调色、Fusion、Fairlight、项目生命周期任务、扩展开发，以及不碰源媒体的媒体分析。
 

--- a/install.py
+++ b/install.py
@@ -37,7 +37,7 @@ from src.utils.update_check import (
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.211.0"
+VERSION = "2.212.0"
 # Only hard floor: mcp[cli] requires Python 3.10+. There is no upper bound —
 # Resolve's scripting bridge loads into newer interpreters on recent builds
 # (Python 3.14 verified against Resolve Studio 20.3.2). Older Resolve builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.211.0",
+  "version": "2.212.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "davinci-resolve-mcp",
-      "version": "2.211.0",
+      "version": "2.212.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.211.0",
+  "version": "2.212.0",
   "description": "NPM bootstrapper for the DaVinci Resolve MCP Server.",
   "license": "MIT",
   "author": "Samuel Gursky <samgursky@gmail.com>",

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -87,7 +87,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.211.0"
+VERSION = "2.212.0"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 353-tool granular server instead
 """
 
-VERSION = "2.211.0"
+VERSION = "2.212.0"
 
 import base64
 import os

--- a/src/utils/execution_lifecycle.py
+++ b/src/utils/execution_lifecycle.py
@@ -287,11 +287,14 @@ class RiskClassificationHook(LifecycleHook):
         ("timeline_item_color", "smart_reframe"),
         ("timeline_item_color", "create_magic_mask"),
         ("timeline_item_color", "regenerate_magic_mask"),
-        ("graph", "set_lut"),
-        ("graph", "apply_arri_cdl_lut"),
         # Importing or switching the active comp changes what renders.
         ("timeline_item_fusion", "import_comp"),
         ("timeline_item_fusion", "load_comp"),
+    }
+
+    _GRAPH_LUT_ACTIONS: Set[Tuple[str, str]] = {
+        ("graph", "set_lut"),
+        ("graph", "apply_arri_cdl_lut"),
     }
 
     _READ_ONLY_PREFIXES = ("get_", "list_", "query_", "probe_", "inspect_", "export_", "check_")
@@ -313,6 +316,29 @@ class RiskClassificationHook(LifecycleHook):
             radius = BlastRadius.PROJECT if "project" in tool_name else BlastRadius.TIMELINE
             conf_required = True
             reasons.append(f"Action '{action}' is permanently destructive across {radius.value}")
+        elif pair in cls._GRAPH_LUT_ACTIONS:
+            source = str(params.get("source") or "timeline")
+            destructive = True
+            if source in {"color_group_pre", "color_group_post"}:
+                level = RiskLevel.HIGH
+                radius = BlastRadius.PROJECT
+                conf_required = True
+                reasons.append(
+                    f"Raw graph LUT write '{action}' targets a color-group graph and can affect every clip in that group"
+                )
+            elif source == "item":
+                level = RiskLevel.MEDIUM
+                radius = BlastRadius.ITEM
+                reasons.append(
+                    f"Raw graph LUT write '{action}' is scoped to one timeline item"
+                )
+            else:
+                level = RiskLevel.HIGH
+                radius = BlastRadius.TIMELINE
+                conf_required = True
+                reasons.append(
+                    f"Raw graph LUT write '{action}' targets the timeline graph by default"
+                )
         elif pair in cls._HIGH_RISK_ACTIONS or action.startswith("delete_") or action.startswith("remove_"):
             level = RiskLevel.HIGH
             destructive = True
@@ -662,4 +688,3 @@ def classify_operation_risk(
     tool_name: str, action: str, params: Optional[Dict[str, Any]] = None
 ) -> RiskAssessment:
     return RiskClassificationHook.classify(tool_name, action, params or {})
-

--- a/tests/test_destructive_hook.py
+++ b/tests/test_destructive_hook.py
@@ -369,6 +369,51 @@ class SecurityPolicy(unittest.TestCase):
         [event] = self._audit_events()
         self.assertEqual(event["status"], "allowed")
 
+    def test_safe_mode_blocks_broad_raw_graph_lut_mutations(self) -> None:
+        self._prefs(safe_mode=True)
+        destructive_hook.register_project_root_provider(lambda: None)
+
+        for action, params in (
+            ("set_lut", {"node_index": 1, "lut_path": "look.cube"}),
+            ("apply_arri_cdl_lut", {}),
+            ("set_lut", {"node_index": 1, "lut_path": "look.cube", "source": "color_group_pre"}),
+            ("apply_arri_cdl_lut", {"source": "color_group_post"}),
+        ):
+            calls: list[str] = []
+
+            @destructive_hook.destructive_op("graph")
+            def fake_graph(action: str, params=None):
+                calls.append(action)
+                return {"success": True}
+
+            with self.subTest(action=action):
+                result = fake_graph(action, params)
+                self.assertFalse(result["success"])
+                self.assertEqual(result["error"]["code"], "SAFE_MODE_BLOCKED")
+                self.assertEqual(result["security"]["risk_level"], "high")
+                self.assertEqual(calls, [])
+
+    def test_safe_mode_allows_item_scoped_raw_graph_lut_mutations(self) -> None:
+        self._prefs(safe_mode=True)
+        destructive_hook.register_project_root_provider(lambda: None)
+
+        for action, params in (
+            ("set_lut", {"node_index": 1, "lut_path": "look.cube", "source": "item"}),
+            ("apply_arri_cdl_lut", {"source": "item"}),
+        ):
+            calls: list[str] = []
+
+            @destructive_hook.destructive_op("graph")
+            def fake_graph(action: str, params=None):
+                calls.append(action)
+                return {"success": True}
+
+            with self.subTest(action=action):
+                result = fake_graph(action, params)
+                self.assertTrue(result["success"])
+                self.assertEqual(result["security"]["risk_level"], "medium")
+                self.assertEqual(calls, [action])
+
     # ── dry_run on actions without a native dry-run path ──────────────────
     #
     # Before v2.211.0 `timeline_markers.add` with dry_run=true added a real

--- a/tests/test_execution_lifecycle.py
+++ b/tests/test_execution_lifecycle.py
@@ -216,6 +216,85 @@ class TestExecutionLifecycle(unittest.TestCase):
         self.assertEqual(assessment.blast_radius, BlastRadius.TIMELINE)
         self.assertTrue(any("Ripple" in r for r in assessment.reasons))
 
+    def test_raw_graph_lut_mutations_are_high_risk_for_timeline_or_group(self):
+        cases = (
+            ("set_lut", {"node_index": 1, "lut_path": "look.cube"}, BlastRadius.TIMELINE),
+            ("apply_arri_cdl_lut", {}, BlastRadius.TIMELINE),
+            (
+                "set_lut",
+                {"node_index": 1, "lut_path": "look.cube", "source": "color_group_pre"},
+                BlastRadius.PROJECT,
+            ),
+            ("apply_arri_cdl_lut", {"source": "color_group_post"}, BlastRadius.PROJECT),
+        )
+        for action, params, radius in cases:
+            with self.subTest(action=action, source=params.get("source", "timeline")):
+                assessment = classify_operation_risk("graph", action, params)
+                self.assertEqual(assessment.level, RiskLevel.HIGH)
+                self.assertTrue(assessment.destructive)
+                self.assertTrue(assessment.confirmation_required)
+                self.assertEqual(assessment.blast_radius, radius)
+
+    def test_raw_graph_lut_mutations_stay_medium_for_item_source(self):
+        for action, params in (
+            ("set_lut", {"node_index": 1, "lut_path": "look.cube", "source": "item"}),
+            ("apply_arri_cdl_lut", {"source": "item"}),
+        ):
+            with self.subTest(action=action):
+                assessment = classify_operation_risk("graph", action, params)
+                self.assertEqual(assessment.level, RiskLevel.MEDIUM)
+                self.assertTrue(assessment.destructive)
+                self.assertFalse(assessment.confirmation_required)
+                self.assertEqual(assessment.blast_radius, BlastRadius.ITEM)
+
+    def test_reviewed_medium_band_actions_remain_established_medium(self):
+        """Medium is a reviewed rating, not the classifier's fallthrough."""
+        cases = (
+            ("media_pool", "append_to_timeline", {}, BlastRadius.TIMELINE),
+            ("media_pool", "auto_sync_audio", {}, BlastRadius.TIMELINE),
+            ("media_pool", "move_clips", {}, BlastRadius.TIMELINE),
+            ("media_pool", "move_folders", {}, BlastRadius.TIMELINE),
+            ("media_pool", "setup_multicam_timeline", {}, BlastRadius.TIMELINE),
+            ("timeline", "copy_clips", {}, BlastRadius.TIMELINE),
+            ("timeline", "copy_range", {}, BlastRadius.TIMELINE),
+            ("timeline", "duplicate_clips", {}, BlastRadius.TIMELINE),
+            ("timeline", "duplicate_range", {}, BlastRadius.TIMELINE),
+            ("timeline", "insert_fusion_composition", {}, BlastRadius.TIMELINE),
+            ("timeline", "insert_fusion_generator", {}, BlastRadius.TIMELINE),
+            ("timeline", "insert_fusion_title", {}, BlastRadius.TIMELINE),
+            ("timeline", "insert_generator", {}, BlastRadius.TIMELINE),
+            ("timeline", "insert_ofx_generator", {}, BlastRadius.TIMELINE),
+            ("timeline", "insert_title", {}, BlastRadius.TIMELINE),
+            ("timeline", "set_setting", {}, BlastRadius.TIMELINE),
+            ("timeline", "set_start_timecode", {}, BlastRadius.TIMELINE),
+            ("timeline", "set_voice_isolation_state", {}, BlastRadius.TIMELINE),
+            ("timeline_ai", "analyze_dolby_vision", {}, BlastRadius.TIMELINE),
+            ("timeline_ai", "create_subtitles", {}, BlastRadius.TIMELINE),
+            ("timeline_item", "set_property", {}, BlastRadius.ITEM),
+            ("timeline_item", "set_retime", {}, BlastRadius.ITEM),
+            ("timeline_item", "set_voice_isolation_state", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "add_version", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "assign_color_group", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "create_magic_mask", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "load_version", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "regenerate_magic_mask", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "set_cdl", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "smart_reframe", {}, BlastRadius.ITEM),
+            ("timeline_item_color", "stabilize", {}, BlastRadius.ITEM),
+            ("timeline_item_fusion", "import_comp", {}, BlastRadius.ITEM),
+            ("timeline_item_fusion", "load_comp", {}, BlastRadius.ITEM),
+            ("graph", "set_lut", {"source": "item"}, BlastRadius.ITEM),
+            ("graph", "apply_arri_cdl_lut", {"source": "item"}, BlastRadius.ITEM),
+        )
+        for tool, action, params, radius in cases:
+            with self.subTest(action=f"{tool}.{action}", params=params):
+                assessment = classify_operation_risk(tool, action, params)
+                self.assertEqual(assessment.level, RiskLevel.MEDIUM)
+                self.assertTrue(assessment.destructive)
+                self.assertTrue(assessment.recognised)
+                self.assertFalse(assessment.confirmation_required)
+                self.assertEqual(assessment.blast_radius, radius)
+
     def test_readback_verification_hook_handles_contradiction(self):
         hook = ReadbackVerificationHook()
         ctx = ToolCallContext("timeline", "delete_clips", {})


### PR DESCRIPTION
## Summary

This PR continues the security follow-up from the medium-risk review by making raw graph LUT mutations classify by their actual target scope.

The current classifier treated graph.set_lut and graph.apply_arri_cdl_lut as flat MEDIUM risk. After reading the raw graph handler, that rating is too broad in one direction and too weak in another:

- the raw graph tool defaults to the timeline node graph
- it can also target color_group_pre and color_group_post
- those scopes can affect the rendered look of a whole timeline or every clip in a color group
- the same actions can also be explicitly scoped to source="item", where the mutation is limited to one timeline item

This change keeps the item-scoped case at MEDIUM, but promotes timeline/default and color-group targets to HIGH.

## Behavior

graph.set_lut and graph.apply_arri_cdl_lut now classify as:

- HIGH when source is omitted, because the graph tool defaults to the timeline graph
- HIGH when source="timeline"
- HIGH when source="color_group_pre"
- HIGH when source="color_group_post"
- MEDIUM when source="item"

The blast radius follows the same distinction:

- timeline/default source uses timeline
- color-group source uses project
- item source uses item

Because safe mode blocks established HIGH and CRITICAL operations, the broad graph LUT cases are now blocked before handler execution unless the caller explicitly allows the risky operation.

## Why

The medium band should represent a reviewed middle-risk operation, not a resting place for actions that were not promoted.

For these graph actions, the handler behavior matters more than the action name. A LUT write to one item is meaningfully different from a LUT write to the timeline graph or a color-group graph. Treating all of them as MEDIUM under-rates the broad cases; treating all of them as HIGH would over-block the item-scoped case.

This PR keeps that distinction in the classifier instead of creating a new policy surface.

## Tests

Added focused tests for the new classification behavior:

- inspect_operation / classifier reports raw graph LUT writes as HIGH for timeline/default targets
- inspect_operation / classifier reports raw graph LUT writes as HIGH for color-group targets
- inspect_operation / classifier keeps raw graph LUT writes as MEDIUM for source="item"
- safe mode blocks broad graph LUT writes before the handler runs
- safe mode allows item-scoped graph LUT writes

Also added a medium-band review matrix that pins every remaining MEDIUM destructive action as:

- recognised
- destructive
- not confirmation-gated
- carrying the reviewed blast radius

The existing all-actions drift guard still verifies that inspect_operation and the safe-mode gate agree for every registered destructive action.

## Version

Bumped the project version to 2.212.0 across:

- src/server.py
- src/granular/common.py
- install.py
- package.json
- package-lock.json
- README.md
- README.zh-CN.md
- CHANGELOG.md

## Verification

Run locally:

- .venv/bin/python -m unittest tests.test_destructive_hook tests.test_execution_lifecycle
- .venv/bin/python -m unittest discover -s tests
- .venv/bin/python -m py_compile src/utils/execution_lifecycle.py tests/test_destructive_hook.py tests/test_execution_lifecycle.py src/server.py src/granular/common.py install.py
- git diff --check

Results:

- focused security/lifecycle tests: 65 tests OK
- full unittest discovery: 3318 tests OK, 36 skipped
- py_compile: OK
- diff check: OK