### PR TITLE
feat(markers): add dry-run preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 Release history for the DaVinci Resolve MCP Server. The latest release is summarized in the root README; older entries live here to keep the README focused.
 
+## What's New in v2.224.0 — marker add dry-run preview
+
+Contributed by @rohitkanithi.
+
+### Added
+
+- **`timeline_markers add` now has a native dry-run path.** When callers pass
+  `dry_run=true` or `dryRun=true`, the tool validates the same marker payload
+  it would use for the real edit, resolves defaults such as the current
+  playhead frame, normalizes marker color/duration/custom data, and returns a
+  `would_change` preview without calling Resolve's `AddMarker`.
+- The preview reports `success=true`, `dry_run=true`, and `executed=false`, so
+  automated clients can distinguish an honest no-mutation preview from a
+  completed marker edit.
+
+### Fixed
+
+- Dry-run parsing now treats common string booleans consistently across the
+  destructive-action hook and operation log. Values such as `"false"`, `"0"`,
+  `"no"`, and `"off"` no longer behave like truthy dry-run requests just
+  because they are non-empty strings.
+- Native dry-run previews are treated as plan-only payloads by the destructive
+  hook, so `timeline_markers add` previews do not create timeline archives or
+  versioning rows before returning the preview.
+
+### Validation
+
+- Added marker tests proving `timeline_markers add` with `dry_run=true` returns
+  the resolved preview without adding a marker, while `dry_run="false"` still
+  performs the real add.
+- Added destructive-hook tests for native dry-run plan-only behavior and string
+  boolean coercion.
+- Added operation-log tests so dry-run string values are recorded correctly and
+  successful dry-run attempts summarize as previews.
+
 ## What's New in v2.223.0 — native Resolve 21.1 DCTL validation
 
 Contributed by @legionsound (#215), live-validated on Studio 21.1.0.14.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-2.223.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.224.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(376%20full)-blue.svg)](#server-modes)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 简体中文
 
-[![Version](https://img.shields.io/badge/version-2.223.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
+[![Version](https://img.shields.io/badge/version-2.224.0-blue.svg)](https://github.com/samuelgursky/davinci-resolve-mcp/releases)
 [![npm](https://img.shields.io/npm/v/davinci-resolve-mcp.svg?label=npm&color=CB3837)](https://www.npmjs.com/package/davinci-resolve-mcp)
 [![API Coverage](https://img.shields.io/badge/API%20Coverage-100%25-brightgreen.svg)](docs/reference/api-coverage.md)
 [![Tools](https://img.shields.io/badge/MCP%20Tools-36%20(376%20full)-blue.svg)](#服务器模式)
@@ -12,7 +12,7 @@
 [![Python](https://img.shields.io/badge/python-3.10+-green.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-> 本翻译对应 v2.223.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
+> 本翻译对应 v2.224.0 版 README。如与英文原版有出入，以 [英文原版](README.md) 为准。
 
 一个 Model Context Protocol (MCP) 服务器，让 AI 助手通过官方脚本 API 控制 DaVinci Resolve Studio（达芬奇）。它提供完整的 API 覆盖，外加带护栏的工作流助手，涵盖剪辑、媒体池整理、渲染设置、审阅标记、调色、Fusion、Fairlight、项目生命周期任务、扩展开发，以及不碰源媒体的媒体分析。
 

--- a/install.py
+++ b/install.py
@@ -37,7 +37,7 @@ from src.utils.update_check import (
 
 # ─── Version ──────────────────────────────────────────────────────────────────
 
-VERSION = "2.223.0"
+VERSION = "2.224.0"
 # Only hard floor: mcp[cli] requires Python 3.10+. There is no upper bound —
 # Resolve's scripting bridge loads into newer interpreters on recent builds
 # (Python 3.14 verified against Resolve Studio 20.3.2). Older Resolve builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.223.0",
+  "version": "2.224.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "davinci-resolve-mcp",
-      "version": "2.223.0",
+      "version": "2.224.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "davinci-resolve-mcp",
-  "version": "2.223.0",
+  "version": "2.224.0",
   "description": "NPM bootstrapper for the DaVinci Resolve MCP Server.",
   "license": "MIT",
   "author": "Samuel Gursky <samgursky@gmail.com>",

--- a/src/granular/common.py
+++ b/src/granular/common.py
@@ -87,7 +87,7 @@ if not logging.getLogger().handlers:
         handlers=[logging.StreamHandler()],
     )
 
-VERSION = "2.223.0"
+VERSION = "2.224.0"
 logger = logging.getLogger("davinci-resolve-mcp")
 logger.info(f"Starting DaVinci Resolve MCP Server v{VERSION}")
 logger.info(f"Detected platform: {get_platform()}")

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ Usage:
     python src/server.py --full       # Start the 376-tool granular server instead
 """
 
-VERSION = "2.223.0"
+VERSION = "2.224.0"
 
 import base64
 import os
@@ -69,6 +69,7 @@ from src.utils.proc import safe_run
 from src.utils.readback import verify_by_readback, verification_stats as _verification_stats
 from src.utils import operation_result as _operation_result
 from src.utils import operation_log as _operation_log
+from src.utils.bool_params import explicit_bool_param as _explicit_bool_param
 from src.utils.operation_result import (
     build_operation_envelope as _build_operation_envelope,
     get_envelope_mode as _get_envelope_mode,
@@ -26033,7 +26034,7 @@ def timeline_markers(action: str, params: Optional[Dict[str, Any]] = None) -> An
     itself refuses sub-start timecodes with a bare False.
 
     Actions:
-      add(frame|frame_id|frameId|timecode?, color?, name?, note?, duration?, custom_data?) -> {success, frame}
+      add(frame|frame_id|frameId|timecode?, color?, name?, note?, duration?, custom_data?, dry_run?/dryRun?) -> {success, frame} or dry-run preview
         If frame/timecode is omitted, add uses the current playhead timecode.
       get_all() -> {markers}
       get_by_custom_data(custom_data) -> {markers}
@@ -26066,6 +26067,21 @@ def timeline_markers(action: str, params: Optional[Dict[str, Any]] = None) -> An
         marker, marker_err = _marker_add_payload(p, tl=tl, default_to_current=True)
         if marker_err:
             return marker_err
+        if _explicit_bool_param(p, "dry_run", "dryRun") is True:
+            return {
+                "success": True,
+                "dry_run": True,
+                "executed": False,
+                "would_change": {
+                    "operation": "timeline_markers.add",
+                    "frame": marker["frame"],
+                    "color": marker["color"],
+                    "name": marker["name"],
+                    "note": marker["note"],
+                    "duration": marker["duration"],
+                    "custom_data": marker["custom_data"],
+                },
+            }
         return _add_marker(tl, marker)
     elif action == "get_all":
         return {"markers": _ser(tl.GetMarkers())}

--- a/src/utils/bool_params.py
+++ b/src/utils/bool_params.py
@@ -1,0 +1,33 @@
+"""Boolean coercion helpers for tool parameters and preferences."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+_TRUE_STRINGS = {"1", "true", "yes", "on"}
+_FALSE_STRINGS = {"0", "false", "no", "off"}
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    """Return a predictable bool for user-facing params and config values."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in _TRUE_STRINGS:
+            return True
+        if lowered in _FALSE_STRINGS:
+            return False
+        return default
+    return bool(value)
+
+
+def explicit_bool_param(params: Optional[Dict[str, Any]], *keys: str) -> Optional[bool]:
+    """Coerce the first present key, or None when none of the keys are present."""
+    if not isinstance(params, dict):
+        return None
+    for key in keys:
+        if key in params:
+            return coerce_bool(params[key])
+    return None

--- a/src/utils/destructive_hook.py
+++ b/src/utils/destructive_hook.py
@@ -33,6 +33,7 @@ import uuid
 from typing import Any, Callable, Dict, FrozenSet, Optional, Tuple
 
 from src.utils import analysis_runs, brain_edits, media_pool_changes, timeline_versioning
+from src.utils.bool_params import coerce_bool, explicit_bool_param
 from src.utils.execution_lifecycle import RiskAssessment, RiskLevel, classify_operation_risk
 
 logger = logging.getLogger("resolve-mcp.destructive-hook")
@@ -292,6 +293,7 @@ DRY_RUN_DEFAULT_TRUE_ACTIONS: frozenset = frozenset({
 
 NATIVE_DRY_RUN_ACTIONS: frozenset = frozenset({
     ("media_pool", "clear_clip_marks"),
+    ("timeline_markers", "add"),
     ("timeline_item_color", "apply_trace_plan"),
     ("media_pool", "set_clip_marks"),
     ("media_pool", "setup_multicam_timeline"),
@@ -302,13 +304,7 @@ NATIVE_DRY_RUN_ACTIONS: frozenset = frozenset({
 
 
 def _explicit_dry_run_requested(params: Optional[Dict[str, Any]]) -> bool:
-    if not isinstance(params, dict):
-        return False
-    if "dry_run" in params:
-        return bool(params["dry_run"])
-    if "dryRun" in params:
-        return bool(params["dryRun"])
-    return False
+    return explicit_bool_param(params, "dry_run", "dryRun") is True
 
 
 def lacks_native_dry_run(
@@ -370,11 +366,14 @@ def _payload_is_plan_only(
     tool_name: str, action: str, params: Optional[Dict[str, Any]],
 ) -> bool:
     """True iff this call only produces a plan and mutates nothing."""
+    dry_run = explicit_bool_param(params, "dry_run", "dryRun")
+    if (tool_name, action) in NATIVE_DRY_RUN_ACTIONS and dry_run is True:
+        return True
     if (tool_name, action) not in DRY_RUN_DEFAULT_TRUE_ACTIONS:
         return False
-    if not isinstance(params, dict):
+    if dry_run is None:
         return True  # dry_run defaults to True for these actions
-    return bool(params.get("dry_run", params.get("dryRun", True)))
+    return dry_run
 
 
 def _payload_only_touches_no_archive_keys(
@@ -507,16 +506,7 @@ def _read_preference(key: str, default: Any = None) -> Any:
 
 
 def _coerce_bool(value: Any, default: bool = False) -> bool:
-    if value is None:
-        return default
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"1", "true", "yes", "on"}:
-            return True
-        if lowered in {"0", "false", "no", "off"}:
-            return False
-        return default
-    return bool(value)
+    return coerce_bool(value, default)
 
 
 def _safe_mode_enabled() -> bool:

--- a/src/utils/operation_log.py
+++ b/src/utils/operation_log.py
@@ -16,6 +16,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from src.utils.bool_params import coerce_bool, explicit_bool_param
 from src.utils import operation_result
 
 logger = logging.getLogger("resolve-mcp.operation-log")
@@ -41,16 +42,7 @@ def _read_preference(key: str, default: Any = None) -> Any:
 
 
 def _coerce_bool(value: Any, default: bool = False) -> bool:
-    if value is None:
-        return default
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"1", "true", "yes", "on"}:
-            return True
-        if lowered in {"0", "false", "no", "off"}:
-            return False
-        return default
-    return bool(value)
+    return coerce_bool(value, default)
 
 
 def operation_log_enabled() -> bool:
@@ -72,12 +64,12 @@ def _now_iso() -> str:
 
 
 def _dry_run_requested(params: Optional[Dict[str, Any]], result: Any) -> bool:
-    if isinstance(params, dict):
-        if "dry_run" in params:
-            return bool(params["dry_run"])
-        if "dryRun" in params:
-            return bool(params["dryRun"])
-    return bool(isinstance(result, dict) and result.get("dry_run") is True)
+    requested = explicit_bool_param(params, "dry_run", "dryRun")
+    if requested is not None:
+        return requested
+    if isinstance(result, dict) and "dry_run" in result:
+        return coerce_bool(result.get("dry_run"))
+    return False
 
 
 def _envelope(result: Any) -> Dict[str, Any]:
@@ -119,9 +111,18 @@ def _status(result: Any, envelope: Dict[str, Any]) -> str:
     return str(envelope.get("status") or operation_result.normalize_status(result))
 
 
-def _summary(tool_name: str, action: str, status: str, envelope: Dict[str, Any]) -> str:
+def _summary(
+    tool_name: str,
+    action: str,
+    status: str,
+    envelope: Dict[str, Any],
+    *,
+    dry_run: bool = False,
+) -> str:
     operation = f"{tool_name}.{action}"
     changes = envelope.get("changes")
+    if dry_run and status == "success":
+        return f"{operation} dry-run preview"
     if isinstance(changes, dict) and changes:
         parts = [f"{key}={value}" for key, value in sorted(changes.items())[:4]]
         return f"{operation} {status}; " + ", ".join(parts)
@@ -140,6 +141,7 @@ def build_record(
 ) -> Dict[str, Any]:
     env = _envelope(result)
     status = _status(result, env)
+    dry_run = _dry_run_requested(params, result)
     record = {
         "operation_id": _operation_id(result, env),
         "tool": tool_name,
@@ -147,9 +149,9 @@ def build_record(
         "operation": f"{tool_name}.{action}",
         "risk_level": risk.get("level", "unknown"),
         "risk_established": risk.get("recognised"),
-        "dry_run": _dry_run_requested(params, result),
+        "dry_run": dry_run,
         "timestamp": _now_iso(),
-        "summary": _summary(tool_name, action, status, env),
+        "summary": _summary(tool_name, action, status, env, dry_run=dry_run),
         "status": status,
     }
     if env.get("execution_id") and env.get("execution_id") != record["operation_id"]:

--- a/tests/test_destructive_hook.py
+++ b/tests/test_destructive_hook.py
@@ -435,8 +435,8 @@ class SecurityPolicy(unittest.TestCase):
 
     # ── dry_run on actions without a native dry-run path ──────────────────
     #
-    # Before v2.211.0 `timeline_markers.add` with dry_run=true added a real
-    # marker: the handler never read the flag. The wrapper now refuses an
+    # Before v2.211.0 some marker operations with dry_run=true still ran for real:
+    # the handlers never read the flag. The wrapper now refuses an
     # explicit dry-run request on every registered destructive action outside
     # NATIVE_DRY_RUN_ACTIONS — before archive, before state lookup, before the
     # handler — and says that nothing was simulated or executed.
@@ -455,7 +455,10 @@ class SecurityPolicy(unittest.TestCase):
             calls.append(action)
             return {"success": True}
 
-        result = fake_markers("add", {"frame": 12, "dry_run": True})
+        result = fake_markers(
+            "update_custom_data",
+            {"frame": 12, "custom_data": "marker-12", "dry_run": True},
+        )
 
         self.assertFalse(result["success"])
         self.assertEqual(result["status"], "dry_run_unavailable")
@@ -517,8 +520,30 @@ class SecurityPolicy(unittest.TestCase):
             calls.append(action)
             return {"success": True}
 
-        result = fake_markers("add", {"frame": 12, "dry_run": False})
+        for value in (False, "false", "0", "no", "off"):
+            with self.subTest(value=value):
+                result = fake_markers("add", {"frame": 12, "dry_run": value})
+                self.assertTrue(result["success"])
+        self.assertEqual(calls, ["add", "add", "add", "add", "add"])
+
+    def test_native_dry_run_payload_skips_archive_and_reaches_handler(self) -> None:
+        self._prefs(safe_mode=False)
+
+        def failing_provider():
+            raise AssertionError("native dry-run preview must not resolve project state")
+        destructive_hook.register_project_root_provider(failing_provider)
+
+        calls: list[str] = []
+
+        @destructive_hook.destructive_op("timeline_markers")
+        def fake_markers(action: str, params=None):
+            calls.append(action)
+            return {"success": True, "dry_run": True, "executed": False}
+
+        result = fake_markers("add", {"frame": 12, "dry_run": "true"})
+
         self.assertTrue(result["success"])
+        self.assertTrue(result["dry_run"])
         self.assertEqual(calls, ["add"])
 
     def test_dry_run_on_a_non_destructive_action_is_untouched(self) -> None:

--- a/tests/test_marker_params.py
+++ b/tests/test_marker_params.py
@@ -135,6 +135,51 @@ class TimelineMarkerParamTest(unittest.TestCase):
             (12, "Green", "Marker", "", 1, ""),
         )
 
+    def test_add_dry_run_returns_preview_without_adding_marker(self):
+        out = compound.timeline_markers(
+            "add",
+            {
+                "frame": 12,
+                "color": "green",
+                "name": "Review",
+                "note": "Check audio",
+                "duration": 4,
+                "custom_data": "marker-12",
+                "dry_run": True,
+            },
+        )
+
+        self.assertEqual(
+            _strip_versioning(out),
+            {
+                "success": True,
+                "dry_run": True,
+                "executed": False,
+                "would_change": {
+                    "operation": "timeline_markers.add",
+                    "frame": 12,
+                    "color": "Green",
+                    "name": "Review",
+                    "note": "Check audio",
+                    "duration": 4,
+                    "custom_data": "marker-12",
+                },
+            },
+        )
+        self.assertEqual(self.timeline.add_calls, [])
+
+    def test_add_dry_run_false_string_adds_marker(self):
+        out = compound.timeline_markers(
+            "add",
+            {"frame": 12, "color": "green", "dry_run": "false"},
+        )
+
+        self.assertEqual(_strip_versioning(out), {"success": True, "frame": 12})
+        self.assertEqual(
+            self.timeline.add_calls[-1],
+            (12, "Green", "Marker", "", 1, ""),
+        )
+
     def test_add_accepts_timecode_with_nominal_ntsc_rate(self):
         # 01:00:10:00 @ 23.976 (nominal 24) is 86640 absolute -> 240 relative.
         self.timeline.fps = "23.976"

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -66,6 +66,51 @@ class OperationLogRecords(unittest.TestCase):
         self.assertEqual(record["changes"], {"items_added": 2})
         self.assertIn("items_added=2", record["summary"])
 
+    def test_build_record_coerces_dry_run_strings(self) -> None:
+        for value, expected in (
+            ("true", True),
+            ("1", True),
+            ("yes", True),
+            ("on", True),
+            ("false", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+        ):
+            with self.subTest(value=value):
+                record = operation_log.build_record(
+                    tool_name="timeline_markers",
+                    action="add",
+                    params={"dry_run": value},
+                    result={"success": True, "dry_run": value},
+                    risk={"level": "low", "recognised": True},
+                )
+                self.assertEqual(record["dry_run"], expected)
+
+    def test_build_record_marks_successful_dry_run_summary_as_preview(self) -> None:
+        record = operation_log.build_record(
+            tool_name="timeline_markers",
+            action="add",
+            params={"dryRun": "true"},
+            result={"success": True, "dry_run": True},
+            risk={"level": "low", "recognised": True},
+        )
+
+        self.assertTrue(record["dry_run"])
+        self.assertEqual(record["summary"], "timeline_markers.add dry-run preview")
+
+    def test_exception_record_coerces_dry_run_false_string(self) -> None:
+        record = operation_log.build_exception_record(
+            tool_name="timeline_markers",
+            action="add",
+            params={"dry_run": "false"},
+            exc=RuntimeError("Resolve bridge closed"),
+            risk={"level": "low", "recognised": True},
+            duration_ms=2,
+        )
+
+        self.assertFalse(record["dry_run"])
+
     def test_lifecycle_writes_mutating_operation_record(self) -> None:
         pipeline = LifecyclePipeline()
         ctx = ToolCallContext(


### PR DESCRIPTION
## Summary

This PR adds a native dry-run path for `timeline_markers add` and fixes dry-run boolean parsing in the safety/logging path.

The marker add action is a good first mutation to make previewable because it is bounded, low-risk, and already has centralized payload normalization. With this change, callers can ask what marker would be added without creating a marker, writing a version archive, or producing a misleading simulated success.

## What changed

### Native marker-add dry run

`timeline_markers add` now accepts `dry_run=true` or `dryRun=true`.

When that flag is present, the tool:

- resolves the marker frame using the same path as a real add
- preserves the existing current-playhead default when frame/timecode is omitted
- normalizes marker color through the existing marker color validator
- applies the same defaults for name, note, duration, and custom data
- returns a structured `would_change` preview
- returns `executed=false`
- does not call Resolve's `AddMarker`

Example response shape:

```json
{
  "success": true,
  "dry_run": true,
  "executed": false,
  "would_change": {
    "operation": "timeline_markers.add",
    "frame": 12,
    "color": "Green",
    "name": "Review",
    "note": "Check audio",
    "duration": 4,
    "custom_data": "marker-12"
  }
}
```

### Dry-run boolean parsing

This also fixes the dry-run parsing issue where string values such as `"false"` were treated as truthy because they were passed through `bool(...)`.

The destructive hook and operation log now share a small boolean coercion helper, so common string values are handled consistently:

- true values: `"true"`, `"1"`, `"yes"`, `"on"`
- false values: `"false"`, `"0"`, `"no"`, `"off"`

That means a caller passing `dry_run="false"` now gets the normal mutation path instead of accidentally requesting a dry run.

### Version-on-mutate behavior

`timeline_markers add` is now registered as a native dry-run action.

For an explicit dry-run preview, the destructive hook treats the payload as plan-only. That avoids creating timeline archives and versioning rows for a request that does not mutate Resolve state. A normal marker add remains a mutating operation and keeps the existing safety/versioning behavior.

Unsupported dry-run requests still refuse before handler execution. For example, a marker action without a native preview path continues to return `DRY_RUN_UNAVAILABLE` instead of pretending the operation was simulated.

### Operation log behavior

The operation log now records dry-run values using the same boolean coercion rules as the destructive hook.

Successful dry-run records summarize as previews, which makes the JSONL log easier to scan:

```text
timeline_markers.add dry-run preview
```

## Why this shape

The implementation keeps the preview honest. It does not synthesize a generic response before validation, and it does not report success for an operation that the real handler might reject.

Instead, the dry-run path sits after marker payload resolution and before the actual `AddMarker` call. That gives callers the same resolved frame/color/name/note/duration/custom data that would be passed to Resolve, while guaranteeing no marker is added.

The shared boolean helper keeps the safety layer and operation log from drifting. Both places now agree on whether the caller actually requested a dry run.

## Tests

Added coverage for:

- `timeline_markers add` with `dry_run=true` returning a preview without adding a marker
- `timeline_markers add` with `dry_run="false"` performing the real marker add
- destructive hook coercion for false-like dry-run strings
- native dry-run payloads skipping archive/version lookup and reaching the handler
- unsupported destructive dry-run requests still refusing before handler execution
- operation log coercion for true-like and false-like dry-run strings
- successful dry-run operation summaries being labelled as previews

Validation run locally:

```text
.venv/bin/python -m unittest tests.test_marker_params tests.test_destructive_hook tests.test_operation_log
Ran 79 tests
OK

.venv/bin/python -m py_compile src/utils/bool_params.py src/utils/destructive_hook.py src/utils/operation_log.py src/server.py tests/test_marker_params.py tests/test_destructive_hook.py tests/test_operation_log.py
OK

git diff --check
OK

npm run smoke
OK
```

I also ran the full unittest suite outside the restricted sandbox. It ran 3,456 tests and had one order-dependent existing failure in `tests.test_log_isolation`; that test passes by itself. No failures were observed in the new focused coverage.

## Version

Bumped release surfaces from `2.223.0` to `2.224.0`.
