### PR TITLE
feat(security): log mutating operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.215.0 — mutating operations write a structured operation log
+
+### Added
+
+- **Recognised mutating operations now write compact JSONL operation records.**
+  Each record captures the operation id, tool, action, `tool.action` name,
+  risk level, whether the risk was established by the classifier, blast
+  radius, dry-run flag, timestamp, final status, duration when available, and
+  a short human-readable summary. When a result already reports semantic
+  changes through the operation envelope, those changes are copied into the log
+  instead of guessed.
+
+- **The operation log is separate from both execution traces and the security audit log.**
+  Execution traces explain multi-step work, and the security audit records
+  destructive gate decisions. The new log is the simpler chronological trail
+  for mutating tool calls: what was attempted, whether it ran, and what the
+  result said. Read-only operations are deliberately skipped so the file stays
+  focused on project-changing activity. If a mutating handler raises an
+  unhandled exception before it can return a normal result, the lifecycle error
+  path still writes a failed record with the exception type and message.
+
+- **Setup defaults can enable, disable, and relocate the operation log.**
+  `destructive.operation_log` defaults to `true`, and
+  `destructive.operation_log_path` defaults to `logs/operation-log.jsonl`.
+  The path also honors `RESOLVE_MCP_OPERATION_LOG_FILE` for deployments that
+  need to route records outside the repository. Test isolation redirects the
+  default path so synthetic suite activity never pollutes a real operator log.
+
+### Validation
+
+- Added coverage for record shape, lifecycle writes for mutating operations,
+  read-only suppression, blocked destructive attempts, exception failures,
+  setup set/clear support, and test-suite log redirection.
+
 ## What's New in v2.214.1 — grade calls fail silently off the Color page; apply_trace_plan switches for you
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-2.214.1-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.215.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(353%20full)-blue.svg)](#server-modes)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 简体中文
 
-[![Version](https://img.shields.io/badge/version-2.214.1-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.215.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(353%20full)-blue.svg)](#服务器模式)
@@ -12,7 +12,7 @@
 [![Python](https://img.shields.io/badge/python-3.10+-green.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-> 本翻译对应 v2.214.1 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
+> 本翻译对应 v2.215.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
 
 一个 Model Context Protocol (MCP) 服务器，让 AI 助手通过官方脚本 API 控制 DaVinci Resolve Studio（达芬奇）。它提供完整的 API 覆盖，外加带护栏的工作流助手，涵盖剪辑、媒体池整理、渲染设置、审阅标记、调色、Fusion、Fairlight、项目生命周期任务、扩展开发，以及不碰源媒体的媒体分析。
 

--- a/install.py
+++ b/install.py
@@ -37,7 +37,7 @@ from src.utils.update_check import (
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.214.1"
+VERSION = "2.215.0"
 # Only hard floor: mcp[cli] requires Python 3.10+. There is no upper bound —
 # Resolve's scripting bridge loads into newer interpreters on recent builds
 # (Python 3.14 verified against Resolve Studio 20.3.2). Older Resolve builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.214.1",
+  "version": "2.215.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "davinci-resolve-mcp",
-      "version": "2.214.1",
+      "version": "2.215.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.214.1",
+  "version": "2.215.0",
   "description": "NPM bootstrapper for the DaVinci Resolve MCP Server.",
   "license": "MIT",
   "author": "Samuel Gursky <samgursky@gmail.com>",

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -87,7 +87,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.214.1"
+VERSION = "2.215.0"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 353-tool granular server instead
 """
 
-VERSION = "2.214.1"
+VERSION = "2.215.0"
 
 import base64
 import os
@@ -61,6 +61,7 @@ from src.utils.page_lock import (
 from src.utils.proc import safe_run
 from src.utils.readback import verify_by_readback, verification_stats as _verification_stats
 from src.utils import operation_result as _operation_result
+from src.utils import operation_log as _operation_log
 from src.utils.operation_result import (
     build_operation_envelope as _build_operation_envelope,
     get_envelope_mode as _get_envelope_mode,
@@ -1259,6 +1260,7 @@ def _destructive_preference_provider(key: str) -> Any:
 
 
 _destructive_hook.register_preference_provider(_destructive_preference_provider)
+_operation_log.register_preference_provider(_destructive_preference_provider)
 
 
 # Gated (tool, action) pairs routed through the destructive_hook wrapper that
@@ -15530,6 +15532,8 @@ def _setup_destructive_defaults() -> Dict[str, Any]:
         "safe_mode": _setup_bool(destructive.get("safe_mode"), False),
         "audit_log": _setup_bool(destructive.get("audit_log"), True),
         "audit_log_path": destructive.get("audit_log_path") or os.path.join(project_dir, "logs", "security-audit.jsonl"),
+        "operation_log": _setup_bool(destructive.get("operation_log"), True),
+        "operation_log_path": destructive.get("operation_log_path") or os.path.join(project_dir, "logs", "operation-log.jsonl"),
         "preferences_path": _media_analysis_preferences_path(),
     }
 
@@ -15549,6 +15553,10 @@ def _setup_set_destructive_defaults(destructive_defaults: Dict[str, Any], dry_ru
         "auditlog": "audit_log",
         "audit_log_path": "audit_log_path",
         "auditlogpath": "audit_log_path",
+        "operation_log": "operation_log",
+        "operationlog": "operation_log",
+        "operation_log_path": "operation_log_path",
+        "operationlogpath": "operation_log_path",
     }
     requested: Dict[str, Any] = {}
     for key, value in destructive_defaults.items():
@@ -15577,11 +15585,11 @@ def _setup_set_destructive_defaults(destructive_defaults: Dict[str, Any], dry_ru
         if clear_requested(raw_value):
             destructive.pop(key, None)
             updates[key] = {"before": before.get(key), "after": _setup_destructive_defaults().get(key), "cleared": True}
-        elif key in {"require_confirm_token", "safe_mode", "audit_log"}:
+        elif key in {"require_confirm_token", "safe_mode", "audit_log", "operation_log"}:
             normalized = _setup_bool(raw_value, before.get(key, False))
             destructive[key] = normalized
             updates[key] = {"before": before.get(key), "after": normalized}
-        elif key == "audit_log_path":
+        elif key in {"audit_log_path", "operation_log_path"}:
             path = os.path.realpath(os.path.abspath(os.path.expanduser(str(raw_value))))
             destructive[key] = path
             updates[key] = {"before": before.get(key), "after": path}
@@ -16132,6 +16140,8 @@ def _setup_clear_defaults(keys: Any, dry_run: bool) -> Dict[str, Any]:
         "safe_mode": "destructive.safe_mode",
         "audit_log": "destructive.audit_log",
         "audit_log_path": "destructive.audit_log_path",
+        "operation_log": "destructive.operation_log",
+        "operation_log_path": "destructive.operation_log_path",
     }
     destructive_payload: Dict[str, Any] = {}
     if clear_all or "destructive" in normalized_keys:
@@ -16297,6 +16307,16 @@ def setup(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
                     "values": "absolute or expandable path",
                     "storage": _media_analysis_preferences_path(),
                 },
+                "destructive.operation_log": {
+                    "description": "Write compact JSONL records for every recognised mutating operation.",
+                    "values": [True, False],
+                    "storage": _media_analysis_preferences_path(),
+                },
+                "destructive.operation_log_path": {
+                    "description": "Absolute path for the mutating-operation JSONL log.",
+                    "values": "absolute or expandable path",
+                    "storage": _media_analysis_preferences_path(),
+                },
             },
         }
 
@@ -16411,6 +16431,22 @@ def setup(action: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
                     default=None,
                 )
             } if any(key in merged for key in ("audit_log_path", "auditLogPath")) else {}),
+            **({
+                "operation_log": _first_param(
+                    merged,
+                    "operation_log",
+                    "operationLog",
+                    default=None,
+                )
+            } if any(key in merged for key in ("operation_log", "operationLog")) else {}),
+            **({
+                "operation_log_path": _first_param(
+                    merged,
+                    "operation_log_path",
+                    "operationLogPath",
+                    default=None,
+                )
+            } if any(key in merged for key in ("operation_log_path", "operationLogPath")) else {}),
         }
 
         general_result = _setup_set_general_defaults(general_defaults, dry_run)

--- a/src/utils/execution_lifecycle.py
+++ b/src/utils/execution_lifecycle.py
@@ -24,6 +24,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+from src.utils import operation_log
+
 logger = logging.getLogger("resolve-mcp.execution-lifecycle")
 
 
@@ -542,6 +544,45 @@ class ProvenanceTraceHook(LifecycleHook):
         }
 
 
+class OperationLogHook(LifecycleHook):
+    """Writes a compact append-only record for each mutating operation."""
+    name = "operation_log"
+
+    def after_tool_call(
+        self, ctx: ToolCallContext, result: Any, duration_ms: int
+    ) -> Optional[Dict[str, Any]]:
+        if not ctx.risk.destructive:
+            return None
+        record = operation_log.build_record(
+            tool_name=ctx.tool_name,
+            action=ctx.action,
+            params=ctx.params,
+            result=result,
+            risk=ctx.risk.to_dict(),
+        )
+        operation_log.write_record(record)
+        return {
+            "logged": operation_log.operation_log_enabled(),
+            "operation_id": record["operation_id"],
+            "path": operation_log.operation_log_path(),
+        }
+
+    def on_error(
+        self, ctx: ToolCallContext, exc: Exception, duration_ms: int
+    ) -> None:
+        if not ctx.risk.destructive:
+            return
+        record = operation_log.build_exception_record(
+            tool_name=ctx.tool_name,
+            action=ctx.action,
+            params=ctx.params,
+            exc=exc,
+            risk=ctx.risk.to_dict(),
+            duration_ms=duration_ms,
+        )
+        operation_log.write_record(record)
+
+
 # ─── Pipeline Coordinator ───────────────────────────────────────────────────
 
 
@@ -577,6 +618,7 @@ class LifecyclePipeline:
         self._hooks.append(ReadbackVerificationHook())
         self._hooks.append(DriftDetectionHook())
         self._hooks.append(ProvenanceTraceHook())
+        self._hooks.append(OperationLogHook())
 
     def register_hook(self, hook: LifecycleHook) -> None:
         with self._lock:
@@ -711,4 +753,3 @@ def classify_operation_risk(
     tool_name: str, action: str, params: Optional[Dict[str, Any]] = None
 ) -> RiskAssessment:
     return RiskClassificationHook.classify(tool_name, action, params or {})
-

--- a/src/utils/operation_log.py
+++ b/src/utils/operation_log.py
@@ -1,0 +1,206 @@
+"""Structured operation log for mutating tool calls.
+
+This log is deliberately narrower than execution traces and separate from the
+security audit log. It records the user-visible mutation attempt: which tool
+action ran, its risk, whether it was a dry run, a compact summary, and the
+final status.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from src.utils import operation_result
+
+logger = logging.getLogger("resolve-mcp.operation-log")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PreferenceProvider = Callable[[str], Any]
+_PREFERENCE_PROVIDER: Optional[_PreferenceProvider] = None
+
+
+def register_preference_provider(fn: _PreferenceProvider) -> None:
+    global _PREFERENCE_PROVIDER
+    _PREFERENCE_PROVIDER = fn
+
+
+def _read_preference(key: str, default: Any = None) -> Any:
+    if _PREFERENCE_PROVIDER is None:
+        return default
+    try:
+        value = _PREFERENCE_PROVIDER(key)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def operation_log_enabled() -> bool:
+    return _coerce_bool(_read_preference("destructive.operation_log", True), True)
+
+
+def operation_log_path() -> str:
+    configured = (
+        os.environ.get("RESOLVE_MCP_OPERATION_LOG_FILE")
+        or _read_preference("destructive.operation_log_path", None)
+    )
+    if configured:
+        return os.path.realpath(os.path.abspath(os.path.expanduser(str(configured))))
+    return str(_REPO_ROOT / "logs" / "operation-log.jsonl")
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _dry_run_requested(params: Optional[Dict[str, Any]], result: Any) -> bool:
+    if isinstance(params, dict):
+        if "dry_run" in params:
+            return bool(params["dry_run"])
+        if "dryRun" in params:
+            return bool(params["dryRun"])
+    return bool(isinstance(result, dict) and result.get("dry_run") is True)
+
+
+def _envelope(result: Any) -> Dict[str, Any]:
+    if not isinstance(result, dict):
+        return {}
+    nested = result.get(operation_result.ENVELOPE_KEY)
+    if isinstance(nested, dict):
+        return nested
+    if {"operation", "execution_id", "status"}.intersection(result):
+        return result
+    return {}
+
+
+def _operation_id(result: Any, envelope: Dict[str, Any]) -> str:
+    if isinstance(result, dict) and result.get("operation_id"):
+        return str(result["operation_id"])
+    execution_id = envelope.get("execution_id")
+    if execution_id:
+        return str(execution_id)
+    return f"op_{uuid.uuid4().hex[:12]}"
+
+
+def _status(result: Any, envelope: Dict[str, Any]) -> str:
+    raw_status = result.get("status") if isinstance(result, dict) else None
+    error = result.get("error") if isinstance(result, dict) else None
+    category = error.get("category") if isinstance(error, dict) else None
+    if raw_status in {
+        "blocked_by_security_policy",
+        "dry_run_unavailable",
+        "confirmation_required",
+    }:
+        return "blocked"
+    if category in {
+        "destructive_blocked",
+        "dry_run_unavailable",
+        "pending_user_decision",
+    }:
+        return "blocked"
+    return str(envelope.get("status") or operation_result.normalize_status(result))
+
+
+def _summary(tool_name: str, action: str, status: str, envelope: Dict[str, Any]) -> str:
+    operation = f"{tool_name}.{action}"
+    changes = envelope.get("changes")
+    if isinstance(changes, dict) and changes:
+        parts = [f"{key}={value}" for key, value in sorted(changes.items())[:4]]
+        return f"{operation} {status}; " + ", ".join(parts)
+    if status == "blocked":
+        return f"{operation} blocked before mutation"
+    return f"{operation} {status}"
+
+
+def build_record(
+    *,
+    tool_name: str,
+    action: str,
+    params: Optional[Dict[str, Any]],
+    result: Any,
+    risk: Dict[str, Any],
+) -> Dict[str, Any]:
+    env = _envelope(result)
+    status = _status(result, env)
+    record = {
+        "operation_id": _operation_id(result, env),
+        "tool": tool_name,
+        "action": action,
+        "operation": f"{tool_name}.{action}",
+        "risk_level": risk.get("level", "unknown"),
+        "risk_established": risk.get("recognised"),
+        "dry_run": _dry_run_requested(params, result),
+        "timestamp": _now_iso(),
+        "summary": _summary(tool_name, action, status, env),
+        "status": status,
+    }
+    if env.get("execution_id") and env.get("execution_id") != record["operation_id"]:
+        record["execution_id"] = env["execution_id"]
+    if risk.get("blast_radius"):
+        record["blast_radius"] = risk["blast_radius"]
+    if env.get("duration_ms") is not None:
+        record["duration_ms"] = env["duration_ms"]
+    if env.get("changes") is not None:
+        record["changes"] = env["changes"]
+    return record
+
+
+def build_exception_record(
+    *,
+    tool_name: str,
+    action: str,
+    params: Optional[Dict[str, Any]],
+    exc: Exception,
+    risk: Dict[str, Any],
+    duration_ms: int,
+) -> Dict[str, Any]:
+    exception_type = exc.__class__.__name__
+    operation = f"{tool_name}.{action}"
+    return {
+        "operation_id": f"op_{uuid.uuid4().hex[:12]}",
+        "tool": tool_name,
+        "action": action,
+        "operation": operation,
+        "risk_level": risk.get("level", "unknown"),
+        "risk_established": risk.get("recognised"),
+        "dry_run": _dry_run_requested(params, None),
+        "timestamp": _now_iso(),
+        "summary": f"{operation} failed with {exception_type}",
+        "status": "failed",
+        "blast_radius": risk.get("blast_radius"),
+        "duration_ms": max(0, int(duration_ms)),
+        "exception": {
+            "type": exception_type,
+            "message": str(exc),
+        },
+    }
+
+
+def write_record(record: Dict[str, Any]) -> None:
+    if not operation_log_enabled():
+        return
+    path = operation_log_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True, default=str) + "\n")
+    except Exception as exc:
+        logger.warning("operation log write failed: %s", exc)

--- a/tests/offline_guard.py
+++ b/tests/offline_guard.py
@@ -130,6 +130,7 @@ def install() -> bool:
     server.resolve_is_running = offline_resolve_is_running
 
     _redirect_security_audit_log()
+    _redirect_operation_log()
     _redirect_media_analysis_preferences()
 
     setattr(server, _INSTALLED_FLAG, True)
@@ -175,6 +176,29 @@ def _redirect_security_audit_log() -> None:
         return handle.name
 
     destructive_hook._audit_log_path = audit_log_path_offline
+
+
+def _redirect_operation_log() -> None:
+    """Send synthetic mutating-operation records to a temp file during tests."""
+    try:
+        from src.utils import operation_log
+    except Exception:
+        return
+
+    original = operation_log.operation_log_path
+    _originals["operation_log_path"] = original
+    handle = tempfile.NamedTemporaryFile(
+        prefix="operation-log-test-", suffix=".jsonl", delete=False
+    )
+    handle.close()
+    _originals["operation_log_tempfile"] = handle.name
+
+    def operation_log_path_offline() -> str:
+        if operation_log._read_preference("destructive.operation_log_path", None):
+            return original()
+        return handle.name
+
+    operation_log.operation_log_path = operation_log_path_offline
 
 
 def _redirect_media_analysis_preferences() -> None:
@@ -233,6 +257,23 @@ def _restore_security_audit_log() -> None:
             pass
 
 
+def _restore_operation_log() -> None:
+    if "operation_log_path" not in _originals:
+        return
+    try:
+        from src.utils import operation_log
+
+        operation_log.operation_log_path = _originals.pop("operation_log_path")
+    except Exception:
+        _originals.pop("operation_log_path", None)
+    path = _originals.pop("operation_log_tempfile", None)
+    if path and os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
 def uninstall() -> None:
     """Restore the originals. Safe to call when nothing was installed."""
     server = _import_server()
@@ -245,6 +286,7 @@ def uninstall() -> None:
     server.get_resolve = _originals["get_resolve"]
     server.resolve_is_running = _originals["resolve_is_running"]
     _restore_security_audit_log()
+    _restore_operation_log()
     _restore_media_analysis_preferences()
     setattr(server, _INSTALLED_FLAG, False)
 

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -1,0 +1,205 @@
+"""Tests for the mutating-operation JSONL log."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+import src.server as compound
+from src.utils import operation_log, operation_result
+from src.utils.execution_lifecycle import LifecyclePipeline, ToolCallContext
+
+
+class OperationLogRecords(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_provider = operation_log._PREFERENCE_PROVIDER
+        self.tmp = tempfile.TemporaryDirectory()
+        self.log_path = os.path.join(self.tmp.name, "operation-log.jsonl")
+        operation_log.register_preference_provider(
+            lambda key: {
+                "destructive.operation_log": True,
+                "destructive.operation_log_path": self.log_path,
+            }.get(key)
+        )
+
+    def tearDown(self) -> None:
+        operation_log._PREFERENCE_PROVIDER = self.saved_provider
+        self.tmp.cleanup()
+
+    def _records(self):
+        with open(self.log_path, "r", encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+
+    def test_build_record_uses_operation_envelope_and_risk(self) -> None:
+        raw = {
+            "success": True,
+            "operation_id": "op_fixed",
+            "_changes": {"items_added": 2},
+        }
+        enveloped = operation_result.build_operation_envelope(
+            "timeline",
+            "duplicate_clips",
+            {"dry_run": False},
+            raw,
+            duration_ms=17,
+        )
+        record = operation_log.build_record(
+            tool_name="timeline",
+            action="duplicate_clips",
+            params={"dry_run": False},
+            result=enveloped,
+            risk={
+                "level": "medium",
+                "recognised": True,
+                "blast_radius": "timeline",
+            },
+        )
+
+        self.assertEqual(record["operation_id"], "op_fixed")
+        self.assertEqual(record["operation"], "timeline.duplicate_clips")
+        self.assertEqual(record["risk_level"], "medium")
+        self.assertFalse(record["dry_run"])
+        self.assertEqual(record["status"], "success")
+        self.assertEqual(record["duration_ms"], 17)
+        self.assertEqual(record["changes"], {"items_added": 2})
+        self.assertIn("items_added=2", record["summary"])
+
+    def test_lifecycle_writes_mutating_operation_record(self) -> None:
+        pipeline = LifecyclePipeline()
+        ctx = ToolCallContext(
+            "timeline",
+            "duplicate_clips",
+            {"timeline_item_ids": ["c1"]},
+        )
+        pipeline.run_before(ctx)
+        raw = {"success": True, "_changes": {"items_added": 1}}
+        enveloped = operation_result.build_operation_envelope(
+            ctx.tool_name,
+            ctx.action,
+            ctx.params,
+            raw,
+            duration_ms=5,
+        )
+
+        pipeline.run_after(ctx, enveloped, duration_ms=5)
+
+        [record] = self._records()
+        self.assertEqual(record["tool"], "timeline")
+        self.assertEqual(record["action"], "duplicate_clips")
+        self.assertEqual(record["risk_level"], "medium")
+        self.assertEqual(record["changes"]["items_added"], 1)
+
+    def test_lifecycle_does_not_log_read_only_operation(self) -> None:
+        pipeline = LifecyclePipeline()
+        ctx = ToolCallContext("timeline", "get_current", {})
+        pipeline.run_before(ctx)
+        raw = {"success": True, "timeline": "Cut"}
+        enveloped = operation_result.build_operation_envelope(
+            ctx.tool_name,
+            ctx.action,
+            ctx.params,
+            raw,
+            duration_ms=3,
+        )
+
+        pipeline.run_after(ctx, enveloped, duration_ms=3)
+
+        self.assertFalse(os.path.exists(self.log_path))
+
+    def test_blocked_destructive_attempt_logs_as_blocked(self) -> None:
+        pipeline = LifecyclePipeline()
+        ctx = ToolCallContext("timeline", "delete_track", {"track_index": 1})
+        pipeline.run_before(ctx)
+        raw = {
+            "success": False,
+            "status": "blocked_by_security_policy",
+            "error": {"category": "destructive_blocked"},
+        }
+        enveloped = operation_result.build_operation_envelope(
+            ctx.tool_name,
+            ctx.action,
+            ctx.params,
+            raw,
+            duration_ms=0,
+        )
+
+        pipeline.run_after(ctx, enveloped, duration_ms=0)
+
+        [record] = self._records()
+        self.assertEqual(record["status"], "blocked")
+        self.assertEqual(record["summary"], "timeline.delete_track blocked before mutation")
+
+    def test_mutating_exception_logs_failed_record(self) -> None:
+        pipeline = LifecyclePipeline()
+        ctx = ToolCallContext("timeline", "delete_track", {"track_index": 1})
+        pipeline.run_before(ctx)
+
+        pipeline.run_on_error(ctx, RuntimeError("Resolve bridge closed"), duration_ms=9)
+
+        [record] = self._records()
+        self.assertEqual(record["status"], "failed")
+        self.assertEqual(record["operation"], "timeline.delete_track")
+        self.assertEqual(record["risk_level"], "high")
+        self.assertEqual(record["duration_ms"], 9)
+        self.assertEqual(record["exception"]["type"], "RuntimeError")
+        self.assertEqual(record["exception"]["message"], "Resolve bridge closed")
+        self.assertIn("failed with RuntimeError", record["summary"])
+
+    def test_read_only_exception_does_not_write_operation_log(self) -> None:
+        pipeline = LifecyclePipeline()
+        ctx = ToolCallContext("timeline", "get_current", {})
+        pipeline.run_before(ctx)
+
+        pipeline.run_on_error(ctx, RuntimeError("Resolve bridge closed"), duration_ms=9)
+
+        self.assertFalse(os.path.exists(self.log_path))
+
+
+class OperationLogSetup(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_env = os.environ.get("DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS")
+        self.tmp = tempfile.TemporaryDirectory()
+        os.environ["DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS"] = os.path.join(
+            self.tmp.name,
+            "prefs.json",
+        )
+
+    def tearDown(self) -> None:
+        if self.saved_env is None:
+            os.environ.pop("DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS", None)
+        else:
+            os.environ["DAVINCI_RESOLVE_MCP_MEDIA_ANALYSIS_PREFS"] = self.saved_env
+        self.tmp.cleanup()
+
+    def test_setup_sets_and_clears_operation_log_defaults(self) -> None:
+        configured = compound.setup(
+            "set_defaults",
+            {
+                "destructive": {
+                    "operation_log": False,
+                    "operation_log_path": os.path.join(self.tmp.name, "ops.jsonl"),
+                },
+            },
+        )
+        self.assertTrue(configured["success"])
+        destructive = configured["defaults"]["destructive"]
+        self.assertFalse(destructive["operation_log"])
+        self.assertEqual(
+            destructive["operation_log_path"],
+            os.path.realpath(os.path.join(self.tmp.name, "ops.jsonl")),
+        )
+
+        cleared = compound.setup(
+            "clear_defaults",
+            {"keys": ["destructive.operation_log", "destructive.operation_log_path"]},
+        )
+        self.assertTrue(cleared["success"])
+        destructive = cleared["defaults"]["destructive"]
+        self.assertTrue(destructive["operation_log"])
+        self.assertTrue(destructive["operation_log_path"].endswith("logs/operation-log.jsonl"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This adds a compact structured operation log for recognised mutating MCP tool calls.

The existing execution trace system is useful for understanding a multi-step editing run, and the existing security audit records destructive gate decisions. This change adds a narrower chronological trail for project-changing operations: what operation was attempted, what risk level the classifier assigned, whether it was a dry run, when it happened, how it ended, and a short summary derived from the result envelope when one is available.

The goal is traceability without pretending to solve rollback or simulation yet. The log records facts the server already has at lifecycle time and avoids inventing semantic changes when a handler did not report them.

## What changed

- Added `src/utils/operation_log.py` as a small append-only JSONL writer for mutating operation records.
- Added an `OperationLogHook` to the execution lifecycle so records are written after the operation envelope has normalized status, duration, verification, and changes.
- Added lifecycle error-path logging so mutating operations that raise an unhandled exception still write a failed record with the exception type and message.
- Kept read-only operations out of the operation log so the file stays focused on project-changing activity.
- Added setup defaults for enabling/disabling and relocating the log:
  - `destructive.operation_log`
  - `destructive.operation_log_path`
- Added `RESOLVE_MCP_OPERATION_LOG_FILE` as an environment override for deployments that need to route logs outside the repository.
- Updated test isolation so default operation-log writes during the suite go to a temporary file rather than polluting a real operator log.
- Bumped version surfaces to `2.213.0` and added a changelog entry.

## Record shape

A successful mutating operation writes a record in this shape:

```json
{
  "operation_id": "op_123",
  "tool": "timeline",
  "action": "duplicate_clips",
  "operation": "timeline.duplicate_clips",
  "risk_level": "medium",
  "risk_established": true,
  "blast_radius": "timeline",
  "dry_run": false,
  "timestamp": "2026-09-08T10:30:00Z",
  "summary": "timeline.duplicate_clips success; items_added=1",
  "status": "success",
  "duration_ms": 5,
  "changes": {
    "items_added": 1
  }
}
```

If a mutating operation is blocked before mutation, it is logged as `blocked`. If a mutating handler raises before returning a normal result, it is logged as `failed` with an `exception` object. Read-only actions are skipped.

## Why separate from the existing logs

Execution traces answer the larger question of how a run unfolded across one or more tool calls. The security audit records destructive security decisions such as safe-mode blocks and dry-run refusals. This operation log is intentionally simpler: one compact entry per recognised mutating operation attempt.

Keeping it separate avoids overloading the execution trace format and avoids turning the security audit into a general activity log.

## Validation

- `python3 -m py_compile src/utils/operation_log.py src/utils/execution_lifecycle.py tests/test_operation_log.py`
- `.venv/bin/python -m unittest tests.test_operation_log tests.test_execution_lifecycle tests.test_destructive_hook`
  - `Ran 73 tests in 0.889s` / `OK`
- `.venv/bin/python -m unittest discover -s tests`
  - `Ran 3329 tests in 95.875s` / `OK (skipped=36)`
- `git diff --check`
- `npm run smoke`
  - reports `DaVinci Resolve MCP 2.213.0` and `2.213.0`
