### PR TITLE
fix(granular): recognize lowercase Resolve 21.1 item types

### DIFF
--- a/src/granular/timeline_item.py
+++ b/src/granular/timeline_item.py
@@ -5,6 +5,25 @@ from src.utils.clip_colors import clip_color_refusal
 
 resolve = ResolveProxy()
 
+
+def _item_type(item, method="GetType"):
+    """Normalize type values without assuming an optional API is callable.
+
+    Resolve 21.1 documents lowercase types. Keep title-case compatibility,
+    and treat missing/non-string results as unknown rather than as a clip.
+    """
+    getter = getattr(item, method, None)
+    if not callable(getter):
+        return ""
+    value = getter()
+    return value.lower() if isinstance(value, str) else ""
+
+
+def _has_audio_type(item):
+    return (_item_type(item) == "audio"
+            or _item_type(item, "GetMediaType") == "audio")
+
+
 @mcp.resource("resolve://timeline-item/{timeline_item_id}")
 def get_timeline_item_properties(timeline_item_id: str) -> Dict[str, Any]:
     """Get properties of a specific timeline item by ID.
@@ -65,7 +84,7 @@ def get_timeline_item_properties(timeline_item_id: str) -> Dict[str, Any]:
         }
         
         # Get additional properties if it's a video item
-        if timeline_item.GetType() == "Video":
+        if _item_type(timeline_item) == "video":
             # Transform properties
             properties["transform"] = {
                 "position": {
@@ -118,7 +137,7 @@ def get_timeline_item_properties(timeline_item_id: str) -> Dict[str, Any]:
             }
         
         # Audio-specific properties
-        if timeline_item.GetType() == "Audio" or timeline_item.GetMediaType() == "Audio":
+        if _has_audio_type(timeline_item):
             properties["audio"] = {
                 "volume": timeline_item.GetProperty("Volume"),
                 "pan": timeline_item.GetProperty("Pan"),
@@ -239,7 +258,7 @@ def set_timeline_item_transform(timeline_item_id: str,
         if not timeline_item:
             return f"Error: Video timeline item with ID '{timeline_item_id}' not found"
         
-        if timeline_item.GetType() != "Video":
+        if _item_type(timeline_item) != "video":
             return f"Error: Timeline item with ID '{timeline_item_id}' is not a video item"
         
         # Set the property
@@ -299,7 +318,7 @@ def set_timeline_item_crop(timeline_item_id: str,
         if not timeline_item:
             return f"Error: Video timeline item with ID '{timeline_item_id}' not found"
         
-        if timeline_item.GetType() != "Video":
+        if _item_type(timeline_item) != "video":
             return f"Error: Timeline item with ID '{timeline_item_id}' is not a video item"
         
         # Set the property
@@ -368,7 +387,7 @@ def set_timeline_item_composite(timeline_item_id: str,
         if not timeline_item:
             return f"Error: Video timeline item with ID '{timeline_item_id}' not found"
         
-        if timeline_item.GetType() != "Video":
+        if _item_type(timeline_item) != "video":
             return f"Error: Timeline item with ID '{timeline_item_id}' is not a video item"
         
         success = True
@@ -529,7 +548,7 @@ def set_timeline_item_stabilization(timeline_item_id: str,
         if not timeline_item:
             return f"Error: Video timeline item with ID '{timeline_item_id}' not found"
         
-        if timeline_item.GetType() != "Video":
+        if _item_type(timeline_item) != "video":
             return f"Error: Timeline item with ID '{timeline_item_id}' is not a video item"
         
         success = True
@@ -635,7 +654,7 @@ def set_timeline_item_audio(timeline_item_id: str,
             return f"Error: Timeline item with ID '{timeline_item_id}' not found"
         
         # Check if the item has audio capabilities
-        if not is_audio and timeline_item.GetMediaType() != "Audio":
+        if not is_audio and not _has_audio_type(timeline_item):
             return f"Error: Timeline item with ID '{timeline_item_id}' does not have audio properties"
         
         success = True
@@ -737,7 +756,7 @@ def get_timeline_item_keyframes(timeline_item_id: str, property_name: str) -> Di
         audio_properties = ['Volume', 'Pan']
         
         # Check if it's a video item
-        if timeline_item.GetType() == "Video":
+        if _item_type(timeline_item) == "video":
             # Check each property to see if it has keyframes
             for prop in video_properties:
                 if timeline_item.GetKeyframeCount(prop) > 0:
@@ -758,7 +777,7 @@ def get_timeline_item_keyframes(timeline_item_id: str, property_name: str) -> Di
                         })
         
         # Check if it has audio properties (could be video with audio or audio-only)
-        if timeline_item.GetType() == "Audio" or timeline_item.GetMediaType() == "Audio":
+        if _has_audio_type(timeline_item):
             # Check each audio property for keyframes
             for prop in audio_properties:
                 if timeline_item.GetKeyframeCount(prop) > 0:
@@ -877,7 +896,7 @@ def add_keyframe(timeline_item_id: str, property_name: str, frame: int, value: f
         if is_audio and property_name not in audio_properties:
             return f"Error: Property '{property_name}' is not available for audio items"
         
-        if not is_audio and property_name not in video_properties and timeline_item.GetType() != "Video":
+        if not is_audio and property_name not in video_properties and _item_type(timeline_item) != "video":
             return f"Error: Property '{property_name}' is not available for this item type"
             
         # Validate frame is within the item's range
@@ -1241,7 +1260,7 @@ def enable_keyframes(timeline_item_id: str, keyframe_mode: str = "All") -> str:
         if not timeline_item:
             return f"Error: Video timeline item with ID '{timeline_item_id}' not found"
         
-        if timeline_item.GetType() != "Video":
+        if _item_type(timeline_item) != "video":
             return f"Error: Timeline item with ID '{timeline_item_id}' is not a video item"
         
         # Set the keyframe mode

--- a/tests/live_granular_item_types.py
+++ b/tests/live_granular_item_types.py
@@ -1,0 +1,49 @@
+"""Read-only validation of granular clip-type recognition on a running Resolve.
+
+Run from the repository root: python tests/live_granular_item_types.py
+Requires an open timeline with an ordinary video clip on a video track.
+Reads the first such clip through the actual property-resource handler.
+Does not set properties, switch projects/timelines or render. Mutation coverage
+is limited to the stub contracts in test_granular_item_types.py.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def main():
+    from src.granular.common import get_current_project, get_resolve
+    from src.granular.timeline_item import get_timeline_item_properties
+
+    _, project = get_current_project()
+    if project is None or project.GetCurrentTimeline() is None:
+        raise SystemExit("Open a timeline with an ordinary video clip first.")
+    timeline = project.GetCurrentTimeline()
+    item = next((
+        item
+        for track in range(1, timeline.GetTrackCount("video") + 1)
+        for item in (timeline.GetItemListInTrack("video", track) or [])
+        if item.GetMediaPoolItem() is not None
+    ), None)
+    if item is None:
+        raise SystemExit("No ordinary video clip found; nothing was changed.")
+    result = get_timeline_item_properties(str(item.GetUniqueId()))
+    receipt = {
+        "version": get_resolve().GetVersionString(),
+        "type": item.GetType(),
+        "error": result.get("error"),
+        "has_transform": "transform" in result,
+        "has_crop": "crop" in result,
+        "has_composite": "composite" in result,
+        "optional_media_type_callable": callable(getattr(item, "GetMediaType", None)),
+        "mutators_invoked": False,
+    }
+    print(json.dumps(receipt, indent=2))
+    assert receipt["error"] is None, receipt
+    assert receipt["has_transform"] and receipt["has_crop"] and receipt["has_composite"], receipt
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_granular_item_types.py
+++ b/tests/test_granular_item_types.py
@@ -1,0 +1,131 @@
+"""Regression contracts for the lowercase item types documented in Resolve 21.1.
+
+No Resolve connection: test the actual granular handlers against narrow stubs.
+Title-case values are compatibility controls, not a claim about older builds.
+"""
+import unittest
+from unittest.mock import patch
+
+from src.granular import timeline_item as tools
+
+
+class Item:
+    GetMediaType = None  # Resolve's missing methods can resolve to None.
+
+    def __init__(self, kind):
+        self.kind = kind
+        self.writes = []
+
+    def GetType(self):
+        return self.kind
+
+    def GetUniqueId(self):
+        return "item"
+
+    def GetName(self):
+        return "synthetic"
+
+    def GetStart(self):
+        return 86400
+
+    def GetEnd(self):
+        return 86448
+
+    def GetDuration(self):
+        return 48
+
+    def GetProperty(self, name):
+        return 1.0
+
+    def SetProperty(self, name, value):
+        self.writes.append((name, value))
+        return True
+
+
+class Timeline:
+    def __init__(self, item):
+        self.item = item
+
+    def GetTrackCount(self, kind):
+        return 1 if kind == "video" else 0
+
+    def GetItemListInTrack(self, kind, index):
+        return [self.item] if kind == "video" else []
+
+
+class Project:
+    def __init__(self, item):
+        self.timeline = Timeline(item)
+
+    def GetCurrentTimeline(self):
+        return self.timeline
+
+
+class ItemTypeTests(unittest.TestCase):
+    def invoke(self, item, handler, *args, **kwargs):
+        with patch.object(tools, "get_current_project", return_value=(None, Project(item))):
+            return handler("item", *args, **kwargs)
+
+    def test_video_transform_accepts_lowercase_and_title_case(self):
+        for kind in ("video", "Video"):
+            with self.subTest(kind=kind):
+                item = Item(kind)
+                result = self.invoke(item, tools.set_timeline_item_transform, "ZoomX", 0.5)
+                self.assertIn("Successfully", result)
+                self.assertEqual(item.writes, [("ZoomX", 0.5)])
+
+    def test_other_video_guards_accept_documented_type(self):
+        cases = [
+            (tools.set_timeline_item_crop, {"crop_type": "Left", "crop_value": 10}),
+            (tools.set_timeline_item_composite, {"opacity": 0.5}),
+            (tools.set_timeline_item_stabilization, {"enabled": True}),
+            (tools.enable_keyframes, {}),
+        ]
+        for handler, kwargs in cases:
+            with self.subTest(handler=handler.__name__):
+                item = Item("video")
+                result = self.invoke(item, handler, **kwargs)
+                self.assertIn("Successfully", result)
+                self.assertTrue(item.writes)
+
+    def test_non_video_and_unknown_types_are_not_written(self):
+        for kind in ("audio", "generator", "transition", "", None, 1):
+            with self.subTest(kind=kind):
+                item = Item(kind)
+                result = self.invoke(item, tools.set_timeline_item_transform, "ZoomX", 0.5)
+                self.assertIn("not a video item", result)
+                self.assertEqual(item.writes, [])
+
+    def test_video_resource_does_not_call_missing_media_type(self):
+        item = Item("video")
+        result = self.invoke(item, tools.get_timeline_item_properties)
+        self.assertNotIn("error", result)
+        self.assertIn("transform", result)
+        self.assertNotIn("audio", result)
+        self.assertEqual(result["type"], "video")
+
+    def test_audio_resource_accepts_lowercase_and_title_case(self):
+        for kind in ("audio", "Audio"):
+            with self.subTest(kind=kind):
+                result = self.invoke(Item(kind), tools.get_timeline_item_properties)
+                self.assertNotIn("error", result)
+                self.assertIn("audio", result)
+                self.assertNotIn("transform", result)
+
+    def test_optional_media_type_fallback_remains_supported(self):
+        for kind in ("audio", "Audio"):
+            with self.subTest(kind=kind):
+                item = Item("video")
+                item.GetMediaType = lambda: kind
+                result = self.invoke(item, tools.get_timeline_item_properties)
+                self.assertIn("audio", result)
+
+    def test_audio_write_without_media_type_refuses_instead_of_calling_none(self):
+        item = Item("video")
+        result = self.invoke(item, tools.set_timeline_item_audio, volume=0.5)
+        self.assertIn("does not have audio properties", result)
+        self.assertEqual(item.writes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolve Studio 21.1.0.14 returns lowercase `video` from `TimelineItem.GetType()`, as documented in its shipped typed API. Granular timeline-item tools compare against `Video`/`Audio`, rejecting ordinary video clips before calling SetProperty and omitting type-specific fields from resource reads.

This change normalizes string type values for internal checks, retains title-case compatibility, and treats missing/non-string type values as unknown. It also checks that the optional GetMediaType accessor is callable: on the probed 21.1 video clip it is not, so the existing resource read otherwise fails even after entering the correct video branch. Returned public `type` values remain unchanged.

Validation:

- Seven regression tests exercise the actual granular handlers. Before the fix they produced nine subtest failures; after the fix they pass. Cases include transform/crop/composite/stabilization/keyframe-mode dispatch, lowercase audio reads, title-case compatibility, optional accessor handling, and refusing writes to non-video/unknown types.
- Read-only live validation on macOS Studio 21.1.0.14: the property reader returned transform, crop and composite sections with no error. The runnable `tests/live_granular_item_types.py` records this without publishing clip/project names or changing project state.
- Focused existing granular tests and static/drift checks pass.
- Full suite: `PYTHONUTF8=1 python -m unittest discover -s tests -t . -p 'test_*.py'` ran 3,388 tests, OK with 27 skipped. In the fresh checkout I installed the locked advanced-server dependencies first. The initial unconfigured run hit missing jszip, ASCII subprocess decoding and test-package/log initialization failures; the configured run above passed without changes outside this PR.

Live mutation validation is now complete for the representative transform path on Studio 21.1.0.14. In a disposable project with a synthetic 640x360 test-pattern clip, the actual granular set_timeline_item_transform handler accepted lowercase video and set ZoomX to 0.5. Native readback returned ZoomX=ZoomY=0.5 with ganged zoom. Resolve's exported frame changed from full-frame pattern to the expected centered half-width/half-height image with black borders; both frames were visually inspected. Other changed guards have stub contracts, not separate live mutation claims.

No tool additions, version bump, or production timeline edits. Existing property names, units and keyframe API behavior are outside this change.
