### PR TITLE
fix(media-analysis): release the timeline-brain DB before deleting an analysis root

### DIFF
--- a/src/utils/media_analysis.py
+++ b/src/utils/media_analysis.py
@@ -7057,7 +7057,21 @@ def cleanup_artifacts(project_root: str, *, frames_only: bool = True) -> Dict[st
                     shutil.rmtree(full, ignore_errors=True)
                     removed.append(full)
     else:
+        # The whole root goes, including `_soul/timeline_brain.sqlite`. That DB
+        # is kept open in a process-wide cache, so let go of it first: on
+        # Windows the open handle makes the file undeletable, and rmtree's
+        # ignore_errors=True would hide that and report a root we never removed.
+        from src.utils import timeline_brain_db as _brain_db
+
+        _brain_db.close(root)
         shutil.rmtree(root, ignore_errors=True)
+        if os.path.isdir(root):
+            return {
+                "success": False,
+                "error": f"Could not fully remove the project analysis root: {root}",
+                "removed": removed,
+                "frames_only": frames_only,
+            }
         removed.append(root)
     return {"success": True, "removed": removed, "frames_only": frames_only}
 

--- a/src/utils/timeline_brain_db.py
+++ b/src/utils/timeline_brain_db.py
@@ -250,6 +250,25 @@ def close_all() -> None:
         _CONNECTIONS.clear()
 
 
+def close(project_root: str) -> None:
+    """Drop and close the cached connection for `project_root`, if any.
+
+    Callers that are about to delete or move a project's analysis root need
+    this. On Windows the open handle makes `_soul/timeline_brain.sqlite`
+    undeletable; on POSIX the cache would otherwise hand the next writer a
+    connection to a file that no longer has a directory entry, so the write
+    lands nowhere.
+    """
+    path = db_path_for_project(project_root)
+    with _CONNECTION_LOCK:
+        conn = _CONNECTIONS.pop(path, None)
+    if conn is not None:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
+
+
 @contextmanager
 def transaction(project_root: str) -> Iterator[sqlite3.Connection]:
     """Context manager wrapping a write transaction.
@@ -292,13 +311,7 @@ def transaction(project_root: str) -> Iterator[sqlite3.Connection]:
 def reset_for_test(project_root: str) -> None:
     """Drop + recreate every table. Tests only."""
     path = db_path_for_project(project_root)
-    with _CONNECTION_LOCK:
-        conn = _CONNECTIONS.pop(path, None)
-        if conn is not None:
-            try:
-                conn.close()
-            except sqlite3.Error:
-                pass
+    close(project_root)
     for suffix in ("", "-wal", "-shm"):
         try:
             os.remove(path + suffix)

--- a/tests/test_media_analysis.py
+++ b/tests/test_media_analysis.py
@@ -4336,6 +4336,55 @@ class MediaAnalysisPlanningTests(unittest.TestCase):
             self.assertEqual(resumed["pending_clips"], 1)
 
 
+class CleanupArtifactsTests(unittest.TestCase):
+    """cleanup_artifacts(frames_only=False) deletes the whole analysis root, so it
+    has to let go of the cached timeline-brain connection on that root first."""
+
+    def _log_one_edit(self, project_root, run_id):
+        from src.utils import timeline_brain_db
+
+        with timeline_brain_db.transaction(project_root) as conn:
+            conn.execute(
+                "INSERT INTO brain_edits(analysis_run_id, edit_type, created_at)"
+                " VALUES (?, ?, ?)",
+                (run_id, "silence_ripple", "2026-01-01T00:00:00Z"),
+            )
+
+    def test_full_cleanup_releases_the_timeline_brain_connection(self):
+        from src.utils import timeline_brain_db
+
+        self.addCleanup(timeline_brain_db.close_all)
+        tmp = tempfile.mkdtemp(prefix="cleanup_artifacts_test_")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        project_root = os.path.join(tmp, "project-analysis")
+        os.makedirs(project_root)
+        db_path = timeline_brain_db.db_path_for_project(project_root)
+        self._log_one_edit(project_root, "run-before-cleanup")
+        self.assertTrue(os.path.isfile(db_path))
+
+        result = cleanup_artifacts(project_root, frames_only=False)
+        self.assertTrue(result["success"], result)
+        # On Windows the still-open handle makes rmtree skip the DB file, and
+        # ignore_errors=True hides it: the root survives while we report it gone.
+        self.assertFalse(
+            os.path.isdir(project_root),
+            msg=f"analysis root still on disk after cleanup: {project_root}",
+        )
+
+        # And the cached handle must be dropped, or the next write for this root
+        # goes to the deleted file and never reaches disk.
+        self._log_one_edit(project_root, "run-after-cleanup")
+        self.assertTrue(os.path.isfile(db_path), msg=f"write went nowhere: {db_path}")
+        probe = sqlite3.connect(db_path)
+        try:
+            rows = probe.execute(
+                "SELECT analysis_run_id FROM brain_edits"
+            ).fetchall()
+        finally:
+            probe.close()
+        self.assertEqual([r[0] for r in rows], ["run-after-cleanup"])
+
+
 class MediaAnalysisCoverageTests(unittest.TestCase):
     """Pre-flight coverage_report assessment used by editorial / color / online guardrails."""
 


### PR DESCRIPTION
I was looking at what happens when a project's analysis root is thrown away, and `cleanup_artifacts(frames_only=false)` turned out to report success whether or not it actually removed anything.

The root contains `_soul/timeline_brain.sqlite`, and `timeline_brain_db` keeps that connection in a process-wide cache for the life of the server. Nothing lets go of it before the `shutil.rmtree`, and the rmtree runs with `ignore_errors=True`, so the failure is swallowed.

The two ends behave differently, and both are wrong:

- On Windows the open handle makes the DB file undeletable. rmtree stops there, the root stays on disk with `_soul/` and the brain-edit history still in it, and the tool returns `{"success": true, "removed": [root]}`. The user is told the analysis root is gone when it is not.
- On POSIX the root does get removed, but the stale connection stays in `_CONNECTIONS`. The next `connect()` on that project hands it straight back, so the following write goes to a file that no longer has a directory entry. `timeline_brain.sqlite` never reappears and the edit is lost — the dashboard, which opens the path fresh, sees nothing.

What I changed:

- `timeline_brain_db.close(project_root)` drops and closes one cached connection. `close_all()` was the only way to do this and it is too broad here — it would also drop other projects' connections. `reset_for_test` now reuses the new helper instead of duplicating the same pop-and-close.
- `cleanup_artifacts` calls it before the rmtree when `frames_only=False`, and returns `success: False` if the root is still on disk afterwards, rather than reporting a removal that did not happen.

The `frames_only=True` path, which is the one documented in the media-analysis guide, is untouched.

Proof, one test in `tests/test_media_analysis.py`. It logs a brain edit, runs the full cleanup, then checks the root is gone and that a subsequent write lands on disk. It fails on both platforms before the change, each for its own half of the problem:

- Windows: `AssertionError: True is not false : analysis root still on disk after cleanup: ...\project-analysis`
- Linux: `AssertionError: False is not true : write went nowhere: /tmp/.../project-analysis/_soul/timeline_brain.sqlite`

and passes on both after it.

Full offline suite, `python -m unittest discover -s tests -t . -p "test_*.py"`, before and after on each platform:

- Linux: 3529 -> 3530 tests, same 1 failure / 5 errors on both sides (missing optional deps in my environment), and the failing-test list is byte-identical.
- Windows: 3529 -> 3530 tests, same 35 failures / 62 errors on both sides, list also identical.

AI tools used
