### PR TITLE
test(offline_fallback): scan resolve-advanced/server for bare-path imports

### DIFF
--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -261,13 +261,18 @@ class TestDynamicImportsTakeFileUrls(unittest.TestCase):
 
         call = re.compile(r"\bimport\(\s*([^'\"`\s])")
         offenders = []
-        for folder in ("scripts", "bin"):
-            for script in sorted((REPO_ROOT / folder).glob("*.mjs")):
+        # The advanced server loads its own modules with import() too, including from
+        # its tools/ subfolder, so that tree is walked recursively.
+        for folder, pattern in (("scripts", "*.mjs"), ("bin", "*.mjs"),
+                                ("resolve-advanced/server", "**/*.mjs")):
+            for script in sorted((REPO_ROOT / folder).glob(pattern)):
+                if "node_modules" in script.parts:
+                    continue
                 text = script.read_text(encoding="utf-8")
                 for match in call.finditer(text):
                     if not text[match.start(1):].startswith("pathToFileURL("):
                         line = text.count("\n", 0, match.start()) + 1
-                        offenders.append(f"{folder}/{script.name}:{line}")
+                        offenders.append(f"{script.relative_to(REPO_ROOT).as_posix()}:{line}")
         self.assertEqual(offenders, [], "wrap the path in pathToFileURL(...).href")
 
 


### PR DESCRIPTION
Follow-up to the note in #221. The import guard only globbed `scripts/*.mjs` and `bin/*.mjs`, so a bare-path `import()` added under `resolve-advanced/server/` would pass it, and with CI on Linux the Windows failure would stay invisible there too.

This widens the scan to `resolve-advanced/server/`, walked recursively because the server also loads modules from `tools/`. Offenders are now reported by their path from the repo root, so a hit in a nested file points at that file; `scripts/author_interchange.mjs:45` reads the same as before. `node_modules` is skipped in case someone has one inside that tree.

As you said, there is nothing to catch there today: every dynamic import under `resolve-advanced/server/` passes a string literal. So I checked it against a planted file rather than a real bug:

- With the current guard, a probe `resolve-advanced/server/tools/zz_bare_import_probe.mjs` containing `await import(path.join(here, '..', 'lib.mjs'))` passes unnoticed.
- With this change, the same probe fails, naming `resolve-advanced/server/tools/zz_bare_import_probe.mjs:3`.
- With the probe removed, the guard passes on the real tree.
- With the bridge put back to its state before 5e9b143, it still fails on `scripts/author_interchange.mjs:45`.

The probe is not part of the change. I ran `tests/test_offline_fallback.py` on Windows (Python 3.12, Node 25) with and without the change: the same five `.drt` cases error on `Cannot find module 'jszip'` both ways, because I don't have the resolve-advanced npm install on this machine, and nothing else moves. `test_static_undefined_names` and `test_duplicate_definitions` pass.

AI tools used
