### PR TITLE
fix(lut): copy a LUT file byte-for-byte on install

### DIFF
--- a/src/utils/lut_files.py
+++ b/src/utils/lut_files.py
@@ -161,15 +161,24 @@ def install_lut(name: str, *, source: Optional[str] = None,
     if source_path is not None:
         if not os.path.isfile(source_path):
             raise LutPathError(f"source_path not found: {source_path}")
-        with open(source_path, "r", encoding="utf-8", errors="strict") as handle:
+        # A copy has to be byte-exact. Two of the extensions this server
+        # advertises -- .dat and .olut -- are binary, and a .cube carries its
+        # TITLE in whatever encoding the vendor wrote it in, so decoding the
+        # source as UTF-8 turned "install the LUT I already have on disk" into
+        # a UnicodeDecodeError surfacing as LUT_ERROR.
+        with open(source_path, "rb") as handle:
             payload = handle.read()
     else:
         payload = source
     if not payload.strip():
         raise LutPathError("refusing to install an empty LUT")
     os.makedirs(os.path.dirname(absolute), exist_ok=True)
-    with open(absolute, "w", encoding="utf-8") as handle:
-        handle.write(payload)
+    if isinstance(payload, bytes):
+        with open(absolute, "wb") as handle:
+            handle.write(payload)
+    else:
+        with open(absolute, "w", encoding="utf-8") as handle:
+            handle.write(payload)
     return {
         "success": True,
         "path": absolute,

--- a/tests/test_lut_file_controls.py
+++ b/tests/test_lut_file_controls.py
@@ -137,6 +137,26 @@ class InstallRemoveTests(TempLutRoot):
         with open(out["path"], encoding="utf-8") as handle:
             self.assertEqual(handle.read(), IDENTITY_CUBE)
 
+    def test_install_from_a_file_copies_a_binary_lut_byte_for_byte(self):
+        blob = bytes(range(256)) * 4
+        source = os.path.join(self.root, "Vendor", "Stock.olut")
+        os.makedirs(os.path.dirname(source), exist_ok=True)
+        with open(source, "wb") as handle:
+            handle.write(blob)
+        out = lut_files.install_lut("copied.olut", source_path=source)
+        with open(out["path"], "rb") as handle:
+            self.assertEqual(handle.read(), blob)
+
+    def test_install_from_a_file_copies_a_cube_that_is_not_utf8(self):
+        text = IDENTITY_CUBE.replace('TITLE "test"', 'TITLE "Lumière"')
+        source = os.path.join(self.root, "Vendor", "Lumiere.cube")
+        os.makedirs(os.path.dirname(source), exist_ok=True)
+        with open(source, "wb") as handle:
+            handle.write(text.encode("latin-1"))
+        out = lut_files.install_lut("lumiere.cube", source_path=source)
+        with open(out["path"], "rb") as handle:
+            self.assertEqual(handle.read(), text.encode("latin-1"))
+
     def test_remove_only_touches_the_writable_subdir(self):
         self.write("Vendor/Stock.cube")
         with self.assertRaises(lut_files.LutPathError):


### PR DESCRIPTION
`install_lut(name, source_path=...)` is documented as "a LUT file on disk to copy in", and `LUT_EXTENSIONS` / `lut(action="capabilities")` advertise `.3dl`, `.cube`, `.dat`, `.lut` and `.olut`. But the copy went through a text round-trip:

```python
with open(source_path, "r", encoding="utf-8", errors="strict") as handle:
    payload = handle.read()
...
with open(absolute, "w", encoding="utf-8") as handle:
    handle.write(payload)
```

`.dat` and `.olut` are binary, so pointing `source_path` at one raises `UnicodeDecodeError` before anything is written, and it surfaces to the caller as a `LUT_ERROR`. The same happens to a perfectly ordinary `.cube` that a vendor wrote in latin-1 — the accent in a `TITLE` line is enough:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe8 in position 11: invalid continuation byte
```

I only noticed because the extension list promises two binary formats that the install path can never accept. The text-source branch (`source=`) is not affected and I left it alone; it is only the file-copy branch that needs to be byte-exact.

The fix reads the source as bytes and writes it back as bytes. Two tests cover it: a binary `.olut` copied byte for byte, and a latin-1 `.cube` that comes out identical. Both fail on `main` with the decode error above and pass with the change.

Checks I ran locally on Windows with Python 3.14:

- `python -m unittest tests.test_lut_file_controls` — 30 tests, OK
- the drift guards the CI runs (`test_static_undefined_names`, `test_duplicate_definitions`, `test_action_list_drift`, `test_panel_docs_drift`, `test_doc_tool_counts`, `test_agent_rules_drift`, `test_import`) — OK
- full discovery over `tests/` before and after: identical results either side (35 failures / 62 errors both times, all of them pre-existing here because this box has no numpy, pillow or ffmpeg), plus the two new tests passing

One note on overlap: I have another small PR open, #225, that touches the `overwritten` flag a few lines below in the same function. The two hunks do not overlap and either order merges cleanly, but they are independent and can be taken separately.

AI tools used
