### PR TITLE
fix(timeline_frame): settle the playhead before reading contact-sheet thumbnails

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -7065,8 +7065,15 @@ def _timeline_thumbnail_contact_sheet(proj, tl, p: Dict[str, Any]) -> Dict[str, 
                         )
                         sampled.append(sample)
                         continue
-                    thumbnail = tl.GetCurrentClipThumbnailImage()
-                    if not thumbnail:
+                    # Poll instead of reading once: the viewer has not caught
+                    # up when the scripting call right after a playhead move
+                    # lands, so a single read returns None on every sample and
+                    # the whole sheet comes back "No thumbnail available at
+                    # frame" while the same calls with a settle succeed.
+                    thumbnail, thumb_err = _playhead_thumbnail_settled(tl)
+                    if thumb_err:
+                        sample["error"] = thumb_err.get("error")
+                    elif not thumbnail:
                         sample["error"] = (
                             "No thumbnail available at frame"
                             if on_color


### PR DESCRIPTION
`_timeline_thumbnail_contact_sheet` moved the playhead and read the thumbnail once, immediately. The viewer has not caught up when the scripting call that follows a playhead move lands, so every sample came back `None` and the whole sheet returned `"No thumbnail available at frame ..."` — while the same calls with a settle succeed.

The fix routes the read through `_playhead_thumbnail_settled`, the polling helper already defined in this file and already used by the single-frame path a few dozen lines down. No new helper, no new dependency — the contact sheet was the one caller that had not been switched over.

## Testing

`python -m unittest discover -s tests -p 'test_*.py'` → 3331 tests, 5 errors, 19 skipped. All five errors are pre-existing on `main` (`test_offline_fallback` DRT authoring, `KeyError: 'success'`) and were reproduced on a clean `origin/main` worktree. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)