### PR TITLE
docs(timeline_frame): capture docstring still says the mark range is not restored

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -14866,12 +14866,18 @@ def _playhead_frame_render(proj, tl, p: Dict[str, Any]):
     A single-frame render honours the grade, Fusion and titles, is frame-exact,
     runs in well under a second, and needs no GUI panel or foreground window.
 
-    The cost is that render settings are project-level state. Format and codec
-    are readable and are restored; the rest (TargetDir, CustomName, mark range)
-    is NOT readable on builds without GetRenderSettings, so this resets those to
-    sane values rather than truly restoring them. Callers who need a strictly
-    side-effect-free read should use quality="thumbnail" and accept per-clip
-    granularity.
+    The cost is that render settings are project-level state, and there is still
+    no GetRenderSettings to read them back from (absent as of 21.1). Three
+    different things happen on the way out:
+      - Format and codec are readable via GetCurrentRenderFormatAndCodec and are
+        genuinely restored.
+      - The mark range is readable via Timeline.GetMarkInOut, so a range the
+        caller had set is put back (offset into SetRenderSettings' absolute
+        frame space); with no range set it falls back to the whole timeline.
+      - TargetDir and CustomName are readable from nowhere, so they are reset to
+        sane values rather than restored.
+    Callers who need a strictly side-effect-free read should use
+    quality="thumbnail" and accept per-clip granularity.
     """
     fmt = str(p.get("format", "jpg")).lower().lstrip(".")
     if fmt == "jpeg":


### PR DESCRIPTION
`_playhead_frame_render`'s docstring lists the mark range with TargetDir and CustomName as things that are "NOT readable on builds without GetRenderSettings, so this resets those to sane values rather than truly restoring them."

Since #200 and v2.213.2 that is no longer true of the mark range: it is read with `Timeline.GetMarkInOut`, offset into `SetRenderSettings`' absolute frame space, and put back. The docstring is the first thing a caller reads to decide whether `quality="frame"` is safe against their render setup, so it pointing the wrong way is worth the six lines.

Rewritten as the three cases that actually happen on the way out — format/codec genuinely restored, mark range restored when one was set (whole timeline as the fallback), TargetDir and CustomName reset because nothing can read them back.

Docstring only. No behaviour change; `ast.parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)