### PR TITLE
fix(lut): install reports overwritten only when a file was replaced

### DIFF
--- a/src/utils/lut_files.py
+++ b/src/utils/lut_files.py
@@ -154,7 +154,8 @@ def install_lut(name: str, *, source: Optional[str] = None,
     if (source is None) == (source_path is None):
         raise LutPathError("provide exactly one of source (text) or source_path (a file to copy)")
     absolute, set_lut_path = resolve_writable(name)
-    if os.path.exists(absolute) and not overwrite:
+    existed = os.path.exists(absolute)
+    if existed and not overwrite:
         raise LutPathError(
             f"{set_lut_path} already exists. Pass overwrite=true to replace it."
         )
@@ -175,7 +176,14 @@ def install_lut(name: str, *, source: Optional[str] = None,
         "path": absolute,
         "set_lut_path": set_lut_path,
         "bytes": os.path.getsize(absolute),
-        "overwritten": bool(overwrite and payload is not None),
+        # Whether a file was actually replaced, not whether the caller allowed
+        # it: `payload is not None` is always true here, so this reported a
+        # replacement for every overwrite=true install, including the ones that
+        # landed on an empty MCP/. This flag is the record of what an install
+        # destroyed -- execution_lifecycle rates `lut install` on the fact that
+        # it "can replace with overwrite=true" -- so it has to be the observed
+        # pre-state, not the permission.
+        "overwritten": existed,
         "note": ("Call project_settings(action='refresh_luts') so Resolve picks up "
                  "the new file before applying it."),
     }

--- a/tests/test_lut_file_controls.py
+++ b/tests/test_lut_file_controls.py
@@ -121,6 +121,14 @@ class InstallRemoveTests(TempLutRoot):
         out = lut_files.install_lut("warm.cube", source=IDENTITY_CUBE, overwrite=True)
         self.assertTrue(out["success"])
 
+    def test_overwritten_reports_a_replacement_that_happened(self):
+        fresh = lut_files.install_lut("warm.cube", source=IDENTITY_CUBE, overwrite=True)
+        self.assertFalse(fresh["overwritten"])
+        replaced = lut_files.install_lut("warm.cube", source=IDENTITY_CUBE, overwrite=True)
+        self.assertTrue(replaced["overwritten"])
+        first = lut_files.install_lut("cool.cube", source=IDENTITY_CUBE)
+        self.assertFalse(first["overwritten"])
+
     def test_install_needs_exactly_one_source(self):
         with self.assertRaises(lut_files.LutPathError):
             lut_files.install_lut("warm.cube")


### PR DESCRIPTION
I was reading through the new `lut` tool from #223 and stopped on the last field
`install` returns:

```python
"overwritten": bool(overwrite and payload is not None),
```

`payload` cannot be None where that line runs. The XOR guard at the top of
`install_lut` guarantees exactly one of `source`/`source_path` is set, and an
empty payload has already raised `LutPathError` by then. So the right-hand side
of the conjunction is always true and the field is just the caller's `overwrite`
argument handed back. An install that passes `overwrite=true` for idempotence and
lands on an empty `MCP/` is reported as having replaced an existing LUT.

That field matters more than its size suggests. `execution_lifecycle`'s
`RiskClassificationHook` rates `lut install` MEDIUM on the grounds that it "can
replace with overwrite=true", so `overwritten` is what a caller and the execution
trace read to learn whether an install actually destroyed existing work — and it
was answering yes on a fresh write.

The fix keeps the `os.path.exists` observation already made one line above to
decide whether to refuse without `overwrite`, and reports that instead. No extra
stat, and the flag becomes the measured pre-state rather than the permission.

## Proof

The test I added fails on `main`:

```
    def test_overwritten_reports_a_replacement_that_happened(self):
        fresh = lut_files.install_lut("warm.cube", source=IDENTITY_CUBE, overwrite=True)
>       self.assertFalse(fresh["overwritten"])
E       AssertionError: True is not false
```

and passes with the change. It covers the three cases: `overwrite=true` onto
nothing, `overwrite=true` onto an existing file, and a plain first install.

Ran on Linux, Python 3.12, with ffmpeg, numpy and the `resolve-advanced` npm
dependencies present so nothing skipped for the wrong reason:

- `python -m pytest tests -q` — 3531 passed, 23 skipped
- `scripts/audit_api_parity.py`, `scripts/gen_api_limitations.py --check`,
  `scripts/audit_readwrite_symmetry.py --check`,
  `node scripts/agent-rules/generate.mjs --check` — all clean
- the static/import unittest set from the CI job — 15 tests, OK
- `git diff --check` — clean

No Resolve involved: `install_lut` is pure filesystem work and the test runs
against a throwaway master LUT root via the existing `TempLutRoot` fixture.

## Scope

One field in one return dict. `overwritten` is not documented in
`docs/reference/lut-file-controls.md`, the README or `docs/SKILL.md`, and no test
asserted its old value, so nothing depended on the previous answer. The tool
signature, the refusal behaviour and the risk classification are untouched.

While reading the module I noticed two other things I have deliberately left out
of this PR, happy to open issues or follow-ups if either is worth it:

- `list_luts` decides `writable` with
  `os.path.realpath(current).startswith(writable_root)`, no separator, so a
  sibling folder such as `MCP_old/` under the master root would be reported as
  removable while `remove_lut` refuses it. The repo does this comparison
  correctly elsewhere (`_is_relative_to` in `utils/media_analysis.py`,
  `clips_root_prefix` with `+ os.sep` in the same file).
- `LUT_EXTENSIONS` and `lut capabilities` advertise `.dat` and `.olut`, but
  `install(source_path=...)` reads the file with
  `open(..., "r", encoding="utf-8", errors="strict")`, so copying a binary LUT in
  raises `UnicodeDecodeError`.

AI tools used
