### PR TITLE
fix(offline_fallback): give the authoring bridge's import() a file URL

### DIFF
--- a/scripts/author_interchange.mjs
+++ b/scripts/author_interchange.mjs
@@ -17,7 +17,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -42,8 +42,10 @@ async function main() {
   }
   if (!outputPath) throw new Error('outputPath is required');
 
+  // A file URL, not a path: on Windows the ESM loader reads `C:\...` as a URL with
+  // scheme `c:` and refuses it (ERR_UNSUPPORTED_ESM_URL_SCHEME). Same fix as 06d5bd6.
   const module = await import(
-    path.join(here, '..', 'resolve-advanced', 'server', 'author-interchange.mjs')
+    pathToFileURL(path.join(here, '..', 'resolve-advanced', 'server', 'author-interchange.mjs')).href
   );
   const authored = await module.authorInterchange(events, target, opts);
 

--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -247,6 +247,30 @@ class TestBridgeScript(unittest.TestCase):
         self.assertIn("aaf", result["error"])
 
 
+class TestDynamicImportsTakeFileUrls(unittest.TestCase):
+    """A path handed to import() works on macOS and Linux and fails on Windows.
+
+    Node reads `C:\\...` as a URL whose scheme is `c:` and throws
+    ERR_UNSUPPORTED_ESM_URL_SCHEME, so every offline authoring call errored on Windows
+    while CI, which only runs Linux, stayed green. The launcher hit this first (06d5bd6);
+    the authoring bridge repeated it. Checked statically because no Linux run can see it.
+    """
+
+    def test_no_dynamic_import_is_given_a_bare_path(self):
+        import re
+
+        call = re.compile(r"\bimport\(\s*([^'\"`\s])")
+        offenders = []
+        for folder in ("scripts", "bin"):
+            for script in sorted((REPO_ROOT / folder).glob("*.mjs")):
+                text = script.read_text(encoding="utf-8")
+                for match in call.finditer(text):
+                    if not text[match.start(1):].startswith("pathToFileURL("):
+                        line = text.count("\n", 0, match.start()) + 1
+                        offenders.append(f"{folder}/{script.name}:{line}")
+        self.assertEqual(offenders, [], "wrap the path in pathToFileURL(...).href")
+
+
 class TestOffer(unittest.TestCase):
     def test_offer_names_what_it_does_not_do(self):
         offer = offline_fallback.offline_alternative(action="create_timeline")


### PR DESCRIPTION
I ran the offline test suite on Windows (Python 3.12, Node 25) and every `TestAuthoring` case in `tests/test_offline_fallback.py` errored with the same message:

```
Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

It comes from `scripts/author_interchange.mjs`, which hands `path.join(here, '..', 'resolve-advanced', 'server', 'author-interchange.mjs')` straight to `import()`. On Windows that is `C:\...`, and Node reads the drive letter as a URL scheme. So `timeline(action="author_offline")` fails for every target on Windows before anything is written. Because the import runs before target validation, the bridge's own error for an unknown target never shows up either (`TestBridgeScript.test_unknown_target_is_an_error` fails there too). The launcher hit exactly this in 06d5bd6 and got `pathToFileURL()`; the bridge was added later and repeated it. CI only runs on ubuntu-latest, so it stayed green.

The fix is the same as 06d5bd6: wrap the path in `pathToFileURL(...).href`. Nothing changes on macOS or Linux.

Since no Linux run can see this, I added a small static test that fails if a dynamic `import()` in `scripts/*.mjs` or `bin/*.mjs` is given anything other than a string literal or `pathToFileURL(...)`. On main it reports `scripts/author_interchange.mjs:45`, and it passes with the change.

What I ran:

- Windows, on main: the otio/edl authoring tests, `TestBridgeScript` and the new test give 2 failures and 4 errors. With the change, all 8 pass.
- Linux (Node 22): the same authoring and bridge tests pass on main and with the change.

One thing I could not check locally: the `.drt` cases need `jszip` from the `resolve-advanced` npm install, which I didn't have on that Windows machine, so there they now stop at `Cannot find module 'jszip'` instead. They get past the import, which is the only part this touches, and CI installs the dependency.

AI tools used
