### PR TITLE
timeline_frame: put a user's mark range back after a frame capture

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -14927,6 +14927,19 @@ def _playhead_frame_render(proj, tl, p: Dict[str, Any]):
         original_tc = tl.GetCurrentTimecode()
     except Exception:
         pass
+    # The capture pins the render range to the captured frame, and there is no
+    # GetRenderSettings to read the surrounding settings back from (still absent
+    # in 21.1). The mark range is the exception: Timeline.GetMarkInOut reports it
+    # in the same record-frame space SetRenderSettings takes, so a range the user
+    # set can be captured here and put back below instead of being flattened to
+    # the whole timeline.
+    original_marks = None
+    try:
+        marks = (tl.GetMarkInOut() or {}).get("video") or {}
+        if "in" in marks and "out" in marks:
+            original_marks = marks
+    except Exception:
+        pass
 
     job = None
     try:
@@ -15020,16 +15033,26 @@ def _playhead_frame_render(proj, tl, p: Dict[str, Any]):
                     original_fc.get("format"), original_fc.get("codec"),
                     restore_exc or "SetCurrentRenderFormatAndCodec returned False",
                 )
-        # Best-effort, not a restore: without GetRenderSettings there is nothing
-        # to restore FROM, so put the mark range back to the whole timeline
-        # rather than leaving it pinned to the captured frame.
+        # Still not a full restore — GetRenderSettings does not exist, so the
+        # other settings cannot be read back. The mark range can: put the user's
+        # own range back when they had one, and fall back to the whole timeline
+        # when they did not, so the range is never left pinned to the captured
+        # frame for the next render job to inherit.
         try:
-            proj.SetRenderSettings({
-                "SelectAllFrames": True,
-                "MarkIn": tl.GetStartFrame(),
-                "MarkOut": tl.GetEndFrame(),
-                "CustomName": "",
-            })
+            if original_marks:
+                restored_marks = {
+                    "SelectAllFrames": False,
+                    "MarkIn": original_marks["in"],
+                    "MarkOut": original_marks["out"],
+                }
+            else:
+                restored_marks = {
+                    "SelectAllFrames": True,
+                    "MarkIn": tl.GetStartFrame(),
+                    "MarkOut": tl.GetEndFrame(),
+                }
+            restored_marks["CustomName"] = ""
+            proj.SetRenderSettings(restored_marks)
         except Exception:
             pass
         try:

--- a/tests/test_playhead_frame_capture.py
+++ b/tests/test_playhead_frame_capture.py
@@ -240,12 +240,13 @@ class CaptureRenderTest(unittest.TestCase):
     """quality='frame' — the default, and the only frame-accurate route."""
 
     def _capture(self, params, rendering=False, job="job-1", status="Complete",
-                 write=True, ffmpeg="/usr/bin/ffmpeg"):
+                 write=True, ffmpeg="/usr/bin/ffmpeg", marks=None):
         """Returns (result, project mock, list of SetRenderSettings payloads)."""
         resolve = _FakeResolve(page="color")
         tl = _fake_timeline(resolve)
         tl.GetStartFrame.return_value = 86400
         tl.GetEndFrame.return_value = 86544
+        tl.GetMarkInOut.return_value = marks if marks is not None else {}
         proj = mock.Mock()
         proj.IsRenderingInProgress.side_effect = [rendering, False]
         proj.GetCurrentRenderFormatAndCodec.return_value = {"format": "mov", "codec": "H.264"}
@@ -312,14 +313,36 @@ class CaptureRenderTest(unittest.TestCase):
             ("mov", "H.264"),
         )
 
-    def test_mark_range_is_reset_to_the_whole_timeline(self):
-        # It cannot be truly restored (no GetRenderSettings), but it must not be
+    def test_mark_range_falls_back_to_the_whole_timeline(self):
+        # No marks were set, so there is nothing to restore. It must still not be
         # left pinned to the captured frame.
         out, _, calls = self._capture({"frame": 86424})
         self.assertIsInstance(out, Image)
         self.assertTrue(calls[-1]["SelectAllFrames"])
         self.assertEqual(calls[-1]["MarkIn"], 86400)
         self.assertEqual(calls[-1]["MarkOut"], 86544)
+
+    def test_an_existing_mark_range_is_restored(self):
+        out, _, calls = self._capture(
+            {"frame": 86424}, marks={"video": {"in": 86410, "out": 86500},
+                                     "audio": {"in": 86410, "out": 86500}})
+        self.assertIsInstance(out, Image)
+        self.assertFalse(calls[-1]["SelectAllFrames"])
+        self.assertEqual(calls[-1]["MarkIn"], 86410)
+        self.assertEqual(calls[-1]["MarkOut"], 86500)
+
+    def test_a_half_set_mark_range_is_not_treated_as_a_range(self):
+        # Only an in point: restoring it as a range would invent an out point.
+        out, _, calls = self._capture({"frame": 86424},
+                                      marks={"video": {"in": 86410}})
+        self.assertIsInstance(out, Image)
+        self.assertTrue(calls[-1]["SelectAllFrames"])
+        self.assertEqual(calls[-1]["MarkIn"], 86400)
+
+    def test_an_unreadable_mark_range_does_not_break_the_capture(self):
+        out, _, calls = self._capture({"frame": 86424}, marks="not a dict")
+        self.assertIsInstance(out, Image)
+        self.assertTrue(calls[-1]["SelectAllFrames"])
 
     def test_refuses_while_another_render_runs(self):
         out, _, _ = self._capture({}, rendering=True)


### PR DESCRIPTION
## What

`timeline_frame capture` at quality `frame` renders a single frame, which means setting the project render range to `MarkIn == MarkOut == <frame>`. The cleanup then reset the range to the whole timeline, with this reasoning in the code:

> Best-effort, not a restore: without GetRenderSettings there is nothing to restore FROM, so put the mark range back to the whole timeline rather than leaving it pinned to the captured frame.

That is true of the render settings as a whole — `GetRenderSettings` does not exist, and it is still absent in 21.1's shipped `DaVinciResolveScript.pyi`. It is not true of the mark range specifically.

`Timeline.GetMarkInOut()` returns `{video: {in, out}, audio: {in, out}}`, and the stub documents those as *"Record frame relative to timeline start"* — the same space `RenderSettings.MarkIn`/`MarkOut` take, and the same space the existing fallback already writes `GetStartFrame()`/`GetEndFrame()` into. This repo already exposes `get_mark_in_out` / `set_mark_in_out` / `clear_mark_in_out` on the `timeline` tool, so the read costs nothing new.

So the range is read before the capture and put back after.

## Why it matters

Without this, a capture silently discards a range the user had set, and the next `prepare_render_job` inherits the whole timeline instead of their selection. The failure is quiet in both directions: the job reports success, with the correct preset, target dir and custom name, and only its range is wrong.

## What is deliberately unchanged

- **The fallback.** With no marks set there is still nothing to restore, so the range goes back to the whole timeline rather than staying pinned to the captured frame — exactly the old behaviour.
- **The scope of the claim.** This does not pretend to restore the render settings. The comment still says so, and still names the missing `GetRenderSettings`.
- **A half-set range** (an in point and no out) is treated as no range, because restoring it as a range would mean inventing the out point.

## Testing

`tests/test_playhead_frame_capture.py` gains the restore case, the half-set case, and an unreadable-`GetMarkInOut` case; the existing whole-timeline test is kept as the no-marks fallback. Full offline suite run: 3344 tests, 19 skipped, and the same 5 pre-existing `test_offline_fallback` DRT errors that are present on an unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)