### PR TITLE
fix: preserve failed verification evidence in operation results

### DIFF
--- a/src/utils/operation_result.py
+++ b/src/utils/operation_result.py
@@ -166,75 +166,57 @@ def extract_verification(raw: Any) -> Dict[str, Any]:
     if not isinstance(raw, dict):
         return unverified
 
-    # An impl that already speaks this shape wins outright.
     existing = raw.get("verification")
-    if isinstance(existing, dict) and existing:
-        merged = dict(existing)
-        merged.setdefault(
-            "status", "passed" if existing.get("verified") else "unverified")
-        merged.setdefault("checks", [])
-        merged.setdefault("contradiction", False)
-        return merged
-
-    checks: List[Dict[str, Any]] = []
-    status = "unverified"
-    contradiction = False
+    existing = existing if isinstance(existing, dict) else {}
+    checks = list(existing.get("checks") or [])
+    statuses = []
+    existing_status = existing.get("status")
+    if existing_status in {"passed", "failed", "partial", "contradiction"}:
+        statuses.append(existing_status)
+    elif existing.get("verified") is True:
+        statuses.append("passed")
+    elif existing.get("verified") is False:
+        statuses.append("failed")
+    contradiction = existing.get("contradiction") is True or raw.get("contradiction") is True
 
     readback = raw.get("readback")
-    if isinstance(readback, dict):
-        missing = readback.get("missing")
-        if isinstance(missing, list):
-            checks.append({
-                "check": "readback_verification",
-                "passed": not missing,
-                "missing_items": len(missing),
-            })
-            status = "passed" if not missing else "failed"
+    if isinstance(readback, dict) and isinstance(readback.get("missing"), list):
+        missing = readback["missing"]
+        checks.append({"check": "readback_verification", "passed": not missing,
+                       "missing_items": len(missing)})
+        statuses.append("failed" if missing else "passed")
 
-    # verify_by_readback's own shape: a mutation that reported success while the
-    # post-state disagrees is a contradiction, this repo's single most valuable
-    # reliability signal — it must not be flattened into a plain failure.
-    if "verified" in raw:
-        verified = bool(raw["verified"])
-        contradiction = bool(raw.get("contradiction"))
-        checks.append({
-            "check": "readback_post_state",
-            "passed": verified,
-            "contradiction": contradiction,
-            "observed": raw.get("observed"),
-        })
-        status = "contradiction" if contradiction else ("passed" if verified else "failed")
+    if type(raw.get("verified")) is bool:
+        checks.append({"check": "readback_post_state", "passed": raw["verified"],
+                       "contradiction": contradiction, "observed": raw.get("observed")})
+        statuses.append("passed" if raw["verified"] else "failed")
 
     if "property_restore_failures" in raw:
         failures = _as_int(raw.get("property_restore_failures"))
-        checks.append({
-            "check": "property_restore",
-            "passed": failures == 0,
-            "restored_items": _as_int(raw.get("properties_restored_items")),
-            "failures": failures,
-        })
-        if failures and status in ("passed", "unverified"):
-            status = "partial"
+        checks.append({"check": "property_restore", "passed": failures == 0,
+                       "restored_items": _as_int(raw.get("properties_restored_items")),
+                       "failures": failures})
+        if failures:
+            statuses.append("partial")
 
-    succeeded, failed = raw.get("succeeded"), raw.get("failed")
-    if isinstance(succeeded, int) and isinstance(failed, int):
-        checks.append({
-            "check": "bulk_operations",
-            "passed": failed == 0,
-            "succeeded": succeeded,
-            "failed": failed,
-        })
-        if status == "unverified":
-            if failed == 0 and succeeded > 0:
-                status = "passed"
-            elif succeeded > 0:
-                status = "partial"
-            elif failed > 0:
-                status = "failed"
-
-    if not checks:
-        return unverified
-    return {"status": status, "checks": checks, "contradiction": contradiction}
+    for check in checks:
+        if isinstance(check, dict):
+            contradiction = contradiction or check.get("contradiction") is True
+            if check.get("passed") is False:
+                statuses.append("partial" if check.get("check") == "property_restore" else "failed")
+    # Command counts are not evidence that Resolve honored those commands.
+    if contradiction or "contradiction" in statuses:
+        status = "contradiction"
+        contradiction = True
+    elif "failed" in statuses:
+        status = "failed"
+    elif "partial" in statuses:
+        status = "partial"
+    elif "passed" in statuses:
+        status = "passed"
+    else:
+        status = "unverified"
+    return {**existing, "status": status, "checks": checks, "contradiction": contradiction}
 
 
 # ─── Changes ─────────────────────────────────────────────────────────────────

--- a/tests/test_operation_result.py
+++ b/tests/test_operation_result.py
@@ -199,10 +199,23 @@ class Verification(unittest.TestCase):
             "property_restore_failures": 2, "properties_restored_items": 5})
         self.assertEqual(v["status"], "partial")
 
-    def test_bulk_counts_become_a_check(self):
-        v = extract_verification({"succeeded": 2, "failed": 1})
-        self.assertEqual(v["status"], "partial")
-        self.assertEqual(v["checks"][0]["check"], "bulk_operations")
+    def test_bulk_counts_do_not_establish_verification(self):
+        for succeeded, failed in ((3, 0), (2, 1), (0, 3)):
+            v = extract_verification({"succeeded": succeeded, "failed": failed})
+            self.assertEqual(v["status"], "unverified")
+            self.assertEqual(v["checks"], [])
+
+    def test_later_pass_does_not_erase_failed_readback(self):
+        v = extract_verification({"readback": {"missing": ["clip"]}, "verified": True})
+        self.assertEqual(v["status"], "failed")
+
+    def test_explicit_pass_does_not_hide_failed_check(self):
+        v = extract_verification({"verification": {"status": "passed", "checks": [{"passed": False}]}})
+        self.assertEqual(v["status"], "failed")
+
+    def test_explicit_pass_does_not_hide_contradiction(self):
+        v = extract_verification({"verification": {"status": "passed"}, "contradiction": True})
+        self.assertEqual(v["status"], "contradiction")
 
     def test_an_impl_that_already_speaks_the_shape_wins(self):
         v = extract_verification({"verification": {"status": "passed", "checks": [{"check": "x"}]}})


### PR DESCRIPTION
Hi! We found a case where the operation envelope could report verification as passed even when readback failed or a contradiction was present. This keeps those failures visible and leaves bulk command counts unverified until there is actual verification evidence.

Starting with this small fix to see whether contributions like this would be useful here. Happy to adjust the approach.

Validation: regression tests, full offline suite, drift guards, CLI/package checks and managed-install handshake. No Resolve API calls changed.
