### PR TITLE
media_pool_item: read the full transcript on Resolve 21.1+

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -909,8 +909,12 @@ Key actions: `get_name`, `get_metadata(key?)`, `set_metadata(key, value)`,
 `set_name(name)`, `link_full_resolution_media(path)`,
 `replace_clip_preserve_sub_clip(path)`, `monitor_growing_file`,
 `transcribe_audio(use_speaker_detection?)`, `clear_transcription`,
-`get_transcription` (read back `{text, truncated, status, has_transcription}`;
-`truncated` flags when Resolve's preview cut the text off),
+`get_transcription(include_words?, use_nested_clip_transcription?)` (read back
+`{text, segments, language, source, truncated, status, has_transcription}`; on
+Resolve 21.1+ it uses `MediaPoolItem.GetTranscription`, so `segments` carries
+`{start, end, text, speaker}` in SOURCE timecode and nothing is truncated, and
+on 21.0.x it falls back to the `Transcription` clip property, where `truncated`
+flags a cut-off preview — `source` says which route ran),
 `perform_audio_classification`,
 `analyze_for_intellisearch(identify_faces?, is_better_mode?)`, `analyze_for_slate(marker_color?)`,
 `remove_motion_blur(deblur_option?)` (Resolve 21+; AI Extras / confirm-token gated as noted above),

--- a/src/server.py
+++ b/src/server.py
@@ -21305,11 +21305,15 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
       get_unique_id(clip_id) -> {id}
       transcribe_audio(clip_id, use_speaker_detection?, background?) -> {success | job_id}  — use_speaker_detection is Resolve 21+; background=true returns a job_id (poll resolve_control job_status)
       clear_transcription(clip_id) -> {success}
-      get_transcription(clip_id) -> {text, truncated, status, has_transcription}
-        Read a clip's transcription. `truncated` flags when Resolve's preview
-        property cut the text off (the full transcript is longer). Clip-level and
-        separate from the timeline subtitle transcript (timeline.get_transcript)
-        that propose_cuts uses.
+      get_transcription(clip_id, include_words?, use_nested_clip_transcription?) -> {text, segments, language, source, truncated, status, has_transcription}
+        Read a clip's transcription. On Resolve 21.1+ this uses
+        MediaPoolItem.GetTranscription, which does not truncate: `segments`
+        carries {start, end, text, speaker} in SOURCE timecode and `truncated`
+        is False. Pass include_words=true to keep each segment's per-word
+        timings. On 21.0.x it falls back to the `Transcription` clip property,
+        `segments` is null, and `truncated` flags a cut-off preview; `source`
+        says which route ran. Clip-level and separate from the timeline subtitle
+        transcript (timeline.get_transcript) that propose_cuts uses.
       extract_frames(clip_id, timestamps, output_dir?) -> {frame_paths, output_dir, count, errors}
         Extract still JPEGs from the clip's source at the given timestamps (seconds)
         via ffmpeg. Source-safe: reads source, writes only to a scratch dir.
@@ -21562,13 +21566,45 @@ def media_pool_item(action: str, params: Optional[Dict[str, Any]] = None) -> Dic
             status = clip.GetClipProperty("Transcription Status")
         except Exception:
             status = None
-        return {
+        out = {
             "clip_id": p.get("clip_id"),
             "text": text,
             "truncated": _is_truncated(text),
             "status": status or None,
             "has_transcription": bool(text.strip()),
+            "segments": None,
+            "language": None,
+            "source": "clip_property",
         }
+        # The `Transcription` clip property is a preview and stops at an
+        # ellipsis. Resolve 21.1 added a real accessor that does not truncate,
+        # so prefer it and keep the property as the 21.0.x fallback. Verified on
+        # Studio 21.1.0.14: 1550 segments with per-word start/end timecodes.
+        # Segment timecodes are SOURCE timecodes, not timeline positions.
+        if _has_method(clip, "GetTranscription"):
+            try:
+                full = clip.GetTranscription(bool(p.get("use_nested_clip_transcription", False)))
+            except Exception:
+                full = None
+            segs = full.get("segments") if isinstance(full, dict) else None
+            if segs:
+                if not p.get("include_words"):
+                    # `words` is several times the bulk of the segment text and
+                    # most callers want segment-level timing. Opt in for it.
+                    segs = [{k: v for k, v in seg.items() if k != "words"}
+                            if isinstance(seg, dict) else seg for seg in segs]
+                joined = " ".join(seg.get("text", "") for seg in segs
+                                  if isinstance(seg, dict)).strip()
+                out.update({
+                    "segments": segs,
+                    "language": full.get("language"),
+                    "source": "get_transcription",
+                    "truncated": False,
+                })
+                if joined:
+                    out["text"] = joined
+                    out["has_transcription"] = True
+        return out
     elif action == "extract_frames":
         return _extract_clip_frames(clip, p)
     elif action == "perform_audio_classification":

--- a/tests/test_transcript_read.py
+++ b/tests/test_transcript_read.py
@@ -70,5 +70,72 @@ class GetTranscriptionTest(unittest.TestCase):
         self.assertFalse(out["has_transcription"])
 
 
+class FakeClip211(FakeClip):
+    """A 21.1 clip: the property is still a truncated preview, GetTranscription
+    is the whole thing."""
+
+    SEGMENTS = [
+        {"start": "01:00:00:00", "end": "01:00:02:00", "text": "First part",
+         "speaker": "Speaker 1",
+         "words": [{"start": "01:00:00:00", "end": "01:00:01:00", "text": "First"}]},
+        {"start": "01:00:02:00", "end": "01:00:04:00", "text": "second part",
+         "speaker": "Speaker 1", "words": []},
+    ]
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.nested_arg = None
+
+    def GetTranscription(self, useNestedClipTranscription=False):
+        self.nested_arg = useNestedClipTranscription
+        return {"language": "en", "segments": self.SEGMENTS}
+
+
+class GetTranscription211Test(GetTranscriptionTest):
+    def test_prefers_the_method_over_the_truncated_property(self):
+        out = self._call(FakeClip211("This goes on and on\u2026"))
+        self.assertEqual(out["source"], "get_transcription")
+        self.assertEqual(out["text"], "First part second part")
+        self.assertFalse(out["truncated"])
+        self.assertEqual(out["language"], "en")
+        self.assertEqual(len(out["segments"]), 2)
+
+    def test_words_are_dropped_unless_asked_for(self):
+        out = self._call(FakeClip211("preview\u2026"))
+        self.assertNotIn("words", out["segments"][0])
+        self.assertEqual(out["segments"][0]["speaker"], "Speaker 1")
+
+    def test_include_words(self):
+        clip = FakeClip211("preview\u2026")
+        mp = mock.Mock()
+        with mock.patch.object(s, "_get_mp", return_value=(None, None, mp, None)), \
+             mock.patch.object(s, "_find_clip", return_value=clip):
+            out = s.media_pool_item("get_transcription",
+                                    {"clip_id": "x", "include_words": True})
+        self.assertEqual(len(out["segments"][0]["words"]), 1)
+
+    def test_falls_back_when_the_method_returns_nothing(self):
+        clip = FakeClip211("A preview\u2026")
+        clip.GetTranscription = lambda *a, **k: {"segments": []}
+        out = self._call(clip)
+        self.assertEqual(out["source"], "clip_property")
+        self.assertEqual(out["text"], "A preview\u2026")
+        self.assertTrue(out["truncated"])
+
+    def test_falls_back_when_the_method_raises(self):
+        clip = FakeClip211("A preview\u2026")
+        def boom(*a, **k):
+            raise RuntimeError("no transcript")
+        clip.GetTranscription = boom
+        out = self._call(clip)
+        self.assertEqual(out["source"], "clip_property")
+        self.assertTrue(out["truncated"])
+
+    def test_210_clip_still_reports_the_property_route(self):
+        out = self._call(FakeClip("A complete transcript."))
+        self.assertEqual(out["source"], "clip_property")
+        self.assertIsNone(out["segments"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`media_pool_item get_transcription` read the `Transcription` clip property. That property is a preview: it stops at an ellipsis once the transcript is longer than it exposes, and there was no way to get the rest. The action shipped a `truncated` flag instead of the text.

Resolve 21.1 added `MediaPoolItem.GetTranscription(useNestedClipTranscription)`, which returns `{language, segments[{start, end, text, speaker, words[]}]}` and does not truncate. This prefers that method when it is present and keeps the property as the 21.0.x fallback. `source` in the result says which route ran, so a caller can tell the difference without probing the version.

## Two things the docstring now states, because they bite at the call site

- **The segment timecodes are SOURCE timecodes, not timeline positions.** Anything placing them on a timeline has to map through the timeline item's own start.
- **`words` is several times the bulk of the segment text**, so it is stripped unless `include_words` is passed. Measured on a live Studio 21.1.0.14: 1550 segments on one clip, each carrying its own word list.

## Evidence

`MediaPoolItem.GetTranscription` is declared in 21.1's shipped `Developer/Scripting/DaVinciResolveScript.pyi` and listed under 21.1 "Added" in the shipped `CHANGELOG.md` ("Media Transcription - MediaPoolItem.GetTranscription"). Its return was read on a live Studio 21.1.0.14 and matched the declared shape, including a populated `speaker` field and `(...)` as Resolve's own silence marker.

The `api_truth` entry for the truncated property is unchanged and still correct — the property is still a preview on 21.1. This adds the route around it.

## Compatibility

No new action, so the action list is unchanged. The pre-existing keys (`text`, `truncated`, `status`, `has_transcription`) keep their meaning on both routes; `segments`, `language` and `source` are additions.

## Testing

`tests/test_transcript_read.py` covers both routes plus every fallback: method absent, method present but returning no segments, and method raising. Full offline suite run: 3344 tests, 19 skipped, and the same 5 pre-existing `test_offline_fallback` DRT errors that are present on an unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)