### PR TITLE
fix(lut): decide LUT writability by path segment, not string prefix

### DIFF
--- a/src/utils/lut_files.py
+++ b/src/utils/lut_files.py
@@ -50,6 +50,20 @@ def writable_dir() -> str:
     return os.path.join(master_lut_dir(), WRITABLE_SUBDIR)
 
 
+def _is_within(path: str, parent: str) -> bool:
+    """Whether ``path`` is ``parent`` itself or sits under it, compared by segment.
+
+    ``commonpath`` is the comparison the rest of the repo uses for confinement
+    checks (`media_analysis._is_relative_to`), and it is the only one that is
+    correct here: a string prefix test also accepts a sibling whose name merely
+    starts with the same characters.
+    """
+    try:
+        return os.path.commonpath([path, parent]) == parent
+    except (ValueError, OSError):
+        return False
+
+
 def normalize_relative(name: str, *, default_ext: Optional[str] = None) -> str:
     """Validate a caller-supplied LUT name and return it as a POSIX relative path.
 
@@ -123,7 +137,13 @@ def list_luts(subdir: Optional[str] = None) -> Dict[str, Any]:
             except OSError:
                 size = None
             try:
-                is_writable = os.path.realpath(current).startswith(writable_root)
+                # Segment-wise, not a string prefix: a sibling of the writable
+                # subdir whose name starts with it -- MCP_old/ after a manual
+                # backup, MCPresets/ from a vendor pack -- cleared
+                # `startswith(writable_root)` and was listed as writable, while
+                # `remove` resolves names under MCP/ and refuses the very path
+                # the listing handed back.
+                is_writable = _is_within(os.path.realpath(current), writable_root)
             except OSError:
                 is_writable = False
             found.append({

--- a/tests/test_lut_file_controls.py
+++ b/tests/test_lut_file_controls.py
@@ -89,6 +89,21 @@ class ListingTests(TempLutRoot):
         self.assertFalse(by_path["Vendor/Stock.cube"]["writable"])
         self.assertTrue(by_path[f"{lut_files.WRITABLE_SUBDIR}/Mine.cube"]["writable"])
 
+    def test_a_sibling_folder_sharing_the_prefix_is_not_writable(self):
+        self.write(f"{lut_files.WRITABLE_SUBDIR}/Mine.cube")
+        self.write(f"{lut_files.WRITABLE_SUBDIR}_old/Backup.cube")
+        self.write(f"{lut_files.WRITABLE_SUBDIR}resets/Vendor.cube")
+        by_path = {row["set_lut_path"]: row for row in lut_files.list_luts()["luts"]}
+        self.assertTrue(by_path[f"{lut_files.WRITABLE_SUBDIR}/Mine.cube"]["writable"])
+        self.assertFalse(by_path[f"{lut_files.WRITABLE_SUBDIR}_old/Backup.cube"]["writable"])
+        self.assertFalse(by_path[f"{lut_files.WRITABLE_SUBDIR}resets/Vendor.cube"]["writable"])
+
+    def test_writability_matches_what_remove_will_accept(self):
+        self.write(f"{lut_files.WRITABLE_SUBDIR}_old/Backup.cube")
+        row = lut_files.list_luts()["luts"][0]
+        if row["writable"]:
+            lut_files.remove_lut(row["set_lut_path"])
+
     def test_set_lut_path_is_master_relative_with_forward_slashes(self):
         self.write("A/B/Deep.cube")
         out = lut_files.list_luts()


### PR DESCRIPTION
While reading the LUT file controls from #223 I noticed that `list_luts` decides the `writable` flag with a string prefix test:

```python
is_writable = os.path.realpath(current).startswith(writable_root)
```

`writable_root` is `<master>/MCP`, so any directory whose realpath merely begins with those characters clears the test. A sibling of the writable subdir under the master root does: `MCP_old/` left behind by a hand backup, or a vendor pack that unpacks as `MCPresets/`. Every LUT inside is reported as `writable: true`.

Nothing destructive follows from it, which is why it is easy to miss, but the listing then contradicts the only tool that consumes the flag. `remove_lut` resolves names inside `MCP/`, so feeding back the `set_lut_path` the listing just handed out fails:

```
MCP/MCP_old/Backup.cube is not present in MCP/. This server only removes LUTs
it can install; stock and vendor LUTs are left alone.
```

That is the wrong way round for a flag whose docstring is "whether this server may remove it", and it tells a caller that vendor LUTs are this server's to delete when the module's stated rule is that they are never touched here.

The fix uses `commonpath`, which is the comparison this repo already uses for confinement: `_is_relative_to` in `utils/media_analysis.py` and in `utils/media_analysis_jobs.py`, and `resolve_writable` two functions above in this same file. The other prefix tests in the tree (`media_analysis.py:7768`, `resolve_bridge_ops.py:125`) append `os.sep` for the same reason; `list_luts` was the one place that did not.

No signature, no key and no value type changes. The flag only flips for directories that share the prefix without being under `MCP/`, and for those `remove` already refused, so nothing that worked before stops working. The documented case in `docs/reference/lut-file-controls.md` — an installed `MCP/` LUT appearing in the listing marked writable — still holds, and `_is_within` returns True for the writable root itself.

Proof, with `tests/test_lut_file_controls.py`:

- `test_a_sibling_folder_sharing_the_prefix_is_not_writable` fails on `main` with `AssertionError: True is not false` for `MCP_old/Backup.cube`, and passes with the change.
- `test_writability_matches_what_remove_will_accept` takes the listing at its word and calls `remove_lut` on anything marked writable. On `main` it errors with the `LutPathError` above; with the change the flag is False, so the contradiction cannot arise.
- `tests/test_lut_file_controls.py`, `tests/test_lut_paths.py` and `tests/test_lut_write_gates.py` are green: 47 tests, no failures.

This is my third small fix on this file; it does not overlap the hunks in #225 or #226.

AI tools used
